### PR TITLE
[RUN-0000] Fix CVE-2026-71497 by forcing jsoup 1.23.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -272,6 +272,8 @@ allprojects {
             // CVE and compatibility fixes
             force "commons-fileupload:commons-fileupload:${commonsFileuploadVersion}"
             force "com.google.protobuf:protobuf-java:${protobufVersion}" // CVE-2024-7254 fix
+            // CVE-2026-71497: jsoup pulled transitively via micronaut-openapi (compileOnly)
+            force "org.jsoup:jsoup:${jsoupVersion}"
             // CWE-770 (SNYK-JAVA-COMFASTERXMLJACKSONCORE-15365924): build-tooling configs such as
             // groovyScript pull groovy-yaml -> jackson 2.19.2, which the jackson BOM only covers in
             // app/plugin configs. Force jackson onto the managed version across ALL configurations.

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,6 +40,8 @@ jacksonDataformatCBORVersion=2.22.1
 jacksonAnnotationsVersion=2.22
 snakeyamlVersion=2.6
 gsonVersion=2.14.0
+# Updated from 1.22.1 - fixes CVE-2026-71497 (transitive via micronaut-openapi)
+jsoupVersion=1.23.1
 httpCoreVersion=4.4.16
 httpClientVersion=4.5.14
 # CVE-2026-54399 (SNYK-JAVA-ORGAPACHEHTTPCOMPONENTSCORE5-17817218): httpcore5-h2 HTTP/2 DoS,


### PR DESCRIPTION
## Tell us about your PR

**Is this a bug fix, or an enhancement? Please describe.**
Security fix for CVE-2026-71497 (SNYK-JAVA-ORGJSOUP-18593889). Snyk reports jsoup 1.22.1 introduced through `io.micronaut.openapi:micronaut-openapi@6.20.0` on rundeckapp compile classpath.

**Describe the solution you've implemented**
- Added `jsoupVersion=1.23.1` to `gradle.properties`
- Forced `org.jsoup:jsoup:${jsoupVersion}` in the root `resolutionStrategy` (same pattern as other CVE pins)

**Describe alternatives you've considered**
- Waiting for micronaut-openapi to bump its jsoup dependency
- Excluding jsoup from micronaut-openapi and declaring it explicitly (more invasive for a compileOnly transitive)

**Additional context**
Verified with:
`./gradlew :rundeckapp:dependencyInsight --dependency jsoup --configuration compileClasspath`
→ `org.jsoup:jsoup:1.23.1 (forced)`

Related rundeckpro PR: https://github.com/rundeckpro/rundeckpro/pull/4942

## Release Notes
Upgraded jsoup to 1.23.1 to address CVE-2026-71497 in OpenAPI tooling dependencies.