### PR TITLE
[RUN-4749] Update nanoid for CVE-2026-67213

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/_package-manager/package-lock.json
+++ b/rundeckapp/grails-app/assets/javascripts/_package-manager/package-lock.json
@@ -6289,9 +6289,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://npm.artifacts.pd-internal.com/npm/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://npm.artifacts.pd-internal.com/npm/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",

--- a/rundeckapp/grails-app/assets/javascripts/_package-manager/package.json
+++ b/rundeckapp/grails-app/assets/javascripts/_package-manager/package.json
@@ -47,6 +47,7 @@
     },
     "cross-spawn": "^7.0.6",
     "serialize-javascript": "^7.0.3",
-    "ajv": "6.14.0"
+    "ajv": "6.14.0",
+    "nanoid": "^3.3.17"
   }
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
@@ -19391,9 +19391,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://npm.artifacts.pd-internal.com/npm/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://npm.artifacts.pd-internal.com/npm/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",

--- a/rundeckapp/grails-spa/packages/ui-trellis/package.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package.json
@@ -175,7 +175,8 @@
     "@babel/runtime": "^7.26.10",
     "tough-cookie": "^4.1.3",
     "@azure/ms-rest-js": "2.7.0",
-    "uuid": "$uuid"
+    "uuid": "$uuid",
+    "nanoid": "^3.3.17"
   },
   "jest-junit": {
     "outputDirectory": "./build/test-results",


### PR DESCRIPTION
## Release Notes

This release addresses CVE-2026-67213 by updating the nanoid JavaScript dependency used in the Rundeck web UI to version 3.3.17, fixing a denial-of-service vulnerability that could cause excessive CPU use during ID generation.

## PR Details

This pull request updates the `nanoid` dependency to version `3.3.17` across multiple packages and ensures it is explicitly declared in the relevant `package.json` files. This helps keep dependencies up-to-date and consistent throughout the project.

Dependency updates:

* Updated `nanoid` from version `3.3.16` to `3.3.17` in both `rundeckapp/grails-app/assets/javascripts/_package-manager/package-lock.json` and `rundeckapp/grails-spa/packages/ui-trellis/package-lock.json` to ensure the latest patch is used.

Dependency declarations:

* Added `nanoid` version `^3.3.17` to the dependencies in `rundeckapp/grails-app/assets/javascripts/_package-manager/package.json` and `rundeckapp/grails-spa/packages/ui-trellis/package.json` to explicitly declare and manage the dependency.
