### PR TITLE
[RUN-2580] Fix execution metrics SQL time-parse errors on MySQL/MariaDB

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -4757,14 +4757,35 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         }
     }
 
+    /**
+     * Detects MySQL/MariaDB datasources, which require dedicated duration-sum SQL:
+     * a plain {@code date_completed - date_started} projected as TIME overflows
+     * MySQL's TIME range (max 838:59:59) once the aggregated duration across the
+     * queried executions exceeds it.
+     */
+    boolean isMySqlDatasource() {
+        try {
+            def dataSource = applicationContext.getBean('dataSource', DataSource)
+            return dataSource.getConnection().withCloseable { conn ->
+                conn.metaData.databaseProductName in ['MySQL', 'MariaDB']
+            }
+        } catch (Exception ex) {
+            log.debug("Unable to determine datasource type, assuming non-MySQL", ex)
+            return false
+        }
+    }
+
     private boolean isSqlCompatible() {
         boolean isCompatible = false
         try {
             boolean isH2 = isH2Datasource()
+            boolean isMySql = isMySqlDatasource()
             Execution.createCriteria().list(max:1) {
                 projections {
                     if (isH2) {
                         sqlProjection 'DATEDIFF(\'SECOND\', date_started, date_completed) as durationSum', 'durationSum', StandardBasicTypes.LONG
+                    } else if (isMySql) {
+                        sqlProjection 'TIMESTAMPDIFF(SECOND, date_started, date_completed) as durationSum', 'durationSum', StandardBasicTypes.LONG
                     } else {
                         sqlProjection '(date_completed - date_started) as durationSum', 'durationSum', StandardBasicTypes.TIME
                     }
@@ -4856,34 +4877,28 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             return Arrays.asList(metricCriteriaH2)
         }
 
-        def metricCriteriaA = {
-            def baseQueryCriteria = query.createCriteria(delegate, jobQueryComponents)
-            baseQueryCriteria()
-
-            resultTransformer(CriteriaSpecification.ALIAS_TO_ENTITY_MAP)
-            projections {
-
-                rowCount("count")
-                sqlProjection 'sum(date_completed - date_started) as durationSum',
-                        'durationSum',
-                        StandardBasicTypes.TIME
-                sqlProjection 'min(date_completed - date_started) as durationMin',
-                        'durationMin',
-                        StandardBasicTypes.TIME
-                sqlProjection 'max(date_completed - date_started) as durationMax',
-                        'durationMax',
-                        StandardBasicTypes.TIME
-
-                // Zero-overhead status count projections
-                sqlProjection 'sum(case when status = \'succeeded\' then 1 else 0 end) as succeededCount',
-                        'succeededCount',
-                        StandardBasicTypes.LONG
-                sqlProjection 'sum(case when status in (\'failed\', \'failed-with-retry\', \'timedout\') then 1 else 0 end) as failedCount',
-                        'failedCount',
-                        StandardBasicTypes.LONG
-
+        if (isMySqlDatasource()) {
+            def metricCriteriaMySql = {
+                def baseQueryCriteria = query.createCriteria(delegate, jobQueryComponents)
+                baseQueryCriteria()
+                resultTransformer(CriteriaSpecification.ALIAS_TO_ENTITY_MAP)
+                projections {
+                    rowCount("count")
+                    sqlProjection 'sum(TIMESTAMPDIFF(SECOND, date_started, date_completed)) as durationSum',
+                            'durationSum', StandardBasicTypes.LONG
+                    sqlProjection 'min(TIMESTAMPDIFF(SECOND, date_started, date_completed)) as durationMin',
+                            'durationMin', StandardBasicTypes.LONG
+                    sqlProjection 'max(TIMESTAMPDIFF(SECOND, date_started, date_completed)) as durationMax',
+                            'durationMax', StandardBasicTypes.LONG
+                    sqlProjection 'sum(case when status = \'succeeded\' then 1 else 0 end) as succeededCount',
+                            'succeededCount', StandardBasicTypes.LONG
+                    sqlProjection 'sum(case when status in (\'failed\', \'failed-with-retry\', \'timedout\') then 1 else 0 end) as failedCount',
+                            'failedCount', StandardBasicTypes.LONG
+                }
             }
+            return Arrays.asList(metricCriteriaMySql)
         }
+
         def metricCriteriaB = {
             // Run main query criteria
             def baseQueryCriteria = query.createCriteria(delegate, jobQueryComponents)
@@ -4940,7 +4955,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                         StandardBasicTypes.LONG
             }
         }
-        return Arrays.asList(metricCriteriaA, metricCriteriaB, metricCriteriaC)
+        return Arrays.asList(metricCriteriaB, metricCriteriaC)
     }
 
     /**

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -4775,17 +4775,40 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         }
     }
 
+    /**
+     * Detects Oracle datasources. Oracle's {@code date - date} arithmetic produces an
+     * INTERVAL DAY TO SECOND value; the Oracle JDBC driver's accessor for that type does
+     * not implement {@code getTime()}, so projecting it as SQL TIME fails with
+     * ORA-17004 ("Invalid column type"). Oracle needs both sides cast to DATE first,
+     * turning the subtraction into classic date arithmetic (a NUMBER of fractional
+     * days) that can be safely multiplied by 86400 for seconds.
+     */
+    boolean isOracleDatasource() {
+        try {
+            def dataSource = applicationContext.getBean('dataSource', DataSource)
+            return dataSource.getConnection().withCloseable { conn ->
+                conn.metaData.databaseProductName == 'Oracle'
+            }
+        } catch (Exception ex) {
+            log.debug("Unable to determine datasource type, assuming non-Oracle", ex)
+            return false
+        }
+    }
+
     private boolean isSqlCompatible() {
         boolean isCompatible = false
         try {
             boolean isH2 = isH2Datasource()
             boolean isMySql = isMySqlDatasource()
+            boolean isOracle = isOracleDatasource()
             Execution.createCriteria().list(max:1) {
                 projections {
                     if (isH2) {
                         sqlProjection 'DATEDIFF(\'SECOND\', date_started, date_completed) as durationSum', 'durationSum', StandardBasicTypes.LONG
                     } else if (isMySql) {
                         sqlProjection 'TIMESTAMPDIFF(SECOND, date_started, date_completed) as durationSum', 'durationSum', StandardBasicTypes.LONG
+                    } else if (isOracle) {
+                        sqlProjection 'round((CAST(date_completed AS DATE) - CAST(date_started AS DATE)) * 86400) as durationSum', 'durationSum', StandardBasicTypes.LONG
                     } else {
                         sqlProjection '(date_completed - date_started) as durationSum', 'durationSum', StandardBasicTypes.TIME
                     }
@@ -4899,6 +4922,32 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             return Arrays.asList(metricCriteriaMySql)
         }
 
+        if (isOracleDatasource()) {
+            // Oracle: date_completed/date_started are TIMESTAMP columns, so a plain subtraction
+            // yields an INTERVAL DAY TO SECOND (whose JDBC accessor doesn't support getLong()).
+            // Casting both sides to DATE forces classic Oracle date arithmetic, which returns a
+            // NUMBER of fractional days; multiply by 86400 for integer seconds.
+            def metricCriteriaOracle = {
+                def baseQueryCriteria = query.createCriteria(delegate, jobQueryComponents)
+                baseQueryCriteria()
+                resultTransformer(CriteriaSpecification.ALIAS_TO_ENTITY_MAP)
+                projections {
+                    rowCount("count")
+                    sqlProjection 'sum(round((CAST(date_completed AS DATE) - CAST(date_started AS DATE)) * 86400)) as durationSum',
+                            'durationSum', StandardBasicTypes.LONG
+                    sqlProjection 'min(round((CAST(date_completed AS DATE) - CAST(date_started AS DATE)) * 86400)) as durationMin',
+                            'durationMin', StandardBasicTypes.LONG
+                    sqlProjection 'max(round((CAST(date_completed AS DATE) - CAST(date_started AS DATE)) * 86400)) as durationMax',
+                            'durationMax', StandardBasicTypes.LONG
+                    sqlProjection 'sum(case when status = \'succeeded\' then 1 else 0 end) as succeededCount',
+                            'succeededCount', StandardBasicTypes.LONG
+                    sqlProjection 'sum(case when status in (\'failed\', \'failed-with-retry\', \'timedout\') then 1 else 0 end) as failedCount',
+                            'failedCount', StandardBasicTypes.LONG
+                }
+            }
+            return Arrays.asList(metricCriteriaOracle)
+        }
+
         def metricCriteriaB = {
             // Run main query criteria
             def baseQueryCriteria = query.createCriteria(delegate, jobQueryComponents)
@@ -4927,35 +4976,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                         StandardBasicTypes.LONG
             }
         }
-        // Oracle: DATE - DATE returns NUMBER (fractional days); multiply by 86400 for integer seconds
-        def metricCriteriaC = {
-            def baseQueryCriteria = query.createCriteria(delegate, jobQueryComponents)
-            baseQueryCriteria()
-
-            resultTransformer(CriteriaSpecification.ALIAS_TO_ENTITY_MAP)
-            projections {
-
-                rowCount("count")
-                sqlProjection 'sum(round((date_completed - date_started) * 86400)) as durationSum',
-                        'durationSum',
-                        StandardBasicTypes.LONG
-                sqlProjection 'min(round((date_completed - date_started) * 86400)) as durationMin',
-                        'durationMin',
-                        StandardBasicTypes.LONG
-                sqlProjection 'max(round((date_completed - date_started) * 86400)) as durationMax',
-                        'durationMax',
-                        StandardBasicTypes.LONG
-
-                // Zero-overhead status count projections
-                sqlProjection 'sum(case when status = \'succeeded\' then 1 else 0 end) as succeededCount',
-                        'succeededCount',
-                        StandardBasicTypes.LONG
-                sqlProjection 'sum(case when status in (\'failed\', \'failed-with-retry\', \'timedout\') then 1 else 0 end) as failedCount',
-                        'failedCount',
-                        StandardBasicTypes.LONG
-            }
-        }
-        return Arrays.asList(metricCriteriaB, metricCriteriaC)
+        return Arrays.asList(metricCriteriaB)
     }
 
     /**

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -6424,10 +6424,51 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
             !service.isMySqlDatasource()
     }
 
+    def "isOracleDatasource returns true when databaseProductName is Oracle"() {
+        given:
+            def mockMetaData = Mock(DatabaseMetaData) { getDatabaseProductName() >> 'Oracle' }
+            def mockConn = Mock(Connection) { getMetaData() >> mockMetaData }
+            def mockDs = Mock(DataSource) { getConnection() >> mockConn }
+            service.applicationContext = Mock(org.springframework.context.ApplicationContext) {
+                getBean('dataSource', DataSource) >> mockDs
+            }
+        expect:
+            service.isOracleDatasource()
+    }
+
+    def "isOracleDatasource returns false when databaseProductName is not Oracle"() {
+        given:
+            def mockMetaData = Mock(DatabaseMetaData) { getDatabaseProductName() >> 'PostgreSQL' }
+            def mockConn = Mock(Connection) { getMetaData() >> mockMetaData }
+            def mockDs = Mock(DataSource) { getConnection() >> mockConn }
+            service.applicationContext = Mock(org.springframework.context.ApplicationContext) {
+                getBean('dataSource', DataSource) >> mockDs
+            }
+        expect:
+            !service.isOracleDatasource()
+    }
+
     def "getCriteriaScenarios returns single MySQL-specific criteria when datasource is MySQL"() {
         given:
             service.metaClass.isH2Datasource = { -> false }
             service.metaClass.isMySqlDatasource = { -> true }
+            service.applicationContext = Mock(org.springframework.context.ApplicationContext) {
+                getBeansOfType(JobQuery) >> [:]
+            }
+            def query = new ExecutionQuery()
+        when:
+            def scenarios = service.getCriteriaScenarios(query)
+        then:
+            scenarios.size() == 1
+        cleanup:
+            service.metaClass = null
+    }
+
+    def "getCriteriaScenarios returns single Oracle-specific criteria when datasource is Oracle"() {
+        given:
+            service.metaClass.isH2Datasource = { -> false }
+            service.metaClass.isMySqlDatasource = { -> false }
+            service.metaClass.isOracleDatasource = { -> true }
             service.applicationContext = Mock(org.springframework.context.ApplicationContext) {
                 getBeansOfType(JobQuery) >> [:]
             }

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -22,6 +22,7 @@ import com.dtolabs.rundeck.core.logging.internal.LogFlusher
  */
 
 
+import com.dtolabs.rundeck.app.support.ExecutionQuery
 import com.dtolabs.rundeck.app.support.QueueQuery
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.SubjectAuthContext
@@ -41,6 +42,7 @@ import com.dtolabs.rundeck.execution.WorkflowExecutionListenerTest
 import groovy.time.TimeCategory
 import org.rundeck.app.auth.types.AuthorizingProject
 import org.rundeck.app.authorization.AppAuthContextProcessor
+import org.rundeck.app.components.jobs.JobQuery
 import org.rundeck.app.authorization.domain.execution.AuthorizingExecution
 import rundeck.data.constants.ExecutionConstants
 import rundeck.data.report.SaveReportRequestImpl
@@ -6384,6 +6386,58 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
             }
         expect:
             !service.isH2Datasource()
+    }
+
+    def "isMySqlDatasource returns true when databaseProductName is MySQL"() {
+        given:
+            def mockMetaData = Mock(DatabaseMetaData) { getDatabaseProductName() >> 'MySQL' }
+            def mockConn = Mock(Connection) { getMetaData() >> mockMetaData }
+            def mockDs = Mock(DataSource) { getConnection() >> mockConn }
+            service.applicationContext = Mock(org.springframework.context.ApplicationContext) {
+                getBean('dataSource', DataSource) >> mockDs
+            }
+        expect:
+            service.isMySqlDatasource()
+    }
+
+    def "isMySqlDatasource returns true when databaseProductName is MariaDB"() {
+        given:
+            def mockMetaData = Mock(DatabaseMetaData) { getDatabaseProductName() >> 'MariaDB' }
+            def mockConn = Mock(Connection) { getMetaData() >> mockMetaData }
+            def mockDs = Mock(DataSource) { getConnection() >> mockConn }
+            service.applicationContext = Mock(org.springframework.context.ApplicationContext) {
+                getBean('dataSource', DataSource) >> mockDs
+            }
+        expect:
+            service.isMySqlDatasource()
+    }
+
+    def "isMySqlDatasource returns false when databaseProductName is not MySQL or MariaDB"() {
+        given:
+            def mockMetaData = Mock(DatabaseMetaData) { getDatabaseProductName() >> 'PostgreSQL' }
+            def mockConn = Mock(Connection) { getMetaData() >> mockMetaData }
+            def mockDs = Mock(DataSource) { getConnection() >> mockConn }
+            service.applicationContext = Mock(org.springframework.context.ApplicationContext) {
+                getBean('dataSource', DataSource) >> mockDs
+            }
+        expect:
+            !service.isMySqlDatasource()
+    }
+
+    def "getCriteriaScenarios returns single MySQL-specific criteria when datasource is MySQL"() {
+        given:
+            service.metaClass.isH2Datasource = { -> false }
+            service.metaClass.isMySqlDatasource = { -> true }
+            service.applicationContext = Mock(org.springframework.context.ApplicationContext) {
+                getBeansOfType(JobQuery) >> [:]
+            }
+            def query = new ExecutionQuery()
+        when:
+            def scenarios = service.getCriteriaScenarios(query)
+        then:
+            scenarios.size() == 1
+        cleanup:
+            service.metaClass = null
     }
 
     def "isSqlCompatible returns false without propagating exception when criteria throws"() {


### PR DESCRIPTION
## Release Notes

Fixed SQL time-parse errors logged on every call to the execution metrics API when using MySQL, MariaDB, or Oracle databases. Metrics data was still returned correctly via a fallback path, but server logs were spammed and response times were slower than necessary. Duration aggregation now uses database-appropriate queries for these backends.

## PR Details

## Summary

- [PR #10186](https://github.com/rundeck/rundeck/pull/10186) fixed the `/executions/metrics` SQL time-parse error (`cannot be parse as time. time must have "99:99:99" format`) for H2 only. Production customers mostly run MySQL/MariaDB, which hits the same underlying bug: aggregating execution durations by casting a raw `date_completed - date_started` diff to SQL `TIME` doesn't work — MySQL's naive datetime subtraction isn't a valid `TIME` value at all, and even where it superficially parses, `TIME` overflows past `838:59:59` once durations are summed across many executions.
- Add `isMySqlDatasource()` and a dedicated MySQL/MariaDB branch (mirroring the existing H2 branch) using `TIMESTAMPDIFF(SECOND, ...)` projected as `LONG`, applied in both `getCriteriaScenarios()` and the `isSqlCompatible()` compatibility gate.
- The `isSqlCompatible()` gate was the more subtle half of the bug: it silently caught the SQL exception and fell back to in-memory metrics calculation, so the API kept returning correct data while still spamming `service.log` with the SQL error on every call — matching the exact symptom in the original report.
- Follow-up commit also fixed the same bug class on Oracle (TIMESTAMP interval arithmetic), adding `isOracleDatasource()` and an explicit Oracle branch.

## Test plan

- [x] `ExecutionServiceSpec`: added unit tests for `isMySqlDatasource()` (MySQL, MariaDB, non-MySQL) and for `getCriteriaScenarios()` selecting the MySQL branch. Full suite: 295 tests, 0 failures.
- [x] Verified end-to-end against a real `mysql:8.4`-backed Rundeck instance (built from this branch, isolated docker-compose): before the fix, `/executions/metrics` logged `cannot be parse as time` on every call; after, zero SQL errors across repeated calls, and response latency dropped (SQL aggregation path instead of in-memory fallback).
- [x] Verified end-to-end against Oracle (`gvenzl/oracle-free`): zero SQL errors across repeated `/executions/metrics` calls, correct duration data.
- [x] PostgreSQL verified live — existing `extract(EPOCH ...)` path unaffected, no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
