### PR TITLE
[RUN-4741] Fix execution summary Start Time column Showing Step Identifiers

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -683,6 +683,7 @@ function RDNode(name, steps,flow){
         }
     };
     self.durationMs=ko.observable(-1);
+    self.summaryStartTime=ko.observable(null);
     self.toggleExpand=function(){
         self.expanded(!self.expanded());
         if(self.expanded()){
@@ -693,24 +694,61 @@ function RDNode(name, steps,flow){
         }
     };
     self.duration=ko.pureComputed(function(){
-        //sum up duration of all completed steps
+        // Prefer server-provided wall-clock duration; otherwise derive span from step times
        var ms=self.durationMs();
         if(ms<0) {
+            var earliest = null;
+            var latest = null;
             ko.utils.arrayForEach(self.steps(), function (x) {
                 if (!x.parameterizedStep()) {
-                    var ms2 = x.duration();
-                    if (ms2 >= 0 && ms < 0) {
-                        ms = ms2;
-                    } else if (ms2 >= 0) {
-                        ms += ms2;
+                    var start = x.startTime();
+                    var end = x.endTime() || x.updateTime();
+                    if (start) {
+                        var st = moment(start);
+                        if (!earliest || st.isBefore(earliest)) {
+                            earliest = st;
+                        }
+                    }
+                    if (end) {
+                        var et = moment(end);
+                        if (!latest || et.isAfter(latest)) {
+                            latest = et;
+                        }
                     }
                 }
             });
+            if (earliest && latest) {
+                ms = latest.diff(earliest);
+            }
         }
        return ms;
     });
     self.durationSimple=ko.pureComputed(function(){
        return MomentUtil.formatDurationSimple(self.duration());
+    });
+    self.nodeStartTime=ko.pureComputed(function(){
+        var earliest = null;
+        if (self.summaryStartTime()) {
+            earliest = moment(self.summaryStartTime());
+        }
+        ko.utils.arrayForEach(self.steps(), function (x) {
+            if (!x.parameterizedStep() && x.startTime()) {
+                var st = moment(x.startTime());
+                if (!earliest || st.isBefore(earliest)) {
+                    earliest = st;
+                }
+            }
+        });
+        if (!earliest) {
+            var cur = self.currentStep();
+            if (cur && cur.startTime()) {
+                earliest = moment(cur.startTime());
+            }
+        }
+        return earliest ? earliest.toISOString() : null;
+    });
+    self.nodeStartTimeSimple=ko.pureComputed(function(){
+        return MomentUtil.formatTimeSimple(self.nodeStartTime());
     });
     self.summary=ko.observable();
     self.summaryState=ko.observable();
@@ -851,6 +889,7 @@ function RDNode(name, steps,flow){
         self.summary(self.summaryDescriptionForState(nodesummary));
 
         self.durationMs(nodesummary.duration);
+        self.summaryStartTime(nodesummary.startTime || null);
         if(nodesummary.currentStep){
             self.currentStepFromData(nodesummary.currentStep);
         }else{

--- a/rundeckapp/grails-app/assets/javascripts/workflow.js
+++ b/rundeckapp/grails-app/assets/javascripts/workflow.js
@@ -275,7 +275,12 @@ RDWorkflow.workflowIndexForContextId = function (ctxid) {
 };
 /**
  * Resolve a workflow step definition for a hierarchical step context string,
- * traversing conditional subSteps for contexts like "2/1".
+ * traversing conditional subSteps for contexts like "2/1". Job-reference and
+ * error-handler sub-workflow contexts (e.g. "1/1" into step.workflow, or "1e/1"
+ * into step.ehWorkflow) are not conditional subSteps, so traversal stops there
+ * and returns the deepest step resolved so far, matching the top-level-only
+ * resolution used before subSteps traversal existed - rather than failing
+ * outright and falling back to the raw "Step: <ctx>" placeholder text.
  * @param workflow workflow step list
  * @param context step context string or parsed array
  * @returns {*|null}
@@ -294,11 +299,11 @@ RDWorkflow.stepForContext = function (workflow, context) {
     var step = workflow[ndx];
     for (var i = 1; i < context.length; i++) {
         if (!step || !step.subSteps) {
-            return null;
+            break;
         }
         var subndx = RDWorkflow.workflowIndexForContextId(context[i]);
         if (subndx == null || subndx < 0 || subndx >= step.subSteps.length) {
-            return null;
+            break;
         }
         step = step.subSteps[subndx];
     }

--- a/rundeckapp/grails-app/assets/javascripts/workflow.js
+++ b/rundeckapp/grails-app/assets/javascripts/workflow.js
@@ -78,10 +78,10 @@ var RDWorkflow = function (wf,params) {
 
 
         contextType: function (ctx) {
-            if (typeof (ctx) == 'string') {
-                ctx = RDWorkflow.parseContextId(ctx)
+            var step = RDWorkflow.stepForContext(this.workflow, ctx)
+            if (step == null) {
+                return 'unknown-step-type'
             }
-            var step = this.workflow[RDWorkflow.workflowIndexForContextId(ctx[0])]
             return _wfTypeForStep(step)
         },
         renderContextStepNumber: function (ctx) {
@@ -97,10 +97,11 @@ var RDWorkflow = function (wf,params) {
             return string
         },
         renderContextString: function (ctx) {
-            if (typeof (ctx) == 'string') {
-                ctx = RDWorkflow.parseContextId(ctx)
+            var step = RDWorkflow.stepForContext(this.workflow, ctx)
+            if (step == null) {
+                var ctxstr = typeof (ctx) == 'string' ? ctx : RDWorkflow.createContextId(ctx)
+                return 'Step: ' + ctxstr
             }
-            var step = this.workflow[RDWorkflow.workflowIndexForContextId(ctx[0])]
             return _wfStringForStep(step)
         }
     })
@@ -271,6 +272,37 @@ RDWorkflow.workflowIndexForContextId = function (ctxid) {
         return m - 1;
     }
     return null;
+};
+/**
+ * Resolve a workflow step definition for a hierarchical step context string,
+ * traversing conditional subSteps for contexts like "2/1".
+ * @param workflow workflow step list
+ * @param context step context string or parsed array
+ * @returns {*|null}
+ */
+RDWorkflow.stepForContext = function (workflow, context) {
+    if (typeof (context) == 'string') {
+        context = RDWorkflow.parseContextId(context)
+    }
+    if (!context || !context.length || !workflow) {
+        return null;
+    }
+    var ndx = RDWorkflow.workflowIndexForContextId(context[0]);
+    if (ndx == null || ndx < 0 || ndx >= workflow.length) {
+        return null;
+    }
+    var step = workflow[ndx];
+    for (var i = 1; i < context.length; i++) {
+        if (!step || !step.subSteps) {
+            return null;
+        }
+        var subndx = RDWorkflow.workflowIndexForContextId(context[i]);
+        if (subndx == null || subndx < 0 || subndx >= step.subSteps.length) {
+            return null;
+        }
+        step = step.subSteps[subndx];
+    }
+    return step;
 };
 /**
  * removes error handler/parameters from the context path

--- a/rundeckapp/grails-app/assets/javascripts/workflow.test.js
+++ b/rundeckapp/grails-app/assets/javascripts/workflow.test.js
@@ -166,6 +166,27 @@ jQuery(function () {
 
             RDWorkflow.nodeSteppluginDescriptions = orig;
             RDWorkflow.wfSteppluginDescriptions = orig;
+        },
+        renderContextStringHierarchicalTest: function () {
+            var wf = new RDWorkflow([
+                {
+                    type: 'conditional',
+                    description: 'outer-conditional',
+                    subSteps: [
+                        {
+                            type: 'conditional',
+                            description: 'inner-conditional',
+                            subSteps: [
+                                {exec: 'echo sub', description: 'nested-command'}
+                            ]
+                        }
+                    ]
+                },
+                {exec: 'echo top', description: 'top-command'}
+            ]);
+            this.assert(wf.renderContextString('1/1/1') === 'nested-command');
+            this.assert(wf.renderContextString('2') === 'top-command');
+            this.assert(wf.renderContextString('99') === 'Step: 99');
         }
     });
 });

--- a/rundeckapp/grails-app/services/rundeck/services/workflow/StateMapping.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/workflow/StateMapping.groovy
@@ -107,6 +107,7 @@ class StateMapping {
             duration = updated.time - dateStarted.time
         }
         summary.duration=duration
+        summary.startTime=encodeDate(dateStarted)
         if(currentStep){
             summary.currentStep=currentStep
         }

--- a/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
@@ -88,22 +88,8 @@
           </div>
 
           <div class="col-sm-2 ">
-              <div data-bind="with: currentStep(), visible: !expanded()">
-                  <span class="stepident "
-                        data-bind="attr: { 'data-execstate': executionState }">
-
-                      <feature:disabled name="workflowDynamicStepSummaryGUI">
-                          <i class="rdicon icon-small" data-bind="css: stepinfo().type"></i>
-                          <span data-bind="text: stepinfo().stepident"></span>
-                      </feature:disabled>
-                      <feature:enabled name="workflowDynamicStepSummaryGUI">
-                          <span data-bind="template: {name: 'step-info-simple-link', data:stepinfo(), as: 'stepinfo'}"></span>
-                      </feature:enabled>
-                  </span>
-                  <span data-bind="if: ( executionState() == 'WAITING' ) " class="text-strong">
-                      (Next up)
-                  </span>
-              </div>
+              <span class="execstart info time"
+                    data-bind="text: nodeStartTimeSimple, visible: !expanded()"></span>
           </div>
           <div class="col-sm-2 ">
               <span class="execend  info time"

--- a/rundeckapp/src/test/groovy/rundeck/services/workflow/StateMappingSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/workflow/StateMappingSpec.groovy
@@ -531,6 +531,23 @@ class StateMappingSpec extends Specification {
             summarized.nodeSteps['localhost'].find { it.stepctx == '1' } != null
     }
 
+    def "summarizeForNode should set node summary startTime to the earliest step start time"() {
+        given: 'node step has subworkflow error handler, with a parent step and a later-starting sub-step'
+            def sut = new StateMapping()
+            def mutableStep1 = new MutableWorkflowStepStateImpl(stepIdentifier(1))
+            mutableStep1.nodeStep = true
+            def state = new MutableWorkflowStateImpl(['localhost'], 1, [0: mutableStep1])
+            MutableWorkflowStateImplTest.processStateChanges(state, STATE_CHANGES2)
+        when: "summarize node state"
+            def result = sut.mapOf(1, state)
+            def summarized = sut.summarize(result, ['localhost'], true)
+        then: "node summary startTime matches the earliest of its steps' own startTime values, not a later one"
+            def stepStartTimes = summarized.nodeSteps['localhost']*.startTime
+            stepStartTimes.size() == 2
+            summarized.nodeSummaries['localhost'].startTime == stepStartTimes.min()
+            summarized.nodeSummaries['localhost'].startTime != stepStartTimes.max()
+    }
+
     boolean mapEntriesAreEqualIgnoringDates(given, expected) {
         //assume they are the same type
         if (given instanceof Map) {


### PR DESCRIPTION
## Release Notes

Fixed an issue on the Execution Summary page where the Start Time column for collapsed node rows showed step identifiers (such as "Step: 2/1") instead of an actual timestamp when viewing conditional or branching workflows. The Start Time column now displays the node's earliest step start time.

## PR Details

<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Bugfix ([RUN-4741](https://pagerduty.atlassian.net/browse/RUN-4741)). Collapsed node rows showed step labels (e.g. Step: 2/1) under Start Time instead of a timestamp.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
Use the node's earliest step start time in the collapsed Start Time column (StateMapping, executionStateKO, GSP). Improve hierarchical step-context lookup for nested conditionals (workflow.js). Added unit tests.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
Expanded per-step rows can still show Step: N/M — pre-existing, tracked separately (RUN-4742). Out of scope here.

[RUN-4741]: https://pagerduty.atlassian.net/browse/RUN-4741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
