### PR TITLE
[RUN-4482] Resolve job reference override filter against child project when using referenced job's nodes

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3734,6 +3734,10 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      * @param nodeFilter
      * @param nodeThreadcount
      * @param nodeKeepgoing
+     * @param childProject project of the referenced (child) job; used as the node resolution scope
+     *        when {@code useChildNodes} is enabled and no intersection is requested (RUN-4482)
+     * @param useChildNodes when true, resolve a non-intersecting override filter against the
+     *        referenced job's project ({@code childProject}) instead of the calling job's project
      * @return
      */
     StepExecutionContext overrideJobReferenceNodeFilter(
@@ -3745,7 +3749,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             Boolean nodeKeepgoing,
             String nodeRankAttribute,
             Boolean nodeRankOrderAscending,
-            Boolean nodeIntersect
+            Boolean nodeIntersect,
+            String childProject = null,
+            Boolean useChildNodes = null
     )
     {
         def builder = ExecutionContextImpl.builder(newContext);
@@ -3770,16 +3776,25 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
 
             def INodeSet trialNodes
+            //project whose node set the override filter is resolved against; defaults to the
+            //calling (parent) job's project.
+            def String targetProject = newContext.frameworkProject
             if (nodeIntersect) {
                 // Create intersection of overridden node filter and upstream job nodes
                 trialNodes = com.dtolabs.rundeck.core.common.NodeFilter.filterNodes(nodeselector, origContext.nodes)
                 nodeselector = SelectorUtils.nodeList(trialNodes.nodeNames)
             } else {
-                trialNodes = frameworkService.filterNodeSet(nodeselector, newContext.frameworkProject)
+                //RUN-4482: when "Use referenced job's nodes" is enabled, resolve the override
+                //filter against the referenced (child) job's project so the parent can select the
+                //child project's nodes by attribute, instead of the calling job's project.
+                if (useChildNodes && childProject) {
+                    targetProject = childProject
+                }
+                trialNodes = frameworkService.filterNodeSet(nodeselector, targetProject)
             }
 
             INodeSet nodeSet = rundeckAuthContextProcessor.filterAuthorizedNodes(
-                    newContext.frameworkProject,
+                    targetProject,
                     new HashSet<String>(["read", "run"]),
                     trialNodes,
                     newContext.userAndRolesAuthContext);
@@ -3975,7 +3990,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     nodeKeepgoing,
                     nodeRankAttribute,
                     nodeRankOrderAscending,
-                    nodeIntersect
+                    nodeIntersect,
+                    se?.project,
+                    useChildNodes
             )
         }
         if(dovalidate){

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionService2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionService2Spec.groovy
@@ -1905,6 +1905,70 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
         1 == 1
     }
     /**
+     * RUN-4482: with "Use referenced job's nodes" enabled and no intersection, the override node
+     * filter must be resolved (and authorized) against the referenced (child) job's project.
+     */
+    void testOverrideJobReferenceNodeFilter_useChildNodesResolvesAgainstChildProject() {
+        def context = ExecutionContextImpl.builder()
+                                          .frameworkProject('parentProject')
+                                          .nodes(makeNodeSet(['parent-1']))
+                                          .nodeSelector(makeSelector("parent-1", 1, false))
+                                          .threadCount(1)
+                                          .keepgoing(false)
+                                          .build()
+        String filteredProject = null
+        service.frameworkService=mockWith(FrameworkService){
+            filterNodeSet(1..1){ NodesSelector selector, String project->
+                filteredProject = project
+                makeNodeSet(['child-1'])
+            }
+        }
+        String authProject = null
+        service.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
+            1 * filterAuthorizedNodes(_, _, _, _)>> { arguments -> authProject = arguments[0] as String; makeNodeSet(['child-1']) }
+        }
+
+        def newctx=service.overrideJobReferenceNodeFilter(null,new ExecutionContextImpl(), context, 'VMID:123', null, null, null, null, false, 'childProject', true)
+        assertEquals('childProject', filteredProject)
+        assertEquals('childProject', authProject)
+        assertEquals(['child-1'] as Set,newctx.nodes.nodeNames as Set)
+
+        expect:
+        // asserts validate above
+        1 == 1
+    }
+    /**
+     * RUN-4482 regression: without "Use referenced job's nodes", the override node filter keeps
+     * being resolved against the calling (parent) job's project.
+     */
+    void testOverrideJobReferenceNodeFilter_withoutChildNodesResolvesAgainstParentProject() {
+        def context = ExecutionContextImpl.builder()
+                                          .frameworkProject('parentProject')
+                                          .nodes(makeNodeSet(['parent-1']))
+                                          .nodeSelector(makeSelector("parent-1", 1, false))
+                                          .threadCount(1)
+                                          .keepgoing(false)
+                                          .build()
+        String filteredProject = null
+        service.frameworkService=mockWith(FrameworkService){
+            filterNodeSet(1..1){ NodesSelector selector, String project->
+                filteredProject = project
+                makeNodeSet(['parent-1'])
+            }
+        }
+        service.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
+            1 * filterAuthorizedNodes(*_)>> { makeNodeSet(['parent-1']) }
+        }
+
+        def newctx=service.overrideJobReferenceNodeFilter(null,new ExecutionContextImpl(), context, 'VMID:123', null, null, null, null, false, 'childProject', false)
+        assertEquals('parentProject', filteredProject)
+        assertEquals(['parent-1'] as Set,newctx.nodes.nodeNames as Set)
+
+        expect:
+        // asserts validate above
+        1 == 1
+    }
+    /**
      * set node filter and threadcount
      */
     void testOverrideJobReferenceNodeFilter_filterAndThreadcount() {
@@ -2196,6 +2260,77 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
                       'group':'some/where'
                      ].sort().toString(), newCtxt.dataContext['job'].sort().toString())
 
+    }
+    /**
+     * RUN-4482: child job WITH its own filter + blank override filter + "Use referenced job's
+     * nodes" enabled. The override step is skipped entirely (no nodeFilter, no intersect), so the
+     * node set is resolved by createContext using the child job's own filter against the child
+     * (referenced) job's project - NOT the calling job's project.
+     */
+    void testcreateJobReferenceContext_blankOverrideWithChildNodesUsesChildProject(){
+        ScheduledExecution job = prepare()
+
+        def context = ExecutionContextImpl.builder()
+                                          .frameworkProject('parentProject')
+                                          .nodes(makeNodeSet(['parent-1', 'parent-2']))
+                                          .nodeSelector(makeSelector("parent-1 parent-2", 1, false))
+                                          .threadCount(1)
+                                          .keepgoing(false)
+                                          .dataContext(['option':[:],'job':['execid':'123']])
+                                          .user('aUser')
+                                          .build()
+        String filteredProject = null
+        int filterNodeSetCalls = 0
+        service.frameworkService = mockWith(FrameworkService) {
+            parseOptsFromArray(1..1) { String[] args ->
+                ['test1':'value']
+            }
+            getFrameworkPropertiesMap(1..1) { -> [:] }
+            getProjectProperties(1..1) { project -> [:] }
+            parseOptsFromArray(1..1) { String[] args ->
+                ['test1':'value']
+            }
+            getProjectGlobals(1..1) { project ->
+                [:]
+            }
+            //only createContext calls this; overrideJobReferenceNodeFilter must NOT be invoked
+            filterNodeSet(1..1) { NodesSelector selector, String project ->
+                filterNodeSetCalls++
+                filteredProject = project
+                makeNodeSet(['child-1','child-2'])
+            }
+        }
+        service.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+            1 * filterAuthorizedNodes(*_) >> { makeNodeSet(['child-1','child-2']) }
+        }
+        service.storageService=mockWith(StorageService){
+            storageTreeWithContext(1..1){AuthContext->
+                null
+            }
+        }
+        service.jobStateService = mockWith(JobStateService) {
+            jobServiceWithAuthContext { ctx ->
+                null
+            }
+        }
+        service.fileUploadService = mockWith(FileUploadService){
+            executionBeforeStart { evt, skip->
+                null
+            }
+        }
+
+        //nodeFilter=null (blank override), nodeIntersect=false, useChildNodes=true
+        def newCtxt=service.createJobReferenceContext(job,null,context,['-test1','value'] as String[],null,null,null,null,null,null, false,false,true,true);
+
+        //override step skipped: filterNodeSet called exactly once (by createContext)
+        assertEquals(1, filterNodeSetCalls)
+        //resolved against the child (referenced) job's project, not 'parentProject'
+        assertEquals('AProject', filteredProject)
+        assertEquals(['child-1','child-2'] as Set,newCtxt.nodes.nodeNames as Set)
+
+        expect:
+        // asserts validate above
+        1 == 1
     }
     void testcreateJobReferenceContext_overrideNodefilter(){
         ScheduledExecution job = prepare()


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix for [RUN-4482](https://pagerduty.atlassian.net/browse/RUN-4482).

When a Job Reference step has **"Use referenced job's nodes"** enabled together with an **override node filter** (and node intersection *off*), the override filter was resolved against the **calling (parent) job's project**. As a result the referenced job kept dispatching to the parent project's nodes and could not select the child project's nodes by attribute (e.g. `VMID:${node.VMID}`), even though the child-nodes option was checked.

**Describe the solution you've implemented**

`overrideJobReferenceNodeFilter` now receives the referenced job's project (`se.project`) and the `useChildNodes` flag from `createJobReferenceContext`. When `useChildNodes` is enabled and no intersection is requested, the non-intersecting override filter is resolved — and authorized (`read`/`run`) — against the **child** project instead of the calling job's project. This mirrors the project scoping that `createContext` already applies when resolving the referenced job's own node set.

Behavior left unchanged:
- **Without** "Use referenced job's nodes": override filter still resolves against the parent project.
- **Node intersection** branch: untouched (still intersects with the parent's upstream nodes).

**Describe alternatives you've considered**

- Setting `newContext.frameworkProject` to the child project in `createContext` — rejected as too broad (it also drives storage, plugin-control and auth scope), so the fix is contained to the override path.
- Defining a combined semantics for `useChildNodes` + node-intersection — intentionally out of scope; that combination is contradictory (intersect pins to the parent's nodes) and will be addressed via documentation.

**Additional context**

Unit tests added/covered in `ExecutionService2Spec`:
- `overrideJobReferenceNodeFilter` resolves against the child project when `useChildNodes` is on.
- Regression: without `useChildNodes`, it still resolves against the parent project.
- `createJobReferenceContext` with a blank override + `useChildNodes` resolves the child job's own filter against the child project (override step skipped).

## Release Notes

Fixed: Job Reference steps with "Use referenced job's nodes" enabled and an override node filter now resolve the filter against the referenced job's project, allowing the parent job to select the child project's nodes by attribute.


[RUN-4482]: https://pagerduty.atlassian.net/browse/RUN-4482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ