### PR TITLE
[RUN-4543] Fix stored CSS injection via unguarded style attribute in HTML sanitizer

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/MotdSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/MotdSpec.groovy
@@ -44,17 +44,17 @@ class MotdSpec extends SeleniumBase {
             projectEditPage.save()
             projectEditPage.validateConfigFileSave()
             motdPage.clickMOTD()
-        then: "validate that motd is shown in the navbar and it has the right value"
-            motdPage.waitForMessageShownInProject("a simple message")
+        then: "validate that motd is shown in the navbar and it has the right value, with the script tag inert but not stripped"
+            motdPage.waitForMessageShownInProject(motdMessage)
         when:
             projectDashboard.go("/project/${projectName}/home")
         then: "validate motd shown on project dashboard"
-            motdPage.waitForMessageShownInProject("a simple message")
+            motdPage.waitForMessageShownInProject(motdMessage)
         when:
             homePage.setLoadPath("/menu/home")
             homePage.go()
         then:
-            motdPage.waitForMessageShownInHome("a simple message")
+            motdPage.waitForMessageShownInHome(motdMessage)
         cleanup:
             deleteProject(projectName)
 
@@ -86,17 +86,17 @@ class MotdSpec extends SeleniumBase {
             projectEditPage.clickNavLink(NavProjectSettings.USER_INTERFACE)
             projectEditPage.selectAllMotdPlaces()
             projectEditPage.save()
-        then: "validate that motd is shown in the navbar and it has the right value"
-            motdPage.waitForMessageShownInProject("a simple message")
+        then: "validate that motd is shown in the navbar and it has the right value, with the script tag inert but not stripped"
+            motdPage.waitForMessageShownInProject(motdMessage)
         when:
             projectDashboard.go("/project/${projectName}/home")
         then: "validate motd shown on project dashboard"
-            motdPage.waitForMessageShownInProject("a simple message")
+            motdPage.waitForMessageShownInProject(motdMessage)
         when:
             homePage.setLoadPath("/menu/home")
             homePage.go()
         then:
-            motdPage.waitForMessageShownInHome("a simple message")
+            motdPage.waitForMessageShownInHome(motdMessage)
         cleanup:
             deleteProject(projectName)
     }

--- a/rundeckapp/grails-app/utils/rundeck/codecs/MarkdownCodec.groovy
+++ b/rundeckapp/grails-app/utils/rundeck/codecs/MarkdownCodec.groovy
@@ -39,6 +39,7 @@ class MarkdownCodec {
             .extensions(Arrays.asList(TablesExtension.create())).build();
     static HtmlRenderer renderer = HtmlRenderer.builder()
             .extensions(extensions)
+            .escapeHtml(true)
             .build();
 
     static String decodeStr (String str){

--- a/rundeckapp/grails-app/utils/rundeck/codecs/SanitizedHTMLCodec.groovy
+++ b/rundeckapp/grails-app/utils/rundeck/codecs/SanitizedHTMLCodec.groovy
@@ -16,6 +16,7 @@
 
 package rundeck.codecs
 
+import org.owasp.html.CssSchema
 import org.owasp.html.ElementPolicy
 import org.owasp.html.HtmlChangeListener
 import org.owasp.html.HtmlPolicyBuilder
@@ -78,6 +79,7 @@ class SanitizedHTMLCodec {
             .onElements('svg')
             .allowAttributes('x','y','height','width','style','fill')
             .onElements('rect')
+            .allowStyling(CssSchema.DEFAULT)
             .withPreprocessor(new AutoClosingEventProcessor(autoCloseTags: ['circle','polygon','path','rect']))
             .toFactory();
     static final PolicyFactory POLICY =
@@ -132,7 +134,7 @@ class SanitizedHTMLCodec {
                             'td','th',
                     ).allowAttributes('colspan').onElements(
                             'th',
-                    )
+                    ).allowStyling(CssSchema.DEFAULT)
 
                                 .toFactory()
                     )

--- a/rundeckapp/src/test/groovy/rundeck/codecs/MarkdownCodecTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/codecs/MarkdownCodecTest.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 SimplifyOps Inc, <http://simplifyops.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rundeck.codecs
+
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+/**
+ * MarkdownCodecTest covers PS-1683: raw inline HTML in markdown must be
+ * escaped rather than passed through as live markup, while normal
+ * markdown syntax keeps rendering.
+ */
+class MarkdownCodecTest {
+    @Test
+    void testNormalMarkdownStillRenders(){
+        assertEquals(
+            '<article class="markdown-body"><p><strong>bold</strong></p>\n</article>',
+            MarkdownCodec.decodeStr('**bold**')
+        )
+    }
+
+    @Test
+    void testRawHtmlInMarkdownIsEscaped(){
+        assertEquals(
+            '<article class="markdown-body"><p>some text</p>\n' +
+            '<p>&lt;td style&#61;&#34;position:fixed;inset:0;background:url(&#39;//attacker/leak&#39;)&#34;&gt;x&lt;/td&gt;</p>\n</article>',
+            MarkdownCodec.decodeStr(
+                'some text\n\n<td style="position:fixed;inset:0;background:url(\'//attacker/leak\')">x</td>'
+            )
+        )
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeck/codecs/SanitizedHTMLCodecTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/codecs/SanitizedHTMLCodecTest.groovy
@@ -45,4 +45,33 @@ class SanitizedHTMLCodecTest {
     void testScript(){
         assertEquals('', SanitizedHTMLCodec.encode('<script>alert(1)</script>'))
     }
+
+    // PS-1683: style attribute must be CSS-guarded, not passed through verbatim
+    @Test
+    void testTdStyleMaliciousCssStripped(){
+        assertEquals(
+            '<table><tbody><tr><td style="width:100vw;height:100vh">x</td></tr></tbody></table>',
+            SanitizedHTMLCodec.encode(
+                '<td style="position:fixed;inset:0;width:100vw;height:100vh;background:url(\'//attacker/leak\')">x</td>'
+            )
+        )
+    }
+
+    @Test
+    void testSvgRectStyleMaliciousCssStripped(){
+        assertEquals(
+            '<svg><rect fill="red"></rect></svg>',
+            SanitizedHTMLCodec.encode(
+                '<svg><rect style="position:fixed;inset:0;background:url(\'//attacker/leak\')" fill="red"/></svg>'
+            )
+        )
+    }
+
+    @Test
+    void testTdStyleNormalCssStillWorks(){
+        assertEquals(
+            '<table><tbody><tr><td style="color:red;font-weight:bold;text-align:center">ok</td></tr></tbody></table>',
+            SanitizedHTMLCodec.encode('<td style="color:red;font-weight:bold;text-align:center">ok</td>')
+        )
+    }
 }


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Security bugfix. `SanitizedHTMLCodec` allows the `style` attribute on `td`, `th`, and several SVG elements (`svg`, `g`, `text`, `path`, `polygon`, `rect`) but never calls `allowStyling()` and configures no `CssSchema`, so arbitrary CSS passes through the sanitizer verbatim. A job option description (or other input rendered via `encodeAsSanitizedHTML`/`SanitizedHTMLCodec.encode`) containing HTML with a `style` attribute like `position:fixed;inset:0;...;background:url('//attacker/leak')` executes that CSS in the browser of anyone who views the page — including admins. This affects job run pages, execution log HTML, and email notifications, since they all route through the same sanitizer policy.

`MarkdownCodec`'s `HtmlRenderer` also had no `escapeHtml(true)`, so raw inline HTML in markdown-authored fields reached the sanitizer as live markup rather than escaped text, giving an extra delivery path for the same payload.

**Describe the solution you've implemented**

- `SanitizedHTMLCodec.groovy`: added `.allowStyling(CssSchema.DEFAULT)` to both `HtmlPolicyBuilder` chains that permit `style` (the SVG builder, and the `td`/`th` builder in the main policy). This makes the sanitizer parse and constrain CSS property values instead of passing the attribute through unvalidated — `position:fixed` and `url(...)` are stripped, generic styling (`color`, `font-weight`, `text-align`, `opacity`, etc.) still works.
- `MarkdownCodec.groovy`: added `.escapeHtml(true)` to the `HtmlRenderer` builder so raw inline HTML in markdown is rendered as literal escaped text rather than live markup before it reaches the sanitizer.
- All `encodeAsSanitizedHTML`/`SanitizedHTMLCodec.encode()` call sites (`ExecutionController`, `NotificationService`, job option views, etc.) share the single `POLICY` object in `SanitizedHTMLCodec`, so this one fix covers all render paths without touching each call site individually.

**Describe alternatives you've considered**

The report suggested `CssSchema.MAXIMUM_SAFE`, but that constant doesn't exist in the `owasp-java-html-sanitizer` version currently pinned in this repo (checked the sources jar for `20260313.1`) — only `CssSchema.DEFAULT` is exposed publicly, so that's what's used here.

Also considered removing `style` from `allowAttributes()` entirely instead of guarding it with a `CssSchema`. Went with the guard so existing legitimate styling (colored table cells, etc.) keeps working rather than breaking outright.

**Additional context**

Known trade-off: `fill`/`stroke`/`stroke-width` aren't modeled in this sanitizer's built-in CSS property definitions at all (only generic properties like `color`/`background-color`/`opacity` are), so `style="fill:...;stroke:..."` on SVG `text`/`g`/`path`/`polygon` will now be stripped. Didn't hand-roll a custom `CssSchema.Property` for these since the internal bit-flag grammar for property values isn't part of the public API — guessing it wrong in a CSS-injection fix risks reopening the hole. `rect` still has a bare `fill` attribute allowed directly and is unaffected.

Verified with standalone `groovyc`/`groovy` runs against the actual pinned dependency jars (full `./gradlew build` isn't runnable from this worktree checkout due to an unrelated `grgit`/JGit worktree limitation):
- Exploit payload `<td style="position:fixed;inset:0;...;background:url('//attacker/leak')">` → CSS collapses to safe `width`/`height` only.
- Same payload via SVG `rect` → CSS fully stripped.
- Same payload via Markdown → raw `<td>` tag is HTML-escaped, never becomes live markup.
- Legit styling (`color:red;font-weight:bold;text-align:center` on `td`) still passes through unchanged.

Source: PS-1683 (internal security report).

## Release Notes

Fixed a stored CSS injection vulnerability where the `style` attribute on table cells and SVG elements was not validated by the HTML sanitizer, allowing arbitrary CSS (including full-page overlays and outbound `url()` requests) to be stored via job option descriptions and rendered to other users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)