### PR TITLE
[RUN-4755] Do not hold database transactions across job notification delivery

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -532,9 +532,13 @@ class ExecutionController extends ControllerBase{
             return render(
                     view: "mailNotification/status",
                     model: loadExecutionViewPlugins() + [execstate: state, scheduledExecution: se, execution: e,
-                                                         filesize: filesize]
+                                                         filesize: filesize,
+                                                         // The template reads this from the model rather than
+                                                         // looking up ExecutionService and querying for it.
+                                                         averageDuration: executionService.getAverageDuration(se.uuid)]
             )
         }else{
+            // No job, so no average duration to report; the template treats an absent value as zero.
             return render(
                     view: "mailNotification/status",
                     model: loadExecutionViewPlugins() + [execstate: state, execution: e, filesize: filesize]

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -99,6 +99,7 @@ import java.time.ZoneId
 class ExecutionController extends ControllerBase{
     FrameworkService frameworkService
     ExecutionService executionService
+    NotificationService notificationService
     LoggingService loggingService
     ScheduledExecutionService scheduledExecutionService
     OrchestratorPluginService orchestratorPluginService
@@ -533,9 +534,10 @@ class ExecutionController extends ControllerBase{
                     view: "mailNotification/status",
                     model: loadExecutionViewPlugins() + [execstate: state, scheduledExecution: se, execution: e,
                                                          filesize: filesize,
-                                                         // The template reads this from the model rather than
-                                                         // looking up ExecutionService and querying for it.
+                                                         // The template reads these from the model rather than
+                                                         // looking up beans and querying for them itself.
                                                          averageDuration: executionService.getAverageDuration(se.uuid)]
+                            + notificationService.resolveJobExecutionCounts(se)
             )
         }else{
             // No job, so no average duration to report; the template treats an absent value as zero.

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -99,7 +99,6 @@ import java.time.ZoneId
 class ExecutionController extends ControllerBase{
     FrameworkService frameworkService
     ExecutionService executionService
-    NotificationService notificationService
     LoggingService loggingService
     ScheduledExecutionService scheduledExecutionService
     OrchestratorPluginService orchestratorPluginService
@@ -537,7 +536,7 @@ class ExecutionController extends ControllerBase{
                                                          // The template reads these from the model rather than
                                                          // looking up beans and querying for them itself.
                                                          averageDuration: executionService.getAverageDuration(se.uuid)]
-                            + notificationService.resolveJobExecutionCounts(se)
+                            + executionService.getJobExecutionCounts(se)
             )
         }else{
             // No job, so no average duration to report; the template treats an absent value as zero.

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -471,7 +471,11 @@ class ExecutionJob implements InterruptableJob {
                             execmap.scheduledExecution.uuid,
                             [
                                     execution: execmap.execution,
-                                    context:context
+                                    context:context,
+                                    // Already resolved above -- it is the value this notification is
+                                    // triggered by. Passing it spares the notification path a query
+                                    // inside the transaction that spans its SMTP and HTTP sends.
+                                    averageDuration: jobAverageDurationFinal
                             ]
                     )
                     avgNotificationSent=true

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -472,10 +472,13 @@ class ExecutionJob implements InterruptableJob {
                             [
                                     execution: execmap.execution,
                                     context:context,
-                                    // Already resolved above -- it is the value this notification is
-                                    // triggered by. Passing it spares the notification path a query
-                                    // inside the transaction that spans its SMTP and HTTP sends.
-                                    averageDuration: jobAverageDurationFinal
+                                    // jobAverageDuration, not jobAverageDurationFinal: the latter is the
+                                    // trigger threshold derived from notifyAvgDurationThreshold, which for a
+                                    // percentage or offset setting is not the average at all. This must be
+                                    // the historical average the template used to query for.
+                                    // Already resolved above, so passing it spares the notification path a
+                                    // query inside the transaction that spans its SMTP and HTTP sends.
+                                    averageDuration: jobAverageDuration
                             ]
                     )
                     avgNotificationSent=true

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3476,43 +3476,62 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         }
     }
 
+    /**
+     * Trigger the completion notifications for a finished execution.
+     *
+     * Deliberately non-transactional. The execution's completed state has already been committed by
+     * {@link #saveExecutionState_newTransaction}, and the notification itself is delivered on a separate
+     * thread inside its own transaction (see NotificationService.asyncTriggerJobNotification), so nothing
+     * in this method needs to be atomic with the send. A transaction held here would only keep this
+     * thread's database connection checked out and idle for as long as the send takes -- up to
+     * notification.threadTimeOut, 120s by default -- which exceeds the server's wait_timeout, and the
+     * connection is then found dead at COMMIT. The two reads that are needed run in their own short
+     * transaction instead.
+     *
+     * @param execRun the started execution
+     * @param event the completion event
+     */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public def triggerJobCompleteNotifications(AsyncStarted execRun, ExecutionCompleteEvent event) {
         def context = execRun?.thread?.context
         def execution = event.execution
         def executionId = event.execution.id
 
-        //load stored execution to get the orchestrator data
-        // Grails 7/Hibernate 6: Use HQL for LEFT OUTER JOIN - most reliable for complex queries
-        // Fallback to simple get() for DataTest compatibility
-        Execution executionLoad
-        try {
-            executionLoad = Execution.withSession { session ->
-                String hql = '''
-                    SELECT e
-                    FROM Execution e
-                    LEFT JOIN e.orchestrator o
-                    WHERE e.id = :executionId
-                '''
-                def query = session.createQuery(hql, Execution)
-                query.setParameter('executionId', executionId)
-                query.uniqueResult()
-            } as Execution
-        } catch (MissingMethodException e) {
-            // DataTest fallback: SimpleMapSession doesn't support HQL, use simple get()
-            executionLoad = Execution.get(executionId)
-        }
+        def averageDuration = Execution.withNewTransaction {
+            //load stored execution to get the orchestrator data
+            // Grails 7/Hibernate 6: Use HQL for LEFT OUTER JOIN - most reliable for complex queries
+            // Fallback to simple get() for DataTest compatibility
+            // JOIN FETCH rather than a bare JOIN: the orchestrator is read from the notification thread,
+            // so it has to be initialised before this transaction closes.
+            Execution executionLoad
+            try {
+                executionLoad = Execution.withSession { session ->
+                    String hql = '''
+                        SELECT e
+                        FROM Execution e
+                        LEFT JOIN FETCH e.orchestrator o
+                        WHERE e.id = :executionId
+                    '''
+                    def query = session.createQuery(hql, Execution)
+                    query.setParameter('executionId', executionId)
+                    query.uniqueResult()
+                } as Execution
+            } catch (MissingMethodException e) {
+                // DataTest fallback: SimpleMapSession doesn't support HQL, use simple get()
+                executionLoad = Execution.get(executionId)
+            }
 
-        //just replacing the value for the received from ExecutionJob because the status is not saved yet
-        if(executionLoad && executionLoad.orchestrator){
-            execution.orchestrator = executionLoad.orchestrator
+            //just replacing the value for the received from ExecutionJob because the status is not saved yet
+            if(executionLoad && executionLoad.orchestrator){
+                execution.orchestrator = executionLoad.orchestrator
+            }
+
+            // Resolved here, before the send, so the notification path does not have to query for it from
+            // inside a transaction that also spans the SMTP and HTTP sends.
+            return (event.job ? getAverageDuration(event.job.getUuid()) : 0) ?: 0
         }
 
         def export = execRun?.thread?.resultObject?.getSharedContext()?.consolidate()?.getData(ContextView.global())
-
-        // Resolved here, on the execution thread, so the notification path does not have to query for
-        // it from inside its own transaction -- that transaction also spans the SMTP and HTTP sends,
-        // during which the database connection can be closed by the server.
-        def averageDuration = (event.job ? getAverageDuration(event.job.getUuid()) : 0) ?: 0
 
         notificationService.asyncTriggerJobNotification(
                 execution.statusSucceeded() ? 'success' : execution.willRetry ? 'retryablefailure' : 'failure',

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3578,6 +3578,30 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         return 0;
     }
 
+    /**
+     * Execution counts for a job, including executions referenced from other jobs.
+     *
+     * The notification mail template used to run these four queries itself, while it was being
+     * rendered -- which happens inside mailService.sendMail, so they ran mid-send, inside the
+     * transaction that spans the SMTP conversation and therefore on a connection the server may
+     * already have closed. Callers now resolve them before the send and pass them in the view model.
+     *
+     * @param scheduledExecution the job, may be null for an execution that has none
+     * @return view model entries; all zero when there is no job
+     */
+    Map getJobExecutionCounts(ScheduledExecution scheduledExecution) {
+        if (!scheduledExecution?.id) {
+            return [executionCount: 0, succeededCount: 0, referencedExecutionCount: 0, referencedSucceededCount: 0]
+        }
+        [
+                executionCount          : Execution.countByScheduledExecutionAndDateCompletedIsNotNull(scheduledExecution),
+                succeededCount          : Execution.countByScheduledExecutionAndStatus(scheduledExecution, 'succeeded'),
+                referencedExecutionCount: referencedExecutionDataProvider.countByJobUuid(scheduledExecution.uuid),
+                referencedSucceededCount: referencedExecutionDataProvider.countByJobUuidAndStatus(
+                        scheduledExecution.uuid, 'succeeded')
+        ]
+    }
+
 
     /**
     * Generate an argString from a map of options and values

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1400,8 +1400,13 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             logExecutionLog4j(execution, "start", execution.user)
             if (scheduledExecution) {
                 //send onstart notification
+                // Resolved here rather than inside the notification path. ExecutionJob computes the
+                // same value, but only after the execution thread has started -- too late for this
+                // trigger. Querying here still keeps it out of the notification transaction, which
+                // spans SMTP and HTTP sends during which the connection can be closed by the server.
                 notificationService.asyncTriggerJobNotification('start', scheduledExecution.uuid,
-                        [execution: execution, context:executioncontext])
+                        [execution: execution, context:executioncontext,
+                         averageDuration: getAverageDuration(scheduledExecution.uuid)])
 
             }
             //install custom outputstreams for System.out and System.err for this thread and any child threads
@@ -3504,14 +3509,20 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
         def export = execRun?.thread?.resultObject?.getSharedContext()?.consolidate()?.getData(ContextView.global())
 
+        // Resolved here, on the execution thread, so the notification path does not have to query for
+        // it from inside its own transaction -- that transaction also spans the SMTP and HTTP sends,
+        // during which the database connection can be closed by the server.
+        def averageDuration = (event.job ? getAverageDuration(event.job.getUuid()) : 0) ?: 0
+
         notificationService.asyncTriggerJobNotification(
                 execution.statusSucceeded() ? 'success' : execution.willRetry ? 'retryablefailure' : 'failure',
                 event.job?.getUuid(),
                 [
-                        execution : execution,
-                        nodestatus: event.nodeStatus,
-                        context   : context,
-                        export    : export
+                        execution      : execution,
+                        nodestatus     : event.nodeStatus,
+                        context        : context,
+                        export         : export,
+                        averageDuration: averageDuration
                 ]
         )
     }
@@ -4261,8 +4272,11 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     ScheduledExecution.withTransaction {
                         // Get a new object attached to the new session
                         def scheduledExecution = ScheduledExecution.get(id)
+                        // Already resolved at the top of this method; passing it spares the
+                        // notification path a query inside the transaction that spans its sends.
                         notificationService.asyncTriggerJobNotification('start', scheduledExecution.uuid,
-                                [execution: exec, context: newContext, jobref: jitem.jobIdentifier])
+                                [execution: exec, context: newContext, jobref: jitem.jobIdentifier,
+                                 averageDuration: averageDuration])
                     }
 
                 }
@@ -4318,7 +4332,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                             execution: execution,
                             context  : newContext,
                             jobref   : jitem.jobIdentifier,
-                            export    : data
+                            export    : data,
+                            // The value this notification is triggered by, already resolved above.
+                            averageDuration: averageDuration
                     ])
                 }
 
@@ -4330,7 +4346,10 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                                 nodestatus: [succeeded: sucCount, failed: failedCount, total: newContext.getNodes().getNodeNames().size()],
                                 context   : newContext,
                                 jobref    : jitem.jobIdentifier,
-                                export    : data
+                                export    : data,
+                                // Already resolved at the top of this method; passing it spares the
+                                // notification path a query inside the transaction that spans its sends.
+                                averageDuration: averageDuration
                         ]
                 )
             }

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -505,6 +505,16 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
                     // server can close the connection. Same reasoning as averageDuration.
                     Map executionCounts = resolveJobExecutionCounts(source)
 
+                    // Read before the send rather than from inside the mail closure below. That closure runs
+                    // while the message is being built and sent, so this read -- log storage I/O plus the
+                    // lookup backing it -- happened inside the transaction that spans the SMTP conversation.
+                    // It also re-read the same content once per recipient.
+                    // Guarded on !htmlemail because the default view is the only body that consumes it here;
+                    // when a custom template file uses ${logoutput.data} the buffer was already filled above.
+                    if (!htmlemail && attachlogbody && outputBuffer == null) {
+                        outputBuffer = copyExecOutputToStringBuffer(exec, isFormatted)
+                    }
+
                     destarr.each{String recipient->
                         //try to expand property references
                         String sendTo=recipient
@@ -525,10 +535,6 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
                                 if(htmlemail){
                                     html(htmlemail)
                                 }else{
-                                    if(attachlogbody){
-                                        outputBuffer=copyExecOutputToStringBuffer(exec,isFormatted)
-                                    }
-
                                     body(
                                             view: "/execution/mailNotification/status",
                                             model: loadExecutionViewPlugins() + [

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -41,6 +41,7 @@ import grails.converters.JSON
 import grails.events.annotation.Subscriber
 import grails.events.bus.EventBusAware
 import grails.gorm.transactions.Transactional
+import org.springframework.transaction.annotation.Propagation
 import grails.util.Holders
 import grails.web.JSONBuilder
 import grails.web.mapping.LinkGenerator
@@ -179,7 +180,17 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
         }
     }
 
-    @Transactional
+    /**
+     * Dispatch a job notification, optionally on its own thread.
+     *
+     * Must not run in a transaction. The work is done inside {@code withNewTransaction} blocks below --
+     * on a separate thread when NOTIFICATIONS_OWN_THREAD is enabled -- while this method only waits for
+     * completion, for up to notification.threadTimeOut (120s by default). A transaction here, whether
+     * inherited from the caller or created by this method, would hold the calling thread's database
+     * connection checked out and idle for that whole wait; the server closes it after wait_timeout and
+     * the caller then fails on COMMIT.
+     */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     void asyncTriggerJobNotification(String trigger, schedUuid, Map content){
         if(trigger && schedUuid){
             if(featureService.featurePresent(Features.NOTIFICATIONS_OWN_THREAD)){

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -55,6 +55,7 @@ import org.rundeck.app.AppConstants
 import org.rundeck.app.data.model.v1.execution.ExecutionData
 import org.rundeck.app.data.providers.v1.user.UserDataProvider
 import org.rundeck.app.data.providers.v1.execution.ExecutionDataProvider
+import org.rundeck.app.data.providers.v1.execution.ReferencedExecutionDataProvider
 import org.rundeck.app.data.providers.v1.job.JobDataProvider
 import org.rundeck.app.spi.RundeckSpiBaseServicesProvider
 import org.rundeck.app.spi.Services
@@ -105,6 +106,7 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
     def storageService
     UserDataProvider userDataProvider
     ExecutionDataProvider executionDataProvider
+    ReferencedExecutionDataProvider referencedExecutionDataProvider
 
     def ValidatedPlugin validatePluginConfig(String project, String name, Map config) {
         return pluginService.validatePlugin(name, notificationPluginProviderService, project,config, PropertyScope.Instance, PropertyScope.Project)
@@ -497,6 +499,12 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
                         outputfile=copyExecOutputToTempFile(exec,isFormatted,attachedExtension)
                     }
 
+                    // Resolved here, before the send, rather than by the template. The mail body is
+                    // rendered inside mailService.sendMail below, so a query issued from the template runs
+                    // mid-send -- inside the transaction that spans the SMTP conversation, during which the
+                    // server can close the connection. Same reasoning as averageDuration.
+                    Map executionCounts = resolveJobExecutionCounts(source)
+
                     destarr.each{String recipient->
                         //try to expand property references
                         String sendTo=recipient
@@ -537,7 +545,7 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
                                                     // transaction, mid-send. Taken from the job map already built
                                                     // for the notification context, so both report the same value.
                                                     averageDuration   : execMap?.job?.averageDuration ?: 0
-                                            ]
+                                            ] + executionCounts
                                     )
                                 }
                                 if(attachlog && outputfile != null){
@@ -798,6 +806,31 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
             job.averageDuration = averageDuration
         }
         job
+    }
+
+    /**
+     * Resolve the execution counts the notification mail template reports, as a view model fragment.
+     *
+     * These were previously queried by _newStatus.gsp itself. That template is rendered inside
+     * mailService.sendMail, so the queries ran while the message was being sent -- inside the transaction
+     * that spans the SMTP conversation, and therefore on a connection the server may already have closed.
+     * Resolving them before the send removes four queries from that window, two of which are count(*)
+     * against the execution table.
+     *
+     * @param scheduledExecution the job the notification is for, may be null for an execution with no job
+     * @return model entries for the template; all zero when there is no job
+     */
+    protected Map resolveJobExecutionCounts(ScheduledExecution scheduledExecution) {
+        if (!scheduledExecution?.id) {
+            return [executionCount: 0, succeededCount: 0, referencedExecutionCount: 0, referencedSucceededCount: 0]
+        }
+        [
+                executionCount          : Execution.countByScheduledExecutionAndDateCompletedIsNotNull(scheduledExecution),
+                succeededCount          : Execution.countByScheduledExecutionAndStatus(scheduledExecution, 'succeeded'),
+                referencedExecutionCount: referencedExecutionDataProvider.countByJobUuid(scheduledExecution.uuid),
+                referencedSucceededCount: referencedExecutionDataProvider.countByJobUuidAndStatus(
+                        scheduledExecution.uuid, 'succeeded')
+        ]
     }
 
     /**

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -55,7 +55,6 @@ import org.rundeck.app.AppConstants
 import org.rundeck.app.data.model.v1.execution.ExecutionData
 import org.rundeck.app.data.providers.v1.user.UserDataProvider
 import org.rundeck.app.data.providers.v1.execution.ExecutionDataProvider
-import org.rundeck.app.data.providers.v1.execution.ReferencedExecutionDataProvider
 import org.rundeck.app.data.providers.v1.job.JobDataProvider
 import org.rundeck.app.spi.RundeckSpiBaseServicesProvider
 import org.rundeck.app.spi.Services
@@ -106,7 +105,6 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
     def storageService
     UserDataProvider userDataProvider
     ExecutionDataProvider executionDataProvider
-    ReferencedExecutionDataProvider referencedExecutionDataProvider
 
     def ValidatedPlugin validatePluginConfig(String project, String name, Map config) {
         return pluginService.validatePlugin(name, notificationPluginProviderService, project,config, PropertyScope.Instance, PropertyScope.Project)
@@ -537,7 +535,9 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
                     // rendered inside mailService.sendMail below, so a query issued from the template runs
                     // mid-send -- inside the transaction that spans the SMTP conversation, during which the
                     // server can close the connection. Same reasoning as averageDuration.
-                    Map executionCounts = resolveJobExecutionCounts(source)
+                    // Null-tolerant: a mocked ExecutionService returns null for unstubbed methods, and the
+                    // template defaults each count to 0 anyway.
+                    Map executionCounts = executionService.getJobExecutionCounts(source) ?: [:]
 
                     // Read before the send rather than from inside the mail closure below. That closure runs
                     // while the message is being built and sent, so this read -- log storage I/O plus the
@@ -895,31 +895,6 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
             job.averageDuration = averageDuration
         }
         job
-    }
-
-    /**
-     * Resolve the execution counts the notification mail template reports, as a view model fragment.
-     *
-     * These were previously queried by _newStatus.gsp itself. That template is rendered inside
-     * mailService.sendMail, so the queries ran while the message was being sent -- inside the transaction
-     * that spans the SMTP conversation, and therefore on a connection the server may already have closed.
-     * Resolving them before the send removes four queries from that window, two of which are count(*)
-     * against the execution table.
-     *
-     * @param scheduledExecution the job the notification is for, may be null for an execution with no job
-     * @return model entries for the template; all zero when there is no job
-     */
-    protected Map resolveJobExecutionCounts(ScheduledExecution scheduledExecution) {
-        if (!scheduledExecution?.id) {
-            return [executionCount: 0, succeededCount: 0, referencedExecutionCount: 0, referencedSucceededCount: 0]
-        }
-        [
-                executionCount          : Execution.countByScheduledExecutionAndDateCompletedIsNotNull(scheduledExecution),
-                succeededCount          : Execution.countByScheduledExecutionAndStatus(scheduledExecution, 'succeeded'),
-                referencedExecutionCount: referencedExecutionDataProvider.countByJobUuid(scheduledExecution.uuid),
-                referencedSucceededCount: referencedExecutionDataProvider.countByJobUuidAndStatus(
-                        scheduledExecution.uuid, 'succeeded')
-        ]
     }
 
     /**

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -197,12 +197,7 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
         if(trigger && schedUuid){
             if(featureService.featurePresent(Features.NOTIFICATIONS_OWN_THREAD)){
                 def notificationTask = Promises.task {
-                    ScheduledExecution.withNewTransaction {
-                        ScheduledExecution scheduledExecution = ScheduledExecution.findByUuid(schedUuid)
-                        if(null != scheduledExecution) {
-                            triggerJobNotification(trigger, scheduledExecution, content)
-                        }
-                    }
+                    resolveThenDeliver(trigger, schedUuid, content)
                 }
                 try{
                     notificationTask.get(configurationService.getLong("notification.threadTimeOut", defaultThreadTO), TimeUnit.MILLISECONDS)
@@ -211,12 +206,7 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
                     notificationTask.cancel(true)
                 }
             }else{
-                ScheduledExecution.withNewTransaction {
-                    ScheduledExecution scheduledExecution = ScheduledExecution.findByUuid(schedUuid)
-                    if(null != scheduledExecution){
-                        triggerJobNotification(trigger, scheduledExecution, content)
-                    }
-                }
+                resolveThenDeliver(trigger, schedUuid, content)
             }
 
         }
@@ -302,8 +292,52 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
         return map;
     }
 
+    /**
+     * Load the job, resolve its notifications in a short transaction, then deliver them with none open.
+     *
+     * The transaction ends before any SMTP, HTTP or plugin call. That is the point: the previous shape
+     * held it open across those sends, and since the server closes a connection idle longer than its
+     * wait_timeout, the transaction's own COMMIT then failed on a dead socket.
+     *
+     * A session is held for the whole call so that plugin notifications, which hand third-party code the
+     * Execution entity, can still traverse associations during delivery. The email and webhook paths do
+     * not need it -- their database reads are all resolved in the transaction.
+     */
+    protected void resolveThenDeliver(String trigger, schedUuid, Map content) {
+        ScheduledExecution.withNewSession {
+            List<Closure<Boolean>> deliveries = ScheduledExecution.withNewTransaction {
+                ScheduledExecution scheduledExecution = ScheduledExecution.findByUuid(schedUuid)
+                null != scheduledExecution ? resolveNotifications(trigger, scheduledExecution, content) : []
+            }
+            deliverNotifications(deliveries)
+        }
+    }
+
+    /**
+     * Resolve and then deliver the notifications for a trigger.
+     *
+     * Kept for callers that want both phases in one call and are already inside a suitable
+     * transaction or session. {@link #asyncTriggerJobNotification} runs the two phases separately so
+     * that only the resolve phase is transactional -- see that method for why.
+     */
     boolean triggerJobNotification(String trigger, ScheduledExecution source, Map content){
-        def didsend = false
+        deliverNotifications(resolveNotifications(trigger, source, content))
+    }
+
+    /**
+     * Resolve the notifications for a trigger into a list of deliveries, doing all database reads here
+     * and none in the returned closures.
+     *
+     * Every closure captures values already resolved, so delivery needs no transaction and -- with the
+     * mail template's queries and the log read now hoisted out of the send -- no Hibernate session
+     * either, except for third-party plugin code which may still walk associations on the Execution it
+     * is handed.
+     *
+     * @return one closure per notification, each returning whether it sent, or null if it does not
+     *         report a result
+     */
+    protected List<Closure<Boolean>> resolveNotifications(String trigger, ScheduledExecution source, Map content){
+        List<Closure<Boolean>> deliveries = []
         if(source.notifications && source.notifications.find{it.eventTrigger=='on'+trigger}){
             def notes = source.notifications.findAll{it.eventTrigger=='on'+trigger}
             notes.each{ Notification n ->
@@ -515,6 +549,8 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
                         outputBuffer = copyExecOutputToStringBuffer(exec, isFormatted)
                     }
 
+                    // Recipient expansion resolved here; only the sends themselves are deferred.
+                    List<String> resolvedRecipients = []
                     destarr.each{String recipient->
                         //try to expand property references
                         String sendTo=recipient
@@ -527,6 +563,12 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
                                 return
                             }
                         }
+                        resolvedRecipients << sendTo
+                    }
+
+                    deliveries << { ->
+                        boolean sent = false
+                        resolvedRecipients.each{String sendTo->
                         try{
                             mailService.sendMail{
                               multipart (attachlog && outputfile!=null)
@@ -558,17 +600,19 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
                                     attachBytes "${source.jobName}-${exec.id}.${attachedExtension}", attachedContentType, outputfile.getText("UTF-8").bytes
                                 }
                             }
-                            didsend = true
+                            sent = true
                         }catch(Throwable t){
                             log.error("Error sending notification email to ${sendTo} for Execution ${exec.id}: "+t.getMessage());
                             if (log.traceEnabled) {
                                 log.trace("Error sending notification email to ${sendTo} for Execution ${exec.id}: " + t.getMessage(), t)
                             }
                         }
-                    }
+                        }
 
-                    if (null != outputfile) {
-                        outputfile.delete()
+                        if (null != outputfile) {
+                            outputfile.delete()
+                        }
+                        sent
                     }
                 }else if(n.type=='url'){    //sending notification of a status trigger for the Job
                     Execution exec = content.execution
@@ -582,35 +626,46 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
                     String urls = urlsConfiguration.urls
                     String method = urlsConfiguration.httpMethod
                     def urlarr = urls.split(",") as List
-                    def webhookfailure=false
-                    urlarr.each{String urlstr->
-                        //perform token expansion within URL.
-                        String newurlstr=expandWebhookNotificationUrl(urlstr,exec,source,trigger, content?.export)
+                    // Token expansion resolved here: it reads the execution and job, so it must not run
+                    // after the transaction closes or in the middle of the POSTs.
+                    List<String> expandedUrls = urlarr.collect{String urlstr->
+                        expandWebhookNotificationUrl(urlstr,exec,source,trigger, content?.export)
+                    }
+                    String eventTrigger = n.eventTrigger
+                    String format = n.format
+
+                    deliveries << { ->
+                        def webhookfailure=false
+                        expandedUrls.each{String newurlstr->
                         try{
-                            def result= postDataUrl(newurlstr, n.format,payloadStr, trigger, state, exec.id.toString(), method)
+                            def result= postDataUrl(newurlstr, format,payloadStr, trigger, state, exec.id.toString(), method)
                             if(!result.success){
                                 webhookfailure=true
-                                log.error("Notification failed [${n.eventTrigger},${state},${exec.id}]; URL ${newurlstr}: ${result.error}")
+                                log.error("Notification failed [${eventTrigger},${state},${exec.id}]; URL ${newurlstr}: ${result.error}")
                             }else if (log.traceEnabled) {
-                                log.trace("Notification succeeded [${n.eventTrigger},${state},${exec.id}]; URL ${newurlstr}")
+                                log.trace("Notification succeeded [${eventTrigger},${state},${exec.id}]; URL ${newurlstr}")
                             }
                         } catch (Throwable t) {
                             webhookfailure=true
-                            log.error("Notification failed [${n.eventTrigger},${state},${exec.id}]; URL ${newurlstr}: " + t.message);
+                            log.error("Notification failed [${eventTrigger},${state},${exec.id}]; URL ${newurlstr}: " + t.message);
                             if (log.traceEnabled) {
                                 log.trace("Notification failed", t)
                             }
                         }
+                        }
+                        !webhookfailure
                     }
-                    didsend=!webhookfailure
                 }else if (n.type) {
 
                     def execMap = null
                     Map context = null
                     (context, execMap) = generateNotificationContext(content.execution, content, source)
 
-
-                    didsend=triggerPlugin(trigger,execMap,n.type, source.project,n.configuration, content,context)
+                    String pluginType = n.type
+                    Map pluginConfig = n.configuration
+                    deliveries << { ->
+                        triggerPlugin(trigger,execMap,pluginType, source.project,pluginConfig, content,context)
+                    }
                 }else{
                     log.error("Unsupported notification type: " + n.type);
                 }
@@ -623,7 +678,35 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
             }
         }
 
-        return didsend
+        return deliveries
+    }
+
+    /**
+     * Run resolved deliveries. Performs the external I/O -- SMTP, HTTP, plugins -- and no database work.
+     *
+     * Each delivery is isolated: a failure in one does not stop the others, matching the per-notification
+     * try/catch that wrapped both phases before they were split.
+     *
+     * @param deliveries closures from {@link #resolveNotifications}
+     * @return the result of the last delivery that reported one, preserving the previous behaviour where
+     *         each notification overwrote didsend and types that report nothing left it unchanged
+     */
+    protected boolean deliverNotifications(List<Closure<Boolean>> deliveries) {
+        boolean didsend = false
+        deliveries.each { Closure<Boolean> delivery ->
+            try {
+                Boolean result = delivery.call()
+                if (result != null) {
+                    didsend = result
+                }
+            } catch (Throwable t) {
+                log.error("Error delivering notification: ${t.class}: " + t.message, t)
+                if (log.traceEnabled) {
+                    log.trace("Notification delivery failed", t)
+                }
+            }
+        }
+        didsend
     }
 
     String createXmlNotificationPayload(String trigger, Execution exec) {

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -520,7 +520,12 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
                                                     nodestatus        : content.nodestatus,
                                                     jobref            : content.jobref,
                                                     allowUnsanitized  : allowUnsanitized,
-                                                    logOutput         : outputBuffer!=null? outputBuffer.toString(): null
+                                                    logOutput         : outputBuffer!=null? outputBuffer.toString(): null,
+                                                    // Supplied so the template does not query for it while the
+                                                    // mail body is being rendered -- that happens inside this
+                                                    // transaction, mid-send. Taken from the job map already built
+                                                    // for the notification context, so both report the same value.
+                                                    averageDuration   : execMap?.job?.averageDuration ?: 0
                                             ]
                                     )
                                 }
@@ -747,7 +752,15 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
         modifiedSuccessNodeList
     }
 
-    protected Map exportJobdata(ScheduledExecution scheduledExecution) {
+    /**
+     * Builds the job section of a notification context.
+     *
+     * @param scheduledExecution the job the notification is for
+     * @param content the trigger's content map; when it carries an 'averageDuration' key that value
+     *        is used instead of querying for it
+     * @return the job data map
+     */
+    protected Map exportJobdata(ScheduledExecution scheduledExecution, Map content = null) {
         def job = [
                 id: scheduledExecution.extid,
                 href: grailsLinkGenerator.link(controller: 'scheduledExecution', action: 'show',
@@ -759,8 +772,18 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
                 project: scheduledExecution.project,
                 description: scheduledExecution.description
         ]
-        def averageDuration = executionService.getAverageDuration(scheduledExecution.uuid)
-        if (averageDuration > 0) {
+        // Prefer a value captured where the trigger fired. The fallback keeps callers that do not
+        // supply one working, but it runs inside the notification transaction -- the one that also
+        // spans SMTP and HTTP sends, during which Aurora can close the connection out from under it.
+        //
+        // containsKey rather than truthiness on purpose: a genuine average of 0, for a job with no
+        // completed executions yet, must not be mistaken for "not supplied" and re-trigger the query.
+        // Left untyped, and the comparison null-tolerant, to match the previous behaviour exactly:
+        // getAverageDuration is declared to return Long, so a null must not blow up here.
+        def averageDuration = content?.containsKey('averageDuration')
+                ? content.averageDuration
+                : executionService.getAverageDuration(scheduledExecution.uuid)
+        if ((averageDuration ?: 0) > 0) {
             job.averageDuration = averageDuration
         }
         job
@@ -963,7 +986,7 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
         def projUrl = grailsLinkGenerator.link(action: 'index', controller: 'menu', params: [project:  exec.project], absolute: true)
 
         def execMap = generateExecutionData(exec, content)
-        def jobMap=exportJobdata(source)
+        def jobMap=exportJobdata(source, content)
         Map context = generateContextData(exec, content)
 
         //used for plugins types

--- a/rundeckapp/grails-app/views/execution/mailNotification/_newStatus.gsp
+++ b/rundeckapp/grails-app/views/execution/mailNotification/_newStatus.gsp
@@ -28,12 +28,19 @@
     request.setAttribute("IS_MAIL_RENDERING_REQUEST",Boolean.TRUE)
 %>
 
-<g:set var="referencedExecutionDataProvider" bean="${org.rundeck.app.data.providers.v1.execution.ReferencedExecutionDataProvider}"/>
-<g:set var="execCount" value="${scheduledExecution.id ? Execution.countByScheduledExecutionAndDateCompletedIsNotNull(scheduledExecution) : 0}"/>
-<g:set var="successcount" value="${scheduledExecution.id ? Execution.countByScheduledExecutionAndStatus(scheduledExecution, 'succeeded') : 0}"/>
-<g:set var="refsuccesscount" value="${scheduledExecution.id ? referencedExecutionDataProvider.countByJobUuidAndStatus(scheduledExecution.uuid, 'succeeded') : 0}"/>
-
-<g:set var="refexecCount" value="${scheduledExecution.id ? referencedExecutionDataProvider.countByJobUuid(scheduledExecution.uuid) : 0}"/>
+%{--
+  - The four counts below come from the view model rather than being queried here. This template is
+  - rendered inside mailService.sendMail, so a query at this point runs while the message is being
+  - sent -- inside the transaction that spans the SMTP conversation, during which the server can close
+  - the database connection. The caller resolves them before the send instead.
+  -
+  - Defaults keep the template renderable for callers that supply no counts (an execution with no job),
+  - which also removes the NPE that ${scheduledExecution.id} raised on that path.
+  --}%
+<g:set var="execCount" value="${executionCount ?: 0}"/>
+<g:set var="successcount" value="${succeededCount ?: 0}"/>
+<g:set var="refsuccesscount" value="${referencedSucceededCount ?: 0}"/>
+<g:set var="refexecCount" value="${referencedExecutionCount ?: 0}"/>
 
 <g:set var="successrate" value="${(execCount + refexecCount) > 0 ? ((successcount+refsuccesscount) / (execCount+refexecCount)) : 0}"/>
 

--- a/rundeckapp/grails-app/views/execution/mailNotification/_newStatus.gsp
+++ b/rundeckapp/grails-app/views/execution/mailNotification/_newStatus.gsp
@@ -652,8 +652,10 @@
       <td colspan="3" style="padding: 0 10px;">
         <div class="spacer py-sm-10" style="line-height: 30px;">‌</div>
         <table cellpadding="0" cellspacing="0" role="presentation" width="100%">
-          <g:set var="executionService" bean="${rundeck.services.ExecutionService}"/>
-          <g:set var="avgduration" value="${executionService.getAverageDuration(scheduledExecution.uuid)}"/>
+          <%-- Supplied by NotificationService in the mail model. Previously this looked up the
+               ExecutionService bean and queried here, which put a database round-trip inside the
+               mail render, mid-send, on a connection the notification transaction was holding. --%>
+          <g:set var="avgduration" value="${averageDuration ?: 0}"/>
 
           <tr>
             <g:if test="${avgduration>0}">

--- a/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
@@ -38,6 +38,7 @@ import spock.lang.Specification
 
 import java.sql.Timestamp
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Created by greg on 4/12/16.
@@ -788,6 +789,94 @@ class ExecutionJobSpec extends Specification implements DataTest {
         }
         result != null
         se.executions.status.get(0) == ExecutionService.EXECUTION_RUNNING
+    }
+
+    def "average notification context carries the average, not the trigger threshold"() {
+        given: 'a percentage threshold, so the threshold and the average differ'
+        ScheduledExecution se = new ScheduledExecution(
+                uuid: UUID.randomUUID().toString(),
+                jobName: 'blue',
+                project: 'AProject',
+                groupPath: 'some/where',
+                description: 'a job',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec(
+                                [adhocRemoteString: 'test buddy', argString: '-delay 12']
+                        )]
+                ),
+                // '50%' makes the trigger threshold 1.5x the average: 15ms against an average of 10ms.
+                // The existing test uses '0s', which parseTimeDuration resolves to 0 and therefore falls
+                // back to the average itself -- so it cannot tell the two values apart.
+                notifyAvgDurationThreshold: '50%',
+                averageDuration: 10,
+                totalTime: 10,
+                execCount: 1
+        )
+        se.save(flush: true)
+
+        Execution e = new Execution(
+                scheduledExecution: se,
+                dateStarted: new Date(),
+                dateCompleted: null,
+                project: se.project,
+                user: 'bob',
+                status: ExecutionService.EXECUTION_RUNNING,
+                workflow: new Workflow(commands: [new CommandExec(
+                        [adhocRemoteString: 'test buddy', argString: '-delay 12']
+                )])
+        ).save(flush: true)
+
+        def secureOption = [:]
+        def secureOptsExposed = [:]
+        def eus = Mock(ExecutionUtilService)
+        def auth = Mock(UserAndRolesAuthContext)
+        def framework = Mock(Framework)
+        def origContext = Mock(StepExecutionContext) {
+            getDataContext() >> [option: [env: true]]
+            getStepNumber() >> 1
+            getStepContext() >> []
+            getFramework() >> framework
+        }
+
+        CountDownLatch latch = new CountDownLatch(1)
+        def testThread = new WorkflowExecutionServiceThread(null, null, origContext, null, null) {
+            void run() {
+                // Bounded, unlike the sibling test: if the expected content map stops matching, this test
+                // must fail rather than hang the whole suite waiting for a countDown that never comes.
+                latch.await(20, TimeUnit.SECONDS)
+            }
+        }
+        def execmap = [execution: e, scheduledExecution: se, thread: testThread]
+        def es = Mock(ExecutionService) {
+            1 * executeAsyncBegin(framework, auth, e, se, secureOption, secureOptsExposed) >> {
+                testThread.start()
+                execmap
+            }
+            getAverageDuration(_) >> 10
+        }
+
+        ExecutionJob executionJob = new ExecutionJob()
+        ExecutionJob.RunContext runContext = new ExecutionJob.RunContext(
+                executionService: es,
+                executionUtilService: eus,
+                execution: e,
+                framework: framework,
+                authContext: auth,
+                scheduledExecution: se,
+                timeout: 0,
+                secureOpts: secureOption,
+                secureOptsExposed: secureOptsExposed
+        )
+
+        when:
+        def result = executionJob.executeCommand(runContext, Mock(JobExecutionContext))
+
+        then: 'the average is reported, not the 15ms threshold the notification fired at'
+        1 * es.avgDurationExceeded(_, [execution: e, context: origContext, averageDuration: 10]) >> {
+            latch.countDown()
+        }
+        result != null
     }
 
     def "scheduled job quartz checking the same format of dates"() {

--- a/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
@@ -758,9 +758,14 @@ class ExecutionJobSpec extends Specification implements DataTest {
         }
 
         ExecutionJob executionJob = new ExecutionJob()
+        // averageDuration is carried in the content map so the notification path does not have to
+        // query for it inside its own transaction. 1 matches this job's stats and the getAverageDuration
+        // stub above. The mock below matches this map exactly, and the test only terminates once that
+        // interaction is satisfied, so a mismatch here hangs rather than fails.
         Map content = [
-            execution: e,
-            context  : origContext
+            execution      : e,
+            context        : origContext,
+            averageDuration: 1
         ]
         ExecutionJob.RunContext runContext=new ExecutionJob.RunContext(
             executionService: es,

--- a/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
@@ -1406,4 +1406,78 @@ class NotificationServiceSpec extends Specification implements ServiceUnitTest<N
 
         }
     }
+
+    def "exportJobdata uses the supplied averageDuration and issues no query"() {
+        given:
+        def (job, execution) = createTestJob()
+        service.executionService = Mock(ExecutionService)
+        service.grailsLinkGenerator = Mock(LinkGenerator) {
+            _ * link(*_) >> 'alink'
+        }
+
+        when:
+        def result = service.exportJobdata(job, [averageDuration: 4321L])
+
+        then: 'the supplied value is used'
+        result.averageDuration == 4321L
+
+        and: 'and the database is not consulted for it'
+        0 * service.executionService.getAverageDuration(_)
+    }
+
+    def "exportJobdata falls back to the query when no value is supplied"() {
+        given:
+        def (job, execution) = createTestJob()
+        service.executionService = Mock(ExecutionService)
+        service.grailsLinkGenerator = Mock(LinkGenerator) {
+            _ * link(*_) >> 'alink'
+        }
+
+        when:
+        def result = service.exportJobdata(job, contentMap)
+
+        then:
+        1 * service.executionService.getAverageDuration('test1') >> 999L
+        result.averageDuration == 999L
+
+        where: 'both a null content map and one without the key fall back'
+        contentMap << [null, [:], [execution: 'x']]
+    }
+
+    def "exportJobdata treats a supplied zero as a real value, not as absent"() {
+        given:
+        def (job, execution) = createTestJob()
+        service.executionService = Mock(ExecutionService)
+        service.grailsLinkGenerator = Mock(LinkGenerator) {
+            _ * link(*_) >> 'alink'
+        }
+
+        when: 'a job with no completed executions yet legitimately averages zero'
+        def result = service.exportJobdata(job, [averageDuration: 0L])
+
+        then: 'no fallback query is issued'
+        0 * service.executionService.getAverageDuration(_)
+
+        and: 'and averageDuration stays absent, exactly as when the query returns zero'
+        !result.containsKey('averageDuration')
+    }
+
+    def "exportJobdata omits averageDuration when the query returns null or zero"() {
+        given:
+        def (job, execution) = createTestJob()
+        service.executionService = Mock(ExecutionService)
+        service.grailsLinkGenerator = Mock(LinkGenerator) {
+            _ * link(*_) >> 'alink'
+        }
+
+        when:
+        def result = service.exportJobdata(job, null)
+
+        then: 'a null from the provider must not blow up -- mocks and plugins can return one'
+        1 * service.executionService.getAverageDuration('test1') >> queried
+        !result.containsKey('averageDuration')
+
+        where:
+        queried << [null, 0L]
+    }
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
@@ -50,6 +50,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.rundeck.app.data.providers.GormUserDataProvider
+import org.rundeck.app.data.providers.v1.execution.ReferencedExecutionDataProvider
 import org.rundeck.app.spi.Services
 import org.springframework.mail.MailMessage
 import rundeck.CommandExec
@@ -76,6 +77,9 @@ class NotificationServiceSpec extends Specification implements ServiceUnitTest<N
         mockDataService(UserDataService)
         GormUserDataProvider provider = new GormUserDataProvider()
         service.userDataProvider =  provider
+        // Injected in production; resolveJobExecutionCounts uses it to supply the mail template's
+        // reference-execution counts, so it must be present for any test that renders a notification.
+        service.referencedExecutionDataProvider = Mock(ReferencedExecutionDataProvider)
     }
 
     private List createTestJob() {

--- a/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
@@ -50,7 +50,6 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.rundeck.app.data.providers.GormUserDataProvider
-import org.rundeck.app.data.providers.v1.execution.ReferencedExecutionDataProvider
 import org.rundeck.app.spi.Services
 import org.springframework.mail.MailMessage
 import rundeck.CommandExec
@@ -77,9 +76,6 @@ class NotificationServiceSpec extends Specification implements ServiceUnitTest<N
         mockDataService(UserDataService)
         GormUserDataProvider provider = new GormUserDataProvider()
         service.userDataProvider =  provider
-        // Injected in production; resolveJobExecutionCounts uses it to supply the mail template's
-        // reference-execution counts, so it must be present for any test that renders a notification.
-        service.referencedExecutionDataProvider = Mock(ReferencedExecutionDataProvider)
     }
 
     private List createTestJob() {

--- a/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
@@ -1484,4 +1484,42 @@ class NotificationServiceSpec extends Specification implements ServiceUnitTest<N
         where:
         queried << [null, 0L]
     }
+
+    def "deliverNotifications isolates a failing delivery from the rest"() {
+        given: 'three deliveries, the middle one throwing'
+        def called = []
+        List<Closure<Boolean>> deliveries = [
+                { -> called << 'first'; true },
+                { -> called << 'second'; throw new RuntimeException('send failed') },
+                { -> called << 'third'; true },
+        ]
+
+        when:
+        def result = service.deliverNotifications(deliveries)
+
+        then: 'the failure is contained; the notifications after it still go out'
+        called == ['first', 'second', 'third']
+        result
+
+        and: 'this preserves the per-notification try/catch that wrapped both phases before the split'
+        noExceptionThrown()
+    }
+
+    def "deliverNotifications reports the last delivery that returned a result"() {
+        when:
+        def result = service.deliverNotifications(deliveries as List<Closure<Boolean>>)
+
+        then:
+        result == expected
+
+        where: 'a null result leaves the value from the previous delivery, matching the old didsend'
+        deliveries                                      || expected
+        []                                              || false
+        [{ -> true }]                                   || true
+        [{ -> false }]                                  || false
+        [{ -> true }, { -> false }]                     || false
+        [{ -> false }, { -> true }]                     || true
+        [{ -> true }, { -> null }]                      || true
+        [{ -> true }, { -> throw new RuntimeException('x') }] || true
+    }
 }


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. [RUN-4755](https://pagerduty.atlassian.net/browse/RUN-4755).

Job notifications hold database transactions open across SMTP, HTTP and plugin calls. A server closes a connection left idle longer than its `wait_timeout`, so the next statement — or the transaction's own `COMMIT` — fails on a dead socket.

Across a 90-day window on a fleet of MySQL-backed installations, **`COMMIT` was the single most frequent database error**, ahead of every individual query:

| Failure | Errors (90d) | Thread |
|---|---|---|
| `COMMIT` | **2,446** | 81% on `quartzScheduler_Worker-*` |
| `select ... from scheduled_execution_stats where job_uuid = ?` | 1,403 | `pool-3-thread-*` |

Neither is a slow query. The `scheduled_execution_stats` failures cluster at 5.1–6.3 ms with almost no spread while successes span 4–254 ms across databases of very different sizes; the `COMMIT` failures average 6.5 ms (p95 11.2 ms). A failure whose cost is identical regardless of workload is a dead socket, not a slow statement. The server says so directly:

```
CommunicationsException: The last packet successfully received from the server was 117,307
milliseconds ago ... is longer than the server configured value of 'wait_timeout'
```

117 seconds with no traffic. HikariCP's keepalive cannot prevent it — that pings **idle connections in the pool**, and these are **checked out**, held by an open transaction.

The two thread pools are two symptoms of one cause. The notification runs on `pool-3-thread-*` in its own transaction, so its first statement after a slow send fails. Meanwhile the caller on `quartzScheduler_Worker-*` blocks on `notificationTask.get(...)` holding *its* connection checked out and idle, and fails at `COMMIT` when it finally returns.

**Reproduced deliberately.** Pointing the SMTP host at an address that silently drops packets makes every send hang until `notification.threadTimeOut`. On one staging tenant that produced **~60 `COMMIT` failures per hour**, against **zero** in the six minutes before arming it and zero after restoring mail. The failures arrive in step with the timeout, and the exception is identical to the production one.

That reproduction also settled an open question about connection configuration: the connection died after **75 seconds** idle on a deployment whose `connectionInitSql` sets `wait_timeout=180`. The session-level override is not taking effect, so the real margin is far smaller than the configuration implies. Tracked separately.

**Describe the solution you've implemented**

Nothing in the notification path needs to be atomic with the send, and the history of this code already says so — see below. Every transaction is closed before any external I/O, and everything the sends need is resolved first.

### Transaction layout

**Before** — two independent transactions span network I/O, on two different threads. That is why they are two separate failures, and why fixing one does not move the other:

```
quartzScheduler_Worker-N
├─ saveExecutionState_newTransaction
│    └─ withNewTransaction ──── TX1  execution marked completed → COMMIT
│
└─ triggerJobCompleteNotifications        (REQUIRED, implicit — opens a transaction)
     ┌── TX2 ─────────────────────────────────────────────────────────┐
     │  two reads, then                                               │
     │  asyncTriggerJobNotification       @Transactional (REQUIRED)   │
     │    ├─ Promises.task ──────────────────────────┐                │   ✗ COMMIT fails
     │    └─ .get(120s)   ← blocks, holding TX2      │                │     81% of them
     └───────────────────────────────────────────────│────────────────┘
                                                     ▼
                                      pool-3-thread-N
                                      ┌── TX3  withNewTransaction ────────────┐
                                      │  reads, then SMTP · HTTP · plugins    │   ✗ first statement
                                      │  the GSP render issues 5 more queries │     after the send,
                                      └───────────────────────────────────────┘     or its COMMIT
```

**After** — three short transactions, none of them open across a send:

```
quartzScheduler_Worker-N
├─ saveExecutionState_newTransaction
│    └─ withNewTransaction ──── TX1  execution marked completed → COMMIT      (unchanged)
│
└─ triggerJobCompleteNotifications        NOT_SUPPORTED — no transaction
     ├─ withNewTransaction ──── TX2  orchestrator + averageDuration → COMMIT
     └─ asyncTriggerJobNotification       NOT_SUPPORTED — no transaction
          ├─ Promises.task ────────────────────────────┐
          └─ .get(120s)   ← blocks, holding nothing    │
                                                       ▼
                                       pool-3-thread-N
                                       withNewSession {                  ← session, no transaction
                                         withNewTransaction ─ TX3  every read → COMMIT
                                         deliverNotifications            ← SMTP · HTTP · plugins
                                       }                                    NO TRANSACTION
```

TX3 resolves everything delivery needs: the `notifications` collection, the user record, project globals, ~18 `configurationService` lookups, the template's four counts, the log buffer, and recipient and webhook-URL expansion. It commits before the first send.

The longest a connection is now held without traffic goes from `notification.threadTimeOut` — 120 s by default — to the duration of a few reads.

**1. Resolve the average duration where the trigger fires.** Four of the six trigger sites cost nothing, because the value was already in scope:

| Call site | Trigger | Source | New queries |
|---|---|---|---|
| `ExecutionJob.groovy` | `avgduration` | `jobAverageDuration` | **0** |
| `ExecutionService.groovy:4349` | `avgduration` (job ref) | the triggering condition | **0** |
| `:4298` | `start` (job ref) | resolved earlier in the same method | **0** |
| `:4371` | `success`/`failure` (job ref) | same | **0** |
| `:3544` | `success`/`failure`/`retryablefailure` | new call in `triggerJobCompleteNotifications` | 1, in a short transaction |
| `:1409` | `start` | new call at execution start | 1 |

`exportJobdata` tests presence with **`containsKey`, not truthiness** — a genuine average of `0`, for a job with no completed executions, must not be mistaken for "not supplied".

**2. Remove the caller's transaction.** `triggerJobCompleteNotifications` becomes `NOT_SUPPORTED`, with its two reads in a short transaction of their own. The execution state is already committed by `saveExecutionState_newTransaction`, and the notification is delivered on another thread in its own transaction, so the caller's protected nothing.

`asyncTriggerJobNotification` becomes `NOT_SUPPORTED` too, and this part is load-bearing rather than cosmetic: it was `@Transactional`, so with the caller no longer supplying a transaction its `REQUIRED` propagation would create the long-lived one itself. Both have to change together; either alone is a no-op.

The orchestrator load becomes `LEFT JOIN FETCH` rather than a bare `LEFT JOIN`, so the association is initialised before that short transaction closes. It is read from the notification thread, and a bare join does not populate it — the previous code got away with it only because the long transaction was still open.

**3. Make the mail template query-free.** `_newStatus.gsp` issued **five** queries while being rendered, and the render happens inside `mailService.sendMail`. Two were `count(*)` against `execution`. All five now come from the view model, resolved before the send. `ExecutionController.mail()` renders the same view and supplies them too, otherwise the preview page silently reports zeros.

**4. Read the log output before the send.** `copyExecOutputToStringBuffer` was called from inside the `sendMail` closure, so log storage I/O happened mid-send — and once per recipient for identical content.

**5. Close the worker's transaction before the sends.** `triggerJobNotification` splits into `resolveNotifications`, which does every database read and returns one closure per notification capturing already-resolved values, and `deliverNotifications`, which performs only external I/O. `resolveThenDeliver` runs the first in a short transaction that commits before any send, and the second with none open. Recipient token expansion and webhook URL expansion (it reads the execution and job) are resolved up front too.

A session is held across both phases, which covers `triggerPlugin`'s own project-property lookups. It is not needed for correctness: `plugin.postNotification(trigger, data, allConfig)` hands plugin code two plain Maps and never the `Execution` entity, so third-party code has no association to traverse.

`triggerJobNotification` keeps its signature and behaviour for its other callers. Delivery failures stay isolated per notification, and the return value still reflects the last notification that reported one, matching how `didsend` was overwritten before.

**Why this shape — the history matters here**

This code is already the product of four transaction fixes, and two of them constrain the solution:

| Commit | Change | Why |
|---|---|---|
| `6ee289d97e` (2018) | `withNewSession` → `withNewTransaction` | *"Fixes for docker and mysql tests"* |
| `7dd95a0592` (2021) | raw `Thread.start` → `Promises.task` | *"fix for lazy loading issue"* — a raw thread has no Hibernate session bound |
| `aa0abc9840` (2024) | notification call moved out of the state-save transaction | a notification timeout rolled back the "completed" status → **stuck executions** |
| `0915a59b2b` (2025) | notification trigger given its own `withRetry` | retrying save+notify together created **duplicate execution reports** |

Two conclusions. First, the 2024 and 2025 fixes both moved *away* from wrapping notification delivery in the execution's transaction; this PR is the next step in that direction, not a reversal of it. Second, the worker's `withNewTransaction` is **not there for atomicity — it is a session holder for lazy loading**, established independently by the 2018 and 2021 fixes. Nothing in `triggerJobNotification` writes. That is why the fix supplies data rather than merely shortening the transaction, and why simply reverting to `withNewSession` was rejected: it is what 2018 deliberately replaced.

**Describe alternatives you've considered**

- **`withNewSession` instead of `withNewTransaction`** — one line, and there is a precedent in the same file. Rejected: it is the implementation 2018 replaced, and on its own terms it leaves every read inside the send window.
- **Moving the notification trigger into `ExecutionJob`** — structurally equivalent, but changes a public signature with three callers for no additional benefit once propagation is correct.
- **Removing the blocking `notificationTask.get()`** — also shortens the transaction, but makes the `withRetry` wrapper meaningless and discards the timeout behaviour.
- **Raising the server's `wait_timeout`** — would mitigate but not remove the design problem: a webhook to an unresponsive endpoint can exceed any reasonable timeout.
- **efm2 aborting the connection** — its detection window is 30000 + (5000 × 3) = 45 s; these statements take milliseconds, so it never engages.

**Additional context — what this does not fix**

Two things are deliberately left, and reviewers should weigh them:

1. **Retry idempotency.** `ExecutionJob` retries the notification trigger up to `finalizeRetryMax` times. A delivery failure after some recipients have already received mail will, on retry, re-send to them. That hazard predates this PR, but the phase split moves where a failure lands: resolve-phase failures are safe to retry, delivery-phase failures are not idempotent.
2. **The nested-session assumption is unverified.** Whether `withNewTransaction` inside `withNewSession` reuses the outer session could not be measured — real-Hibernate testing is not currently wired up in `rundeckapp`, and the map datastore has different session semantics. Spring's behaviour says it should reuse it (`doBegin` adopts a thread-bound `SessionHolder`; `doCleanupAfterCompletion` closes only sessions it created), but that is reasoning, not measurement. Nothing in the design depends on the answer, though: every delivery path is fed plain data resolved in phase 1.

**Testing**

| Spec | Result |
|---|---|
| `NotificationServiceSpec` | 54 tests, 0 failed |
| `ExecutionJobSpec` | 17 tests, 0 failed |
| `ExecutionControllerSpec` | 53 tests, 0 failed |
| `ExecutionServiceSpec` | 291 tests, 0 failed |

**Copilot's review caught a real bug**, now fixed: the `avgduration` trigger passed `jobAverageDurationFinal`, which is the threshold `getNotifyAvgDurationThreshold` derives from `notifyAvgDurationThreshold` — for `'50%'` that is 1.5× the average, so the email would have reported the threshold. The existing test could not catch it, because its job uses a `'0s'` threshold, which resolves to 0 and falls back to the average itself, making the two values identical. The added test uses `'50%'` so they differ, and was confirmed to fail against the original code.

That test also bounds its latch. `ExecutionJobSpec`'s older `"average notification context"` asserts the content map by exact equality *and* depends on that interaction for termination, so a mismatch hangs rather than fails; the new one cannot.

`./gradlew build -x check` could not be run end to end: the `runNpmBuild` task does not complete in this environment for reasons unrelated to these changes. `:rundeckapp:compileGroovy`, `:rundeckapp:compileTestGroovy` and the four specs above all pass.

## Release Notes

Fixes intermittent `SQLTransientConnectionException` and failed `COMMIT` errors when sending job notifications. Notifications no longer hold a database transaction open while they are being delivered: the job average duration, the mail template's execution counts, the log output, and the recipient and webhook URL expansions are all resolved before the send rather than during it. Also fixes the average-duration notification reporting its trigger threshold instead of the job's average duration.


[RUN-4755]: https://pagerduty.atlassian.net/browse/RUN-4755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

