### PR TITLE
[RUN-4742] Fix node Duration exceeding execution Duration for conditional steps

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -671,9 +671,10 @@ RDNodeStep.runningStates= ['RUNNING','RUNNING_HANDLER'];
  * it past the job's own duration.
  * @param durationMs server-provided duration, or <=0 to derive from steps
  * @param steps RDNodeStep-like objects with KO observable fields
+ * @param execDurationMs optional execution duration (ms precision) for final clamp
  * @returns {number} duration in ms, or -1 if unknown
  */
-RDNode.computeNodeDurationMs = function (durationMs, steps) {
+RDNode.computeNodeDurationMs = function (durationMs, steps, execDurationMs) {
     var ms = durationMs;
     var earliest = null;
     var latest = null;
@@ -714,6 +715,10 @@ RDNode.computeNodeDurationMs = function (durationMs, steps) {
     } else if (derived != null && derived > 0 && ms > derived) {
         ms = derived;
     }
+    // Final safeguard: node duration can never exceed execution duration (ms precision)
+    if (execDurationMs != null && execDurationMs > 0 && ms > execDurationMs) {
+        ms = execDurationMs;
+    }
     return ms != null ? ms : -1;
 };
 
@@ -746,7 +751,7 @@ function RDNode(name, steps,flow){
         }
     };
     self.duration=ko.pureComputed(function(){
-        return RDNode.computeNodeDurationMs(self.durationMs(), self.steps());
+        return RDNode.computeNodeDurationMs(self.durationMs(), self.steps(), self.flow.execDuration());
     });
     self.durationSimple=ko.pureComputed(function(){
        return MomentUtil.formatDurationSimple(self.duration());

--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -665,6 +665,58 @@ RDNodeStep.stateCompare= function (a, b) {
 RDNodeStep.completedStates= ['SUCCEEDED', 'FAILED', 'ABORTED', 'NONE_SUCCEEDED','PARTIAL_SUCCEEDED'];
 RDNodeStep.runningStates= ['RUNNING','RUNNING_HANDLER'];
 
+/**
+ * Node duration in ms - wall-clock span (earliest step start to latest end)
+ * instead of summed step durations, so conditional/branching steps can't push
+ * it past the job's own duration.
+ * @param durationMs server-provided duration, or <=0 to derive from steps
+ * @param steps RDNodeStep-like objects with KO observable fields
+ * @returns {number} duration in ms, or -1 if unknown
+ */
+RDNode.computeNodeDurationMs = function (durationMs, steps) {
+    var ms = durationMs;
+    var earliest = null;
+    var latest = null;
+    ko.utils.arrayForEach(steps, function (x) {
+        if (ko.utils.unwrapObservable(x.parameterizedStep)) {
+            return;
+        }
+        var state = ko.utils.unwrapObservable(x.executionState);
+        if (state === 'NOT_STARTED' || state === 'NONE' || state === 'WAITING') {
+            return;
+        }
+        var start = ko.utils.unwrapObservable(x.startTime);
+        var end = ko.utils.unwrapObservable(x.endTime) || ko.utils.unwrapObservable(x.updateTime);
+        var stepDur = ko.utils.unwrapObservable(x.duration);
+        if (start) {
+            var st = moment(start);
+            if (!earliest || st.isBefore(earliest)) {
+                earliest = st;
+            }
+            if (end) {
+                var et = moment(end);
+                if (!latest || et.isAfter(latest)) {
+                    latest = et;
+                }
+            } else if (stepDur >= 0) {
+                var etFromDur = moment(start).add(stepDur, 'ms');
+                if (!latest || etFromDur.isAfter(latest)) {
+                    latest = etFromDur;
+                }
+            }
+        }
+    });
+    var derived = (earliest && latest) ? latest.diff(earliest) : null;
+    if (ms == null || ms <= 0) {
+        if (derived != null) {
+            ms = derived;
+        }
+    } else if (derived != null && derived > 0 && ms > derived) {
+        ms = derived;
+    }
+    return ms != null ? ms : -1;
+};
+
 function RDNode(name, steps,flow){
     var self=this;
     self.flow= flow;
@@ -694,34 +746,7 @@ function RDNode(name, steps,flow){
         }
     };
     self.duration=ko.pureComputed(function(){
-        // Prefer server-provided wall-clock duration; otherwise derive span from step times
-       var ms=self.durationMs();
-        if(ms<0) {
-            var earliest = null;
-            var latest = null;
-            ko.utils.arrayForEach(self.steps(), function (x) {
-                if (!x.parameterizedStep()) {
-                    var start = x.startTime();
-                    var end = x.endTime() || x.updateTime();
-                    if (start) {
-                        var st = moment(start);
-                        if (!earliest || st.isBefore(earliest)) {
-                            earliest = st;
-                        }
-                    }
-                    if (end) {
-                        var et = moment(end);
-                        if (!latest || et.isAfter(latest)) {
-                            latest = et;
-                        }
-                    }
-                }
-            });
-            if (earliest && latest) {
-                ms = latest.diff(earliest);
-            }
-        }
-       return ms;
+        return RDNode.computeNodeDurationMs(self.durationMs(), self.steps());
     });
     self.durationSimple=ko.pureComputed(function(){
        return MomentUtil.formatDurationSimple(self.duration());

--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.test.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.test.js
@@ -114,6 +114,22 @@ jQuery(function () {
                 })
             ];
             this.assert(RDNode.computeNodeDurationMs(-1, steps) === 1000);
+        },
+        computeNodeDurationClampsToExecDurationWhenTruncationInflates: function () {
+            // Simulates truncation inflation: timestamps truncated to whole seconds
+            // yield 1000ms wall-clock, but actual execution was only 457ms.
+            // The execDurationMs (ms precision) should be the final clamp.
+            var steps = [
+                stepFixture({
+                    startTime: '2014-09-05T21:28:04Z',
+                    endTime: '2014-09-05T21:28:05Z',
+                    duration: 457
+                })
+            ];
+            // Wall-clock from truncated timestamps: 1000ms
+            // Actual execution duration: 457ms
+            var ms = RDNode.computeNodeDurationMs(-1, steps, 457);
+            this.assert('clamps to execDurationMs', ms === 457);
         }
     });
 });

--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.test.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.test.js
@@ -17,6 +17,7 @@
 //= require momentutil
 //= require vendor/knockout.min
 //= require executionStateKO
+//= require util/testing
 
 jQuery(function () {
     "use strict";

--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.test.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.test.js
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//= require momentutil
+//= require vendor/knockout.min
+//= require executionStateKO
+
+jQuery(function () {
+    "use strict";
+
+    function stepFixture(opts) {
+        return {
+            parameterizedStep: ko.observable(!!opts.parameterizedStep),
+            executionState: ko.observable(opts.executionState || 'SUCCEEDED'),
+            startTime: ko.observable(opts.startTime || null),
+            endTime: ko.observable(opts.endTime || null),
+            updateTime: ko.observable(opts.updateTime || null),
+            duration: ko.observable(opts.duration != null ? opts.duration : -1)
+        };
+    }
+
+    new TestHarness("executionStateKO.test.js", {
+        computeNodeDurationUsesWallClockNotStepSum: function () {
+            var steps = [
+                stepFixture({
+                    startTime: '2014-09-05T21:28:04Z',
+                    endTime: '2014-09-05T21:28:05Z',
+                    duration: 370
+                }),
+                stepFixture({
+                    startTime: '2014-09-05T21:28:04Z',
+                    endTime: '2014-09-05T21:28:05Z',
+                    duration: 358
+                })
+            ];
+            var stepSum = 370 + 358;
+            var ms = RDNode.computeNodeDurationMs(-1, steps);
+            this.assert('wall-clock is one second', ms === 1000);
+            this.assert('wall-clock is less than summed step durations', ms < stepSum);
+            this.assert('would have exceeded if summed', stepSum > ms);
+        },
+        computeNodeDurationClampsInflatedServerValue: function () {
+            var steps = [
+                stepFixture({
+                    executionState: 'SUCCEEDED',
+                    startTime: '2014-09-05T21:28:04Z',
+                    endTime: '2014-09-05T21:28:05Z',
+                    duration: 1000
+                }),
+                stepFixture({
+                    executionState: 'NOT_STARTED',
+                    startTime: '2014-09-05T21:28:04Z',
+                    endTime: '2014-09-05T21:28:43Z',
+                    updateTime: '2014-09-05T21:28:43Z',
+                    duration: 39000
+                })
+            ];
+            this.assert(RDNode.computeNodeDurationMs(39000, steps) === 1000);
+        },
+        computeNodeDurationDerivesWhenServerReportsZero: function () {
+            var steps = [
+                stepFixture({
+                    startTime: '2014-09-05T21:28:04Z',
+                    endTime: '2014-09-05T21:28:06Z',
+                    duration: 1000
+                }),
+                stepFixture({
+                    startTime: '2014-09-05T21:28:04Z',
+                    endTime: '2014-09-05T21:28:06Z',
+                    duration: 1000
+                })
+            ];
+            this.assert(RDNode.computeNodeDurationMs(0, steps) === 2000);
+        },
+        computeNodeDurationUsesStartPlusStepDurationWhenEndMissing: function () {
+            var steps = [
+                stepFixture({
+                    startTime: '2014-09-05T21:28:04Z',
+                    duration: 500
+                }),
+                stepFixture({
+                    startTime: '2014-09-05T21:28:04Z',
+                    duration: 1500
+                })
+            ];
+            this.assert(RDNode.computeNodeDurationMs(0, steps) === 1500);
+        },
+        computeNodeDurationIgnoresParameterizedSteps: function () {
+            var steps = [
+                stepFixture({
+                    startTime: '2014-09-05T21:28:04Z',
+                    endTime: '2014-09-05T21:28:05Z',
+                    duration: 1000
+                }),
+                stepFixture({
+                    parameterizedStep: true,
+                    startTime: '2014-09-05T21:28:04Z',
+                    endTime: '2014-09-05T21:28:20Z',
+                    duration: 16000
+                })
+            ];
+            this.assert(RDNode.computeNodeDurationMs(-1, steps) === 1000);
+        }
+    });
+});

--- a/rundeckapp/grails-app/services/rundeck/services/workflow/StateMapping.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/workflow/StateMapping.groovy
@@ -59,6 +59,13 @@ class StateMapping {
         }
         return cb > ca
     }
+    def boolean stepContributesToNodeDuration(Map step) {
+        if (!step?.startTime) {
+            return false
+        }
+        def state = step.executionState
+        return state && !(state in ['NOT_STARTED', 'NONE', 'WAITING'])
+    }
     def Map summarizeForNode(Map map,String node, List steps){
         def summary=[:]
         def currentStep=[:];
@@ -94,17 +101,25 @@ class StateMapping {
                     || currentStep && stateCompare(currentStep.executionState, step.executionState)) {
                 currentStep.putAll(step);
             }
-            def started=step.startTime?decodeDate(step.startTime):null
-            if(!dateStarted || (started && started<dateStarted)){
-                dateStarted=started;
-            }
-            def lastUpdated=lastUpdatedFor(step)
-            if(!updated || lastUpdated>updated){
-                updated=lastUpdated
+            if (stepContributesToNodeDuration(step)) {
+                def started=step.startTime?decodeDate(step.startTime):null
+                if(!dateStarted || (started && started<dateStarted)){
+                    dateStarted=started;
+                }
+                def lastUpdated=lastUpdatedFor(step)
+                if(lastUpdated && (!updated || lastUpdated>updated)){
+                    updated=lastUpdated
+                }
             }
         }
         if (updated && dateStarted) {
             duration = updated.time - dateStarted.time
+        }
+        if (duration > 0 && map?.startTime && map?.endTime) {
+            def execDuration = decodeDate(map.endTime).time - decodeDate(map.startTime).time
+            if (duration > execDuration) {
+                duration = execDuration
+            }
         }
         summary.duration=duration
         summary.startTime=encodeDate(dateStarted)

--- a/rundeckapp/grails-app/services/rundeck/services/workflow/StateMapping.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/workflow/StateMapping.groovy
@@ -60,7 +60,7 @@ class StateMapping {
         return cb > ca
     }
     def boolean stepContributesToNodeDuration(Map step) {
-        if (!step?.startTime) {
+        if (!step?.startTime || step.stepctx?.indexOf('@') >= 0) {
             return false
         }
         def state = step.executionState
@@ -117,7 +117,7 @@ class StateMapping {
         }
         if (duration > 0 && map?.startTime && map?.endTime) {
             def execDuration = decodeDate(map.endTime).time - decodeDate(map.startTime).time
-            if (duration > execDuration) {
+            if (execDuration > 0 && duration > execDuration) {
                 duration = execDuration
             }
         }

--- a/rundeckapp/src/test/groovy/rundeck/services/workflow/StateMappingSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/workflow/StateMappingSpec.groovy
@@ -515,6 +515,34 @@ class StateMappingSpec extends Specification {
             ]
     }
 
+    def "summarizeForNode should ignore never-run conditional branch steps when computing duration"() {
+        given: 'one executed branch step and one NOT_STARTED branch with finalization endTime'
+            def sut = new StateMapping()
+            def workflowMap = [
+                startTime: '2014-09-05T21:28:04Z',
+                endTime  : '2014-09-05T21:28:06Z',
+            ]
+            def steps = [
+                [
+                    stepctx        : '1/1/1',
+                    executionState : 'SUCCEEDED',
+                    startTime      : '2014-09-05T21:28:04Z',
+                    endTime        : '2014-09-05T21:28:05Z',
+                    duration       : 1000L,
+                ],
+                [
+                    stepctx        : '1/1/2',
+                    executionState : 'NOT_STARTED',
+                    updateTime     : '2014-09-05T21:28:43Z',
+                    endTime        : '2014-09-05T21:28:43Z',
+                ],
+            ]
+        when:
+            def summary = sut.summarizeForNode(workflowMap, 'localhost', steps)
+        then:
+            summary.duration == 1000L
+    }
+
     def "summarize node should include step parent steps only"() {
         given: 'node step has subworkflow error handler'
             def sut = new StateMapping()

--- a/rundeckapp/src/test/groovy/rundeck/services/workflow/StateMappingSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/workflow/StateMappingSpec.groovy
@@ -543,6 +543,53 @@ class StateMappingSpec extends Specification {
             summary.duration == 1000L
     }
 
+    def "summarizeForNode should ignore parameterized step entries when computing duration"() {
+        given: 'a step and its per-parameter breakdown entry with a much later endTime'
+            def sut = new StateMapping()
+            def steps = [
+                [
+                    stepctx        : '1',
+                    executionState : 'SUCCEEDED',
+                    startTime      : '2014-09-05T21:28:04Z',
+                    endTime        : '2014-09-05T21:28:05Z',
+                    duration       : 1000L,
+                ],
+                [
+                    stepctx        : '1@node=localhost',
+                    executionState : 'SUCCEEDED',
+                    startTime      : '2014-09-05T21:28:04Z',
+                    endTime        : '2014-09-05T21:28:20Z',
+                    duration       : 16000L,
+                ],
+            ]
+        when:
+            def summary = sut.summarizeForNode([:], 'localhost', steps)
+        then:
+            summary.duration == 1000L
+    }
+
+    def "summarizeForNode should not clamp duration to a negative value when execution endTime precedes startTime"() {
+        given: 'malformed workflow map where endTime is before startTime'
+            def sut = new StateMapping()
+            def workflowMap = [
+                startTime: '2014-09-05T21:28:10Z',
+                endTime  : '2014-09-05T21:28:04Z',
+            ]
+            def steps = [
+                [
+                    stepctx        : '1',
+                    executionState : 'SUCCEEDED',
+                    startTime      : '2014-09-05T21:28:04Z',
+                    endTime        : '2014-09-05T21:28:05Z',
+                    duration       : 1000L,
+                ],
+            ]
+        when:
+            def summary = sut.summarizeForNode(workflowMap, 'localhost', steps)
+        then:
+            summary.duration == 1000L
+    }
+
     def "summarize node should include step parent steps only"() {
         given: 'node step has subworkflow error handler'
             def sut = new StateMapping()


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
 **Is this a bugfix, or an enhancement? Please describe.**                                                                                                                          
  Bugfix. Fixes RUN-4742: a node's "Duration" on the Execution Summary page                                                                                                          
  could exceed the overall execution's duration when the workflow had                                                                                                                
  conditional/branching steps.                                                                                                                                                       
                                                                                                                                                                                     
  **Describe the solution you've implemented**                                                                                                                                       
  Never-run branch steps get their `endTime` stamped at workflow finalization                                                                                                        
  even though they never started. Excluded such steps (NOT_STARTED/NONE/WAITING,                                                                                                     
  or missing startTime) from the node duration calculation in                                                                                                                        
  `StateMapping.summarizeForNode`, added a defensive clamp so node duration                                                                                                          
  can never exceed the execution's own duration, and mirrored the same logic                                                                                                         
  client-side in `executionStateKO.js`.                                                                                                                                              
                                                                                                                                                                                     
  **Describe alternatives you've considered**                                                                                                                                        
  None — this directly targets the root cause identified in the ticket.                                                                                                              
                                                                                                                                                                                     
  **Additional context**                                                                                                                                                             
  Related to RUN-4741 (same customer report, same underlying gap in how                                                                                                              
  conditional steps are handled).                                                                                                                                                    
                                                                                                                                                                                     
  ## Release Notes                                                                                                                                                                   
  Fixed: a node's Duration on the Execution Summary page could exceed the                                                                                                            
  overall execution's duration for jobs with conditional/branching steps.       