### PR TITLE
[RUN-4646] [Backend] Swapping and/or logic in a Conditional step

### DIFF
--- a/rundeck-data-models/src/main/java/org/rundeck/app/data/model/v1/job/workflow/ConditionalSet.java
+++ b/rundeck-data-models/src/main/java/org/rundeck/app/data/model/v1/job/workflow/ConditionalSet.java
@@ -20,10 +20,10 @@ import java.util.Map;
 
 /**
  * Represents a set of conditions organized in AND/OR groups.
- * The structure uses nested lists where:
+ * The structure uses nested lists where, by default (isInvertLogic() == false):
  * - Each inner list represents an AND group (all conditions must be true)
  * - The outer list represents OR groups (any group being true passes the ConditionalSet)
- * 
+ *
  * Example:
  * conditionGroups = [
  *   [Condition1, Condition2],  // AND group 1: Condition1 AND Condition2
@@ -31,6 +31,11 @@ import java.util.Map;
  *   [Condition4, Condition5]   // AND group 3: Condition4 AND Condition5
  * ]
  * Evaluates as: (Condition1 AND Condition2) OR Condition3 OR (Condition4 AND Condition5)
+ *
+ * When isInvertLogic() is true, the polarity is inverted: each inner list becomes an
+ * OR group (any condition in the group must be true), and the outer list becomes an
+ * AND group (every group must pass). The same example above would instead evaluate as:
+ * (Condition1 OR Condition2) AND Condition3 AND (Condition4 OR Condition5)
  */
 public interface ConditionalSet {
     /**
@@ -42,6 +47,14 @@ public interface ConditionalSet {
     List<List<ConditionalDefinition>> getConditionGroups();
 
     boolean isNodeStep();
+
+    /**
+     * Whether the AND/OR polarity of {@link #getConditionGroups()} is inverted:
+     * conditions within a group are OR'd together, and groups are AND'd together.
+     * Defaults to false, preserving the original AND-within/OR-across semantics.
+     * @return true if inverted (OR-within-group / AND-across-groups)
+     */
+    boolean isInvertLogic();
 
     Map toMap();
 

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
@@ -286,6 +286,12 @@ class ExecutionUtilService {
     }
 
     /**
+     * Upper bound on the number of combinations {@link #normalizeToDnf} may generate, to guard
+     * against combinatorial (Cartesian product) blowup from a pathological invertLogic condition set.
+     */
+    private static final int MAX_DNF_COMBINATIONS = 256
+
+    /**
      * Normalize a ConditionalSet to standard OR-of-ANDs (DNF) form so it can be safely combined
      * by {@link #combineConditionSets}, which assumes both inputs are in that form.
      * If invertLogic is false, the set is already in this form and is returned unchanged.
@@ -294,6 +300,7 @@ class ExecutionUtilService {
      * groups, picking exactly one condition from each group per combination.
      * @param set The condition set to normalize (can be null)
      * @return An equivalent ConditionalSet with invertLogic == false, or the original if already normalized/null
+     * @throws IllegalArgumentException if expanding to DNF would exceed {@link #MAX_DNF_COMBINATIONS}
      */
     private ConditionalSet normalizeToDnf(ConditionalSet set) {
         if (set == null || !set.isInvertLogic()) return set
@@ -303,6 +310,13 @@ class ExecutionUtilService {
         List<List> combinations = [[]]
         groups.each { group ->
             if (group == null || group.isEmpty()) return // neutral OR-branch, skip
+            int nextSize = combinations.size() * group.size()
+            if (nextSize > MAX_DNF_COMBINATIONS) {
+                throw new IllegalArgumentException(
+                    "Conditional step with invertLogic expands to more than ${MAX_DNF_COMBINATIONS} " +
+                    "condition combinations. Reduce the number of condition groups or conditions per group."
+                )
+            }
             List<List> next = []
             combinations.each { partial -> group.each { cond -> next.add(partial + [cond]) } }
             combinations = next

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
@@ -286,14 +286,50 @@ class ExecutionUtilService {
     }
 
     /**
+     * Normalize a ConditionalSet to standard OR-of-ANDs (DNF) form so it can be safely combined
+     * by {@link #combineConditionSets}, which assumes both inputs are in that form.
+     * If invertLogic is false, the set is already in this form and is returned unchanged.
+     * If invertLogic is true (AND-of-ORs: groups=[[A,B],[C,D]] meaning (A OR B) AND (C OR D)),
+     * distributes AND over OR to produce the equivalent DNF: the Cartesian product across
+     * groups, picking exactly one condition from each group per combination.
+     * @param set The condition set to normalize (can be null)
+     * @return An equivalent ConditionalSet with invertLogic == false, or the original if already normalized/null
+     */
+    private ConditionalSet normalizeToDnf(ConditionalSet set) {
+        if (set == null || !set.isInvertLogic()) return set
+        def groups = set.conditionGroups
+        if (groups == null || groups.isEmpty()) return set
+
+        List<List> combinations = [[]]
+        groups.each { group ->
+            if (group == null || group.isEmpty()) return // neutral OR-branch, skip
+            List<List> next = []
+            combinations.each { partial -> group.each { cond -> next.add(partial + [cond]) } }
+            combinations = next
+        }
+
+        def normalized = new org.rundeck.app.data.workflow.ConditionalSetImpl()
+        normalized.nodeStep = set.nodeStep
+        normalized.invertLogic = false
+        normalized.conditionGroups = combinations
+        return normalized
+    }
+
+    /**
      * Combine two ConditionalSets using Cartesian product of OR groups to implement AND logic.
      * Example: Parent [A, B] + Child [C, D] → Combined [A+C, A+D, B+C, B+D]
      * All conditions in a group must be true (AND), at least one group must match (OR)
+     * Both inputs are normalized to DNF (OR-of-ANDs) form via {@link #normalizeToDnf} before
+     * combining, so the result is always in standard OR-of-ANDs form with invertLogic == false,
+     * regardless of whether either input had invertLogic set.
      * @param parent parent conditional set (may be null)
      * @param child child conditional set (may be null)
      * @return combined conditional set, or the non-null input if one is null
      */
     private ConditionalSet combineConditionSets(ConditionalSet parent, ConditionalSet child) {
+        parent = normalizeToDnf(parent)
+        child = normalizeToDnf(child)
+
         if (parent == null) return child
         if (child == null) return parent
 

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/workflow/ConditionalSetImpl.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/workflow/ConditionalSetImpl.groovy
@@ -13,6 +13,7 @@ import org.rundeck.app.data.model.v1.job.workflow.ConditionalSet
 class ConditionalSetImpl implements ConditionalSet {
     List<List<ConditionalDefinition>> conditionGroups
     boolean nodeStep
+    boolean invertLogic
 
     private final ConditionalSet dataModelConditionalSet;
 
@@ -27,6 +28,7 @@ class ConditionalSetImpl implements ConditionalSet {
         this.dataModelConditionalSet = dataModelConditionalSet;
         this.conditionGroups = dataModelConditionalSet.conditionGroups;
         this.nodeStep = dataModelConditionalSet.isNodeStep();
+        this.invertLogic = dataModelConditionalSet.isInvertLogic();
     }
 
     /**
@@ -64,6 +66,7 @@ class ConditionalSetImpl implements ConditionalSet {
             }
             condSet.conditionGroups = groups
             condSet.nodeStep = setMap.nodeStep == true
+            condSet.invertLogic = setMap.invertLogic == true
         }
         return condSet
     }
@@ -98,6 +101,7 @@ class ConditionalSetImpl implements ConditionalSet {
             }
             map.conditionGroups = groups
             map.nodeStep = nodeStep
+            map.invertLogic = invertLogic
         }
         return map
     }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/workflow/ConditionalStep.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/workflow/ConditionalStep.groovy
@@ -26,6 +26,7 @@ class ConditionalStep implements WorkflowStepData, Validateable {
     Boolean keepgoingOnSuccess
     String description
     Boolean nodeStep
+    Boolean invertLogic
 
     static constraints = {
         importFrom SharedWorkflowStepConstraints
@@ -117,6 +118,7 @@ class ConditionalStep implements WorkflowStepData, Validateable {
 
         def step = new ConditionalStep()
         step.nodeStep = stepMap.nodeStep ?: false
+        step.invertLogic = stepMap.invertLogic ?: false
         step.description = stepMap.description
         step.keepgoingOnSuccess = stepMap.keepgoingOnSuccess
 
@@ -231,7 +233,7 @@ class ConditionalStep implements WorkflowStepData, Validateable {
      * @return Map representation
      */
     Map toMap() {
-        def map = [type: pluginType, nodeStep: nodeStep]
+        def map = [type: pluginType, nodeStep: nodeStep, invertLogic: invertLogic]
 
         if (configuration) {
             map.configuration = configuration

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/workflow/ConditionalStep.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/workflow/ConditionalStep.groovy
@@ -26,7 +26,7 @@ class ConditionalStep implements WorkflowStepData, Validateable {
     Boolean keepgoingOnSuccess
     String description
     Boolean nodeStep
-    Boolean invertLogic
+    Boolean invertLogic = false
 
     static constraints = {
         importFrom SharedWorkflowStepConstraints

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/workflow/WorkflowDataWorkflowExecutionItemFactory.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/workflow/WorkflowDataWorkflowExecutionItemFactory.groovy
@@ -105,6 +105,12 @@ class WorkflowDataWorkflowExecutionItemFactory implements WorkflowExecutionItemF
     }
 
     /**
+     * Upper bound on the number of combinations {@link #normalizeToDnf} may generate, to guard
+     * against combinatorial (Cartesian product) blowup from a pathological invertLogic condition set.
+     */
+    private static final int MAX_DNF_COMBINATIONS = 256
+
+    /**
      * Normalize a ConditionalSet to standard OR-of-ANDs (DNF) form so it can be safely combined
      * by {@link #combineConditionSets}, which assumes both inputs are in that form.
      * If invertLogic is false, the set is already in this form and is returned unchanged.
@@ -113,6 +119,7 @@ class WorkflowDataWorkflowExecutionItemFactory implements WorkflowExecutionItemF
      * groups, picking exactly one condition from each group per combination.
      * @param set The condition set to normalize (can be null)
      * @return An equivalent ConditionalSet with invertLogic == false, or the original if already normalized/null
+     * @throws IllegalArgumentException if expanding to DNF would exceed {@link #MAX_DNF_COMBINATIONS}
      */
     private ConditionalSet normalizeToDnf(ConditionalSet set) {
         if (set == null || !set.isInvertLogic()) return set
@@ -122,6 +129,13 @@ class WorkflowDataWorkflowExecutionItemFactory implements WorkflowExecutionItemF
         List<List> combinations = [[]]
         groups.each { group ->
             if (group == null || group.isEmpty()) return // neutral OR-branch, skip
+            int nextSize = combinations.size() * group.size()
+            if (nextSize > MAX_DNF_COMBINATIONS) {
+                throw new IllegalArgumentException(
+                    "Conditional step with invertLogic expands to more than ${MAX_DNF_COMBINATIONS} " +
+                    "condition combinations. Reduce the number of condition groups or conditions per group."
+                )
+            }
             List<List> next = []
             combinations.each { partial -> group.each { cond -> next.add(partial + [cond]) } }
             combinations = next

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/workflow/WorkflowDataWorkflowExecutionItemFactory.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/workflow/WorkflowDataWorkflowExecutionItemFactory.groovy
@@ -105,12 +105,48 @@ class WorkflowDataWorkflowExecutionItemFactory implements WorkflowExecutionItemF
     }
 
     /**
+     * Normalize a ConditionalSet to standard OR-of-ANDs (DNF) form so it can be safely combined
+     * by {@link #combineConditionSets}, which assumes both inputs are in that form.
+     * If invertLogic is false, the set is already in this form and is returned unchanged.
+     * If invertLogic is true (AND-of-ORs: groups=[[A,B],[C,D]] meaning (A OR B) AND (C OR D)),
+     * distributes AND over OR to produce the equivalent DNF: the Cartesian product across
+     * groups, picking exactly one condition from each group per combination.
+     * @param set The condition set to normalize (can be null)
+     * @return An equivalent ConditionalSet with invertLogic == false, or the original if already normalized/null
+     */
+    private ConditionalSet normalizeToDnf(ConditionalSet set) {
+        if (set == null || !set.isInvertLogic()) return set
+        def groups = set.conditionGroups
+        if (groups == null || groups.isEmpty()) return set
+
+        List<List> combinations = [[]]
+        groups.each { group ->
+            if (group == null || group.isEmpty()) return // neutral OR-branch, skip
+            List<List> next = []
+            combinations.each { partial -> group.each { cond -> next.add(partial + [cond]) } }
+            combinations = next
+        }
+
+        def normalized = new ConditionalSetImpl()
+        normalized.nodeStep = set.nodeStep
+        normalized.invertLogic = false
+        normalized.conditionGroups = combinations
+        return normalized
+    }
+
+    /**
      * Combine two ConditionalSets using AND logic (Cartesian product of OR groups).
+     * Both inputs are normalized to DNF (OR-of-ANDs) form via {@link #normalizeToDnf} before
+     * combining, so the result is always in standard OR-of-ANDs form with invertLogic == false,
+     * regardless of whether either input had invertLogic set.
      * @param parent Parent condition set (can be null)
      * @param child Child condition set (can be null)
      * @return Combined condition set, or null if both are null
      */
     private ConditionalSet combineConditionSets(ConditionalSet parent, ConditionalSet child) {
+        parent = normalizeToDnf(parent)
+        child = normalizeToDnf(child)
+
         if (parent == null) return child
         if (child == null) return parent
 

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/workflow/ConditionalSetSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/workflow/ConditionalSetSpec.groovy
@@ -247,6 +247,71 @@ class ConditionalSetSpec extends Specification {
         }
     }
 
+    def "ConditionalSetImpl fromMap reads invertLogic true"() {
+        given:
+        def setMap = [
+            conditionGroups: [
+                [
+                    [key: 'option.env', operator: '==', value: 'prod']
+                ]
+            ],
+            nodeStep: false,
+            invertLogic: true
+        ]
+
+        when:
+        ConditionalSet condSet = new ConditionalSetImpl().fromMap(setMap)
+
+        then:
+        condSet.invertLogic == true
+    }
+
+    def "ConditionalSetImpl fromMap defaults invertLogic to false when absent"() {
+        given:
+        def setMap = [
+            conditionGroups: [
+                [
+                    [key: 'option.env', operator: '==', value: 'prod']
+                ]
+            ],
+            nodeStep: false
+        ]
+
+        when:
+        ConditionalSet condSet = new ConditionalSetImpl().fromMap(setMap)
+
+        then:
+        condSet.invertLogic == false
+    }
+
+    def "ConditionalSetImpl toMap serializes invertLogic"() {
+        given:
+        def condDef = ConditionalDefinitionImpl.fromMap([key: 'option.env', operator: '==', value: 'prod'])
+        ConditionalSetImpl condSet = new ConditionalSetImpl()
+        condSet.conditionGroups = [[condDef]]
+        condSet.invertLogic = true
+
+        when:
+        def map = condSet.toMap()
+
+        then:
+        map.invertLogic == true
+    }
+
+    def "ConditionalSetImpl fromDataModel copies invertLogic"() {
+        given:
+        def condDef = ConditionalDefinitionImpl.fromMap([key: 'option.env', operator: '==', value: 'prod'])
+        def dataModelSet = new ConditionalSetImpl()
+        dataModelSet.conditionGroups = [[condDef]]
+        dataModelSet.invertLogic = true
+
+        when:
+        ConditionalSet result = ConditionalSetImpl.fromDataModel(dataModelSet)
+
+        then:
+        result.invertLogic == true
+    }
+
     def "ConditionalSetImpl fromMap handles ConditionalDefinition objects in groups"() {
         given:
         def condDef = ConditionalDefinitionImpl.fromMap([key: 'option.env', operator: '==', value: 'prod'])

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/workflow/ConditionalStepSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/workflow/ConditionalStepSpec.groovy
@@ -510,6 +510,97 @@ class ConditionalStepSpec extends Specification implements DataTest {
         nestedStep.subSteps[0].errorHandler != null
     }
 
+    def "ConditionalStep fromMap reads invertLogic and propagates it to conditionSet"() {
+        given:
+        def stepMap = [
+            conditionGroups: [
+                [
+                    [key: 'option.env', operator: '==', value: 'prod']
+                ]
+            ],
+            subSteps: [
+                [type: 'exec', exec: 'echo test']
+            ],
+            invertLogic: true
+        ]
+
+        when:
+        ConditionalStep step = ConditionalStep.fromMap(stepMap)
+
+        then:
+        step.invertLogic == true
+        step.conditionSet.invertLogic == true
+    }
+
+    def "ConditionalStep toMap serializes invertLogic at top level"() {
+        given:
+        def condDef = ConditionalDefinitionImpl.fromMap([key: 'option.env', operator: '==', value: 'prod'])
+        def condSet = new ConditionalSetImpl()
+        condSet.conditionGroups = [[condDef]]
+        condSet.invertLogic = true
+
+        ConditionalStep step = new ConditionalStep()
+        step.conditionSet = condSet
+        step.subSteps = [new CommandExec(adhocRemoteString: 'echo test')]
+        step.invertLogic = true
+
+        when:
+        def map = step.toMap()
+
+        then:
+        map.invertLogic == true
+    }
+
+    def "ConditionalStep round-trip fromMap(toMap()) preserves invertLogic"() {
+        given:
+        def stepMap = [
+            conditionGroups: [
+                [
+                    [key: 'option.env', operator: '==', value: 'prod']
+                ]
+            ],
+            subSteps: [
+                [type: 'exec', exec: 'echo test']
+            ],
+            invertLogic: true
+        ]
+
+        when:
+        ConditionalStep step = ConditionalStep.fromMap(stepMap)
+        Map exportedMap = step.toMap()
+        ConditionalStep roundTripped = ConditionalStep.fromMap(exportedMap)
+
+        then:
+        exportedMap.invertLogic == true
+        roundTripped.invertLogic == true
+        roundTripped.conditionSet.invertLogic == true
+    }
+
+    def "ConditionalStep fromMap on legacy map lacking invertLogic defaults to false (backward compatibility)"() {
+        given: "a legacy job definition map with no invertLogic key at all"
+        def legacyStepMap = [
+            conditionGroups: [
+                [
+                    [key: 'option.env', operator: '==', value: 'prod'],
+                    [key: 'option.region', operator: '==', value: 'us-east']
+                ]
+            ],
+            subSteps: [
+                [type: 'exec', exec: 'echo test']
+            ],
+            nodeStep: false
+        ]
+
+        when:
+        ConditionalStep step = ConditionalStep.fromMap(legacyStepMap)
+
+        then: "invertLogic defaults to false and AND-within/OR-across semantics are unchanged"
+        step.invertLogic == false
+        step.conditionSet.invertLogic == false
+        step.conditionSet.conditionGroups.size() == 1
+        step.conditionSet.conditionGroups[0].size() == 2
+    }
+
     def "ConditionalStep validation fails with two levels of nesting (depth=2)"() {
         given: "A conditional with nested conditionals 2 levels deep"
         def condSet = new ConditionalSetImpl()

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/workflow/WorkflowDataWorkflowExecutionItemFactoryConditionalSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/workflow/WorkflowDataWorkflowExecutionItemFactoryConditionalSpec.groovy
@@ -559,6 +559,31 @@ class WorkflowDataWorkflowExecutionItemFactoryConditionalSpec extends Specificat
         combined.conditionGroups[0] == [envProd, regionEast]
     }
 
+    def "consolidateWorkflowSteps rejects invertLogic condition set that would expand beyond the DNF combination limit"() {
+        given: "invertLogic=true with two groups of 17 conditions each (17*17=289 > 256 combination limit)"
+        featureService.featurePresent(Features.EARLY_ACCESS_JOB_CONDITIONAL) >> true
+
+        def group1 = (1..17).collect { ConditionalDefinitionImpl.fromMap([key: 'option.a', operator: '==', value: "v${it}"]) }
+        def group2 = (1..17).collect { ConditionalDefinitionImpl.fromMap([key: 'option.b', operator: '==', value: "v${it}"]) }
+        def condSet = new ConditionalSetImpl()
+        condSet.conditionGroups = [group1, group2]
+        condSet.invertLogic = true
+
+        def conditionalStep = new ConditionalStep()
+        conditionalStep.conditionSet = condSet
+        conditionalStep.subSteps = [new CommandExec(adhocRemoteString: 'echo test')]
+
+        def workflow = new WorkflowDataImpl()
+        workflow.steps = [conditionalStep]
+
+        when:
+        factory.createExecutionItemForWorkflow(workflow)
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("more than 256")
+    }
+
     def "consolidateWorkflowSteps preserves step order with nested conditionals"() {
         given:
         featureService.featurePresent(Features.EARLY_ACCESS_JOB_CONDITIONAL) >> true

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/workflow/WorkflowDataWorkflowExecutionItemFactoryConditionalSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/workflow/WorkflowDataWorkflowExecutionItemFactoryConditionalSpec.groovy
@@ -405,6 +405,160 @@ class WorkflowDataWorkflowExecutionItemFactoryConditionalSpec extends Specificat
         stepItem.conditions.conditionGroups[0]*.key == ['option.env', 'option.region']
     }
 
+    def "consolidateWorkflowSteps normalizes to DNF when inverted parent combines with plain child"() {
+        given: "outer (invertLogic=true): (env==prod OR env==staging) AND (region==us-east OR region==us-west); inner (plain): status==ok"
+        featureService.featurePresent(Features.EARLY_ACCESS_JOB_CONDITIONAL) >> true
+
+        def envProd = ConditionalDefinitionImpl.fromMap([key: 'option.env', operator: '==', value: 'prod'])
+        def envStaging = ConditionalDefinitionImpl.fromMap([key: 'option.env', operator: '==', value: 'staging'])
+        def regionEast = ConditionalDefinitionImpl.fromMap([key: 'option.region', operator: '==', value: 'us-east'])
+        def regionWest = ConditionalDefinitionImpl.fromMap([key: 'option.region', operator: '==', value: 'us-west'])
+        def outerCondSet = new ConditionalSetImpl()
+        outerCondSet.conditionGroups = [[envProd, envStaging], [regionEast, regionWest]]
+        outerCondSet.invertLogic = true
+
+        def statusOk = ConditionalDefinitionImpl.fromMap([key: 'option.status', operator: '==', value: 'ok'])
+        def innerCondSet = new ConditionalSetImpl()
+        innerCondSet.conditionGroups = [[statusOk]]
+
+        def innerConditionalStep = new ConditionalStep()
+        innerConditionalStep.conditionSet = innerCondSet
+        innerConditionalStep.subSteps = [new CommandExec(adhocRemoteString: 'echo nested')]
+
+        def outerConditionalStep = new ConditionalStep()
+        outerConditionalStep.conditionSet = outerCondSet
+        outerConditionalStep.subSteps = [innerConditionalStep]
+
+        def workflow = new WorkflowDataImpl()
+        workflow.steps = [outerConditionalStep]
+
+        when:
+        def result = factory.createExecutionItemForWorkflow(workflow)
+
+        then:
+        result.workflow.commands.size() == 1
+        def combined = result.workflow.commands[0].conditions
+        combined.invertLogic == false
+        // DNF of outer: (prod AND east), (prod AND west), (staging AND east), (staging AND west) -- 4 combinations
+        // each ANDed with the plain inner group -> 4 groups of 3 conditions each
+        combined.conditionGroups.size() == 4
+        combined.conditionGroups.every { it.size() == 3 }
+        combined.conditionGroups.every { it.contains(statusOk) }
+    }
+
+    def "consolidateWorkflowSteps normalizes to DNF when plain parent combines with inverted child"() {
+        given: "outer (plain): env==prod; inner (invertLogic=true): (status==ok OR status==warn) AND (region==us-east OR region==us-west)"
+        featureService.featurePresent(Features.EARLY_ACCESS_JOB_CONDITIONAL) >> true
+
+        def envProd = ConditionalDefinitionImpl.fromMap([key: 'option.env', operator: '==', value: 'prod'])
+        def outerCondSet = new ConditionalSetImpl()
+        outerCondSet.conditionGroups = [[envProd]]
+
+        def statusOk = ConditionalDefinitionImpl.fromMap([key: 'option.status', operator: '==', value: 'ok'])
+        def statusWarn = ConditionalDefinitionImpl.fromMap([key: 'option.status', operator: '==', value: 'warn'])
+        def regionEast = ConditionalDefinitionImpl.fromMap([key: 'option.region', operator: '==', value: 'us-east'])
+        def regionWest = ConditionalDefinitionImpl.fromMap([key: 'option.region', operator: '==', value: 'us-west'])
+        def innerCondSet = new ConditionalSetImpl()
+        innerCondSet.conditionGroups = [[statusOk, statusWarn], [regionEast, regionWest]]
+        innerCondSet.invertLogic = true
+
+        def innerConditionalStep = new ConditionalStep()
+        innerConditionalStep.conditionSet = innerCondSet
+        innerConditionalStep.subSteps = [new CommandExec(adhocRemoteString: 'echo nested')]
+
+        def outerConditionalStep = new ConditionalStep()
+        outerConditionalStep.conditionSet = outerCondSet
+        outerConditionalStep.subSteps = [innerConditionalStep]
+
+        def workflow = new WorkflowDataImpl()
+        workflow.steps = [outerConditionalStep]
+
+        when:
+        def result = factory.createExecutionItemForWorkflow(workflow)
+
+        then:
+        result.workflow.commands.size() == 1
+        def combined = result.workflow.commands[0].conditions
+        combined.invertLogic == false
+        combined.conditionGroups.size() == 4
+        combined.conditionGroups.every { it.size() == 3 }
+        combined.conditionGroups.every { it.contains(envProd) }
+    }
+
+    def "consolidateWorkflowSteps normalizes to DNF when both parent and child are inverted"() {
+        given: "outer (invertLogic=true): env==prod OR env==staging (single group); inner (invertLogic=true): status==ok OR status==warn (single group)"
+        featureService.featurePresent(Features.EARLY_ACCESS_JOB_CONDITIONAL) >> true
+
+        def envProd = ConditionalDefinitionImpl.fromMap([key: 'option.env', operator: '==', value: 'prod'])
+        def envStaging = ConditionalDefinitionImpl.fromMap([key: 'option.env', operator: '==', value: 'staging'])
+        def outerCondSet = new ConditionalSetImpl()
+        outerCondSet.conditionGroups = [[envProd, envStaging]]
+        outerCondSet.invertLogic = true
+
+        def statusOk = ConditionalDefinitionImpl.fromMap([key: 'option.status', operator: '==', value: 'ok'])
+        def statusWarn = ConditionalDefinitionImpl.fromMap([key: 'option.status', operator: '==', value: 'warn'])
+        def innerCondSet = new ConditionalSetImpl()
+        innerCondSet.conditionGroups = [[statusOk, statusWarn]]
+        innerCondSet.invertLogic = true
+
+        def innerConditionalStep = new ConditionalStep()
+        innerConditionalStep.conditionSet = innerCondSet
+        innerConditionalStep.subSteps = [new CommandExec(adhocRemoteString: 'echo nested')]
+
+        def outerConditionalStep = new ConditionalStep()
+        outerConditionalStep.conditionSet = outerCondSet
+        outerConditionalStep.subSteps = [innerConditionalStep]
+
+        def workflow = new WorkflowDataImpl()
+        workflow.steps = [outerConditionalStep]
+
+        when:
+        def result = factory.createExecutionItemForWorkflow(workflow)
+
+        then:
+        result.workflow.commands.size() == 1
+        def combined = result.workflow.commands[0].conditions
+        combined.invertLogic == false
+        // each side normalizes to a single-group DNF with 2 combinations (its own OR-group, one condition each)
+        // Cartesian merge: 2 (outer DNF groups) x 2 (inner DNF groups) = 4 groups of 2 conditions each
+        combined.conditionGroups.size() == 4
+        combined.conditionGroups.every { it.size() == 2 }
+    }
+
+    def "consolidateWorkflowSteps combine path unaffected when neither side is inverted (regression)"() {
+        given:
+        featureService.featurePresent(Features.EARLY_ACCESS_JOB_CONDITIONAL) >> true
+
+        def envProd = ConditionalDefinitionImpl.fromMap([key: 'option.env', operator: '==', value: 'prod'])
+        def outerCondSet = new ConditionalSetImpl()
+        outerCondSet.conditionGroups = [[envProd]]
+
+        def regionEast = ConditionalDefinitionImpl.fromMap([key: 'option.region', operator: '==', value: 'us-east'])
+        def innerCondSet = new ConditionalSetImpl()
+        innerCondSet.conditionGroups = [[regionEast]]
+
+        def innerConditionalStep = new ConditionalStep()
+        innerConditionalStep.conditionSet = innerCondSet
+        innerConditionalStep.subSteps = [new CommandExec(adhocRemoteString: 'echo nested')]
+
+        def outerConditionalStep = new ConditionalStep()
+        outerConditionalStep.conditionSet = outerCondSet
+        outerConditionalStep.subSteps = [innerConditionalStep]
+
+        def workflow = new WorkflowDataImpl()
+        workflow.steps = [outerConditionalStep]
+
+        when:
+        def result = factory.createExecutionItemForWorkflow(workflow)
+
+        then:
+        result.workflow.commands.size() == 1
+        def combined = result.workflow.commands[0].conditions
+        combined.invertLogic == false
+        combined.conditionGroups.size() == 1
+        combined.conditionGroups[0] == [envProd, regionEast]
+    }
+
     def "consolidateWorkflowSteps preserves step order with nested conditionals"() {
         given:
         featureService.featurePresent(Features.EARLY_ACCESS_JOB_CONDITIONAL) >> true

--- a/rundeckapp/src/test/groovy/rundeck/services/ExecutionUtilServiceConditionalSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ExecutionUtilServiceConditionalSpec.groovy
@@ -594,6 +594,118 @@ class ExecutionUtilServiceConditionalSpec extends Specification implements Servi
         cmd.conditions.conditionGroups.every { it.size() == 2 }
     }
 
+    def "consolidateWorkflowSteps normalizes to DNF when inverted parent combines with plain child"() {
+        given: "outer (invertLogic=true): (env==prod OR env==staging) AND (region==us-east OR region==us-west); inner (plain): status==ok"
+        service.featureService.featurePresent(Features.EARLY_ACCESS_JOB_CONDITIONAL) >> true
+
+        def envProd = ConditionalDefinitionImpl.fromMap([key: 'option.env', operator: '==', value: 'prod'])
+        def envStaging = ConditionalDefinitionImpl.fromMap([key: 'option.env', operator: '==', value: 'staging'])
+        def regionEast = ConditionalDefinitionImpl.fromMap([key: 'option.region', operator: '==', value: 'us-east'])
+        def regionWest = ConditionalDefinitionImpl.fromMap([key: 'option.region', operator: '==', value: 'us-west'])
+        def outerCondSet = new ConditionalSetImpl()
+        outerCondSet.conditionGroups = [[envProd, envStaging], [regionEast, regionWest]]
+        outerCondSet.invertLogic = true
+
+        def statusOk = ConditionalDefinitionImpl.fromMap([key: 'option.status', operator: '==', value: 'ok'])
+        def innerCondSet = new ConditionalSetImpl()
+        innerCondSet.conditionGroups = [[statusOk]]
+
+        def innerConditional = new ConditionalStep()
+        innerConditional.conditionSet = innerCondSet
+        innerConditional.subSteps = [new CommandExec(adhocRemoteString: 'echo nested')]
+
+        def outerConditional = new ConditionalStep()
+        outerConditional.conditionSet = outerCondSet
+        outerConditional.subSteps = [innerConditional]
+
+        def workflow = new WorkflowDataImpl()
+        workflow.steps = [outerConditional]
+
+        when:
+        def result = service.createExecutionItemForWorkflow(workflow, 'testProject')
+
+        then:
+        result.workflow.commands.size() == 1
+        def combined = result.workflow.commands[0].conditions
+        combined.invertLogic == false
+        // DNF of outer: (prod AND east), (prod AND west), (staging AND east), (staging AND west) -- 4 combinations
+        combined.conditionGroups.size() == 4
+        combined.conditionGroups.every { it.size() == 3 }
+        combined.conditionGroups.every { it.contains(statusOk) }
+    }
+
+    def "consolidateWorkflowSteps normalizes to DNF when both parent and child are inverted"() {
+        given: "outer (invertLogic=true): env==prod OR env==staging (single group); inner (invertLogic=true): status==ok OR status==warn (single group)"
+        service.featureService.featurePresent(Features.EARLY_ACCESS_JOB_CONDITIONAL) >> true
+
+        def envProd = ConditionalDefinitionImpl.fromMap([key: 'option.env', operator: '==', value: 'prod'])
+        def envStaging = ConditionalDefinitionImpl.fromMap([key: 'option.env', operator: '==', value: 'staging'])
+        def outerCondSet = new ConditionalSetImpl()
+        outerCondSet.conditionGroups = [[envProd, envStaging]]
+        outerCondSet.invertLogic = true
+
+        def statusOk = ConditionalDefinitionImpl.fromMap([key: 'option.status', operator: '==', value: 'ok'])
+        def statusWarn = ConditionalDefinitionImpl.fromMap([key: 'option.status', operator: '==', value: 'warn'])
+        def innerCondSet = new ConditionalSetImpl()
+        innerCondSet.conditionGroups = [[statusOk, statusWarn]]
+        innerCondSet.invertLogic = true
+
+        def innerConditional = new ConditionalStep()
+        innerConditional.conditionSet = innerCondSet
+        innerConditional.subSteps = [new CommandExec(adhocRemoteString: 'echo nested')]
+
+        def outerConditional = new ConditionalStep()
+        outerConditional.conditionSet = outerCondSet
+        outerConditional.subSteps = [innerConditional]
+
+        def workflow = new WorkflowDataImpl()
+        workflow.steps = [outerConditional]
+
+        when:
+        def result = service.createExecutionItemForWorkflow(workflow, 'testProject')
+
+        then:
+        result.workflow.commands.size() == 1
+        def combined = result.workflow.commands[0].conditions
+        combined.invertLogic == false
+        combined.conditionGroups.size() == 4
+        combined.conditionGroups.every { it.size() == 2 }
+    }
+
+    def "consolidateWorkflowSteps combine path unaffected when neither side is inverted (regression)"() {
+        given:
+        service.featureService.featurePresent(Features.EARLY_ACCESS_JOB_CONDITIONAL) >> true
+
+        def envProd = ConditionalDefinitionImpl.fromMap([key: 'option.env', operator: '==', value: 'prod'])
+        def outerCondSet = new ConditionalSetImpl()
+        outerCondSet.conditionGroups = [[envProd]]
+
+        def regionEast = ConditionalDefinitionImpl.fromMap([key: 'option.region', operator: '==', value: 'us-east'])
+        def innerCondSet = new ConditionalSetImpl()
+        innerCondSet.conditionGroups = [[regionEast]]
+
+        def innerConditional = new ConditionalStep()
+        innerConditional.conditionSet = innerCondSet
+        innerConditional.subSteps = [new CommandExec(adhocRemoteString: 'echo nested')]
+
+        def outerConditional = new ConditionalStep()
+        outerConditional.conditionSet = outerCondSet
+        outerConditional.subSteps = [innerConditional]
+
+        def workflow = new WorkflowDataImpl()
+        workflow.steps = [outerConditional]
+
+        when:
+        def result = service.createExecutionItemForWorkflow(workflow, 'testProject')
+
+        then:
+        result.workflow.commands.size() == 1
+        def combined = result.workflow.commands[0].conditions
+        combined.invertLogic == false
+        combined.conditionGroups.size() == 1
+        combined.conditionGroups[0] == [envProd, regionEast]
+    }
+
     def "consolidateWorkflowSteps throws exception for nesting depth >= 2"() {
         given: "A workflow with 2-level nested conditionals"
         service.featureService.featurePresent(Features.EARLY_ACCESS_JOB_CONDITIONAL) >> true

--- a/rundeckapp/src/test/groovy/rundeck/services/ExecutionUtilServiceConditionalSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ExecutionUtilServiceConditionalSpec.groovy
@@ -706,6 +706,31 @@ class ExecutionUtilServiceConditionalSpec extends Specification implements Servi
         combined.conditionGroups[0] == [envProd, regionEast]
     }
 
+    def "consolidateWorkflowSteps rejects invertLogic condition set that would expand beyond the DNF combination limit"() {
+        given: "invertLogic=true with two groups of 17 conditions each (17*17=289 > 256 combination limit)"
+        service.featureService.featurePresent(Features.EARLY_ACCESS_JOB_CONDITIONAL) >> true
+
+        def group1 = (1..17).collect { ConditionalDefinitionImpl.fromMap([key: 'option.a', operator: '==', value: "v${it}"]) }
+        def group2 = (1..17).collect { ConditionalDefinitionImpl.fromMap([key: 'option.b', operator: '==', value: "v${it}"]) }
+        def condSet = new ConditionalSetImpl()
+        condSet.conditionGroups = [group1, group2]
+        condSet.invertLogic = true
+
+        def conditionalStep = new ConditionalStep()
+        conditionalStep.conditionSet = condSet
+        conditionalStep.subSteps = [new CommandExec(adhocRemoteString: 'echo test')]
+
+        def workflow = new WorkflowDataImpl()
+        workflow.steps = [conditionalStep]
+
+        when:
+        service.createExecutionItemForWorkflow(workflow, 'testProject')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("more than 256")
+    }
+
     def "consolidateWorkflowSteps throws exception for nesting depth >= 2"() {
         given: "A workflow with 2-level nested conditionals"
         service.featureService.featurePresent(Features.EARLY_ACCESS_JOB_CONDITIONAL) >> true


### PR DESCRIPTION
## Jira Ticket

[RUN-4646](https://pagerduty.atlassian.net/browse/RUN-4646)

## Summary

Add a toggle to the Conditional workflow step that reverses its default condition-grouping logic, from AND-within-a-set/OR-across-sets to OR-within-a-set/AND-across-sets, and wire it end-to-end through the backend (data model, evaluator, job definition serialization).

- `ConditionalSet` gains `isInvertLogic()`; `ConditionalSetImpl`/`ConditionalStep` add an `invertLogic` boolean field (default `false`, unset jobs unaffected) threaded through `fromMap`/`toMap`.
- `ConditionalEvaluator` honors the flag: `true` evaluates conditions within a group as OR and groups as AND; `false`/unset preserves current behavior.
- `ExecutionUtilService` (the live job-execution flattening/combine path) and `WorkflowDataWorkflowExecutionItemFactory` (the validation-time path) both normalize nested condition sets to DNF before combining parent/child conditionals, so combined sets are always evaluated correctly regardless of either side's polarity.

## Related PR

- rundeckpro PR: (added once opened)

## Testing

- Unit tests added/updated in `ConditionalEvaluatorSpec`, `ConditionalSetSpec`, `ConditionalStepSpec`, `WorkflowDataWorkflowExecutionItemFactoryConditionalSpec`, `ExecutionUtilServiceConditionalSpec`.
- Manually verified via Rundeck MCP against a local dev instance: created and validated a job with `invertLogic: true`, confirmed round-trip through YAML export.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

[RUN-4646]: https://pagerduty.atlassian.net/browse/RUN-4646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ