### PR TITLE
[RUN-4722] Recognize JDBC/native Jetty JAAS role principals

### DIFF
--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -66,6 +66,21 @@
     ;
 {% endmacro %}
 
+{% macro JDBCLoginModule() %}
+    org.eclipse.jetty.security.jaas.spi.JDBCLoginModule {{ getv("/rundeck/jaas/jdbc/flag", "required") }}
+        debug="{{ getv("/rundeck/jaas/jdbc/debug", "true") }}"
+        dbDriver="{{ getv("/rundeck/jaas/jdbc/dbdriver") }}"
+        dbUrl="{{ getv("/rundeck/jaas/jdbc/dburl") }}"
+        dbUserName="{{ getv("/rundeck/jaas/jdbc/dbusername", "") }}"
+        dbPassword="{{ getv("/rundeck/jaas/jdbc/dbpassword", "") }}"
+        userTable="{{ getv("/rundeck/jaas/jdbc/usertable") }}"
+        userField="{{ getv("/rundeck/jaas/jdbc/userfield") }}"
+        credentialField="{{ getv("/rundeck/jaas/jdbc/credentialfield") }}"
+        userRoleTable="{{ getv("/rundeck/jaas/jdbc/userroletable") }}"
+        userRoleUserField="{{ getv("/rundeck/jaas/jdbc/userroleuserfield") }}"
+        userRoleRoleField="{{ getv("/rundeck/jaas/jdbc/userrolerolefield") }}";
+{% endmacro %}
+
 {% macro PropertyFileLoginModule(module) %}
     {% if module == "PropertyFileLoginModule" %}
     org.rundeck.jaas.{{module}} 
@@ -85,6 +100,8 @@ rundeck {
             {{ JettyCachingLdapLoginModule("JettyCachingLdapLoginModule") }}
         {% elif module == "JettyCombinedLdapLoginModule" -%}
             {{ JettyCachingLdapLoginModule("JettyCombinedLdapLoginModule") }}
+        {% elif module == "JDBCLoginModule" -%}
+            {{ JDBCLoginModule() }}
         {% elif module == "ReloadablePropertyFileLoginModule" -%}
             {{ PropertyFileLoginModule("ReloadablePropertyFileLoginModule") }}
         {% elif module == "PropertyFileLoginModule" -%}

--- a/functional-test/build.gradle
+++ b/functional-test/build.gradle
@@ -181,3 +181,13 @@ task ldapTest(type: Test){
     systemProperty('spock.configuration', 'spock-configs/IncludeLdapTestsConfig.groovy')
     description = "Run Rundeck OSS LDAP Tests"
 }
+
+task jdbcTest(type: Test){
+    useJUnitPlatform()
+    // Grails 7: Force sequential execution to prevent Docker Compose port conflicts
+    maxParallelForks = 1
+    systemProperty("TEST_IMAGE", "rundeck/rundeck:SNAPSHOT")
+    systemProperty("COMPOSE_PATH", "docker/jdbc/docker-compose.yml")
+    systemProperty('spock.configuration', 'spock-configs/IncludeJdbcTestsConfig.groovy')
+    description = "Run Rundeck OSS JAAS JDBCLoginModule Tests"
+}

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/jdbc/JdbcRolesApiSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/jdbc/JdbcRolesApiSpec.groovy
@@ -1,0 +1,65 @@
+package org.rundeck.tests.functional.api.jdbc
+
+import okhttp3.FormBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.rundeck.util.annotations.JdbcTest
+import org.rundeck.util.api.common.CustomCookieJar
+import org.rundeck.util.container.BaseContainer
+
+/**
+ * Regression test for GH-10423: JDBC JAAS users must have roles in their authorization
+ * Subject after login.
+ *
+ * org.eclipse.jetty.security.jaas.spi.JDBCLoginModule adds role principals to the Subject
+ * as org.eclipse.jetty.security.jaas.JAASRole, not org.rundeck.jaas.RundeckRole. Before the
+ * fix in RundeckJaasAuthorityGranter.grant(), only RundeckRole principals were recognized,
+ * so JDBC users authenticated successfully but ended up with zero granted roles.
+ * Verifies via POST to j_security_check then GET /api/user/roles with the session cookie.
+ */
+@JdbcTest
+class JdbcRolesApiSpec extends BaseContainer {
+
+    static final String JDBC_USER = "jdbctest"
+    static final String JDBC_PASS = "jdbctest"
+    static final List<String> EXPECTED_ROLES = ["admin", "user", "architect", "build", "deploy"]
+
+    def "JDBC user roles are populated in Subject after session login"() {
+        given: "a session-based HTTP client that stores cookies"
+        def cookieJar = new CustomCookieJar()
+        def sessionClient = new OkHttpClient.Builder()
+                .cookieJar(cookieJar)
+                .build()
+
+        when: "the JDBC user logs in via j_security_check"
+        try (def warmupResponse = sessionClient.newCall(new Request.Builder()
+                .url(client.baseUrl)
+                .get()
+                .build()).execute()) {
+            warmupResponse.body().string()
+        }
+        try (def loginResponse = sessionClient.newCall(new Request.Builder()
+                .url("${client.baseUrl}/j_security_check")
+                .post(new FormBody.Builder()
+                        .add("j_username", JDBC_USER)
+                        .add("j_password", JDBC_PASS)
+                        .build())
+                .build()).execute()) {
+            loginResponse.body().string()
+        }
+
+        and: "the roles endpoint is called with the session cookie"
+        def roles
+        try (def rolesResponse = sessionClient.newCall(new Request.Builder()
+                .url("${client.baseUrl}/api/${client.apiVersion}/user/roles")
+                .get()
+                .build()).execute()) {
+            assert rolesResponse.code() == 200: "Roles endpoint returned ${rolesResponse.code()} — login may have failed"
+            roles = (MAPPER.readValue(rolesResponse.body().string(), Map).roles ?: []) as List
+        }
+
+        then: "the JDBC user has the expected group roles — not an empty list"
+        !roles.isEmpty()
+        roles.containsAll(EXPECTED_ROLES)
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/util/annotations/JdbcTest.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/annotations/JdbcTest.groovy
@@ -1,0 +1,12 @@
+package org.rundeck.util.annotations
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Target([ElementType.TYPE, ElementType.METHOD])
+@Retention(RetentionPolicy.RUNTIME)
+@interface JdbcTest {
+
+}

--- a/functional-test/src/test/resources/docker/jdbc/Dockerfile
+++ b/functional-test/src/test/resources/docker/jdbc/Dockerfile
@@ -1,0 +1,2 @@
+ARG IMAGE
+FROM ${IMAGE}

--- a/functional-test/src/test/resources/docker/jdbc/docker-compose.yml
+++ b/functional-test/src/test/resources/docker/jdbc/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+  rundeck:
+    build:
+      context: "."
+      args:
+        IMAGE: ${TEST_IMAGE}
+    platform: ${TEST_TARGET_PLATFORM:-linux/amd64}
+    links:
+      - jdbc-db
+    environment:
+      RUNDECK_MULTIURL_ENABLED: "true"
+      RUNDECK_GRAILS_URL: ${TEST_RUNDECK_GRAILS_URL}
+      RUNDECK_DATABASE_DRIVER: org.mariadb.jdbc.Driver
+      RUNDECK_DATABASE_USERNAME: rundeck
+      RUNDECK_DATABASE_PASSWORD: rundeck
+      RUNDECK_DATABASE_URL: jdbc:mysql://jdbc-db/rundeck?autoReconnect=true&useSSL=false&allowPublicKeyRetrieval=true
+      RUNDECK_JAAS_MODULES_0: JDBCLoginModule
+      RUNDECK_JAAS_JDBC_DBDRIVER: org.mariadb.jdbc.Driver
+      RUNDECK_JAAS_JDBC_DBURL: jdbc:mysql://jdbc-db/rundeck?autoReconnect=true&useSSL=false&allowPublicKeyRetrieval=true
+      RUNDECK_JAAS_JDBC_DBUSERNAME: rundeck
+      RUNDECK_JAAS_JDBC_DBPASSWORD: rundeck
+      RUNDECK_JAAS_JDBC_USERTABLE: jaas_users
+      RUNDECK_JAAS_JDBC_USERFIELD: username
+      RUNDECK_JAAS_JDBC_CREDENTIALFIELD: password
+      RUNDECK_JAAS_JDBC_USERROLETABLE: jaas_roles
+      RUNDECK_JAAS_JDBC_USERROLEUSERFIELD: username
+      RUNDECK_JAAS_JDBC_USERROLEROLEFIELD: role
+    volumes:
+      - "/etc/localtime:/etc/localtime:ro"
+      - "/etc/timezone:/etc/timezone:ro"
+    ports:
+      - "4440:4440"
+
+  jdbc-db:
+    image: mysql:8.4
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=rundeck
+      - MYSQL_USER=rundeck
+      - MYSQL_PASSWORD=rundeck
+    volumes:
+      - ./sql:/docker-entrypoint-initdb.d:ro

--- a/functional-test/src/test/resources/docker/jdbc/sql/01-jaas-schema.sql
+++ b/functional-test/src/test/resources/docker/jdbc/sql/01-jaas-schema.sql
@@ -1,0 +1,24 @@
+-- Test fixture for GH-10423: org.eclipse.jetty.security.jaas.spi.JDBCLoginModule
+-- reads credentials/roles from these tables, entirely independent of Rundeck's own
+-- domain schema (login_user, rduser, ...), which is created afterwards by Liquibase
+-- against the same `rundeck` database.
+
+CREATE TABLE jaas_users (
+    username VARCHAR(255) NOT NULL PRIMARY KEY,
+    password VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE jaas_roles (
+    username VARCHAR(255) NOT NULL,
+    role VARCHAR(255) NOT NULL,
+    PRIMARY KEY (username, role)
+);
+
+INSERT INTO jaas_users (username, password) VALUES ('jdbctest', 'jdbctest');
+
+INSERT INTO jaas_roles (username, role) VALUES
+    ('jdbctest', 'admin'),
+    ('jdbctest', 'user'),
+    ('jdbctest', 'architect'),
+    ('jdbctest', 'build'),
+    ('jdbctest', 'deploy');

--- a/functional-test/src/test/resources/spock-configs/IncludeJdbcTestsConfig.groovy
+++ b/functional-test/src/test/resources/spock-configs/IncludeJdbcTestsConfig.groovy
@@ -1,0 +1,5 @@
+import org.rundeck.util.annotations.JdbcTest
+
+runner {
+    include JdbcTest
+}

--- a/rundeckapp/src/main/groovy/org/rundeck/security/RundeckJaasAuthorityGranter.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/security/RundeckJaasAuthorityGranter.groovy
@@ -32,7 +32,7 @@ class RundeckJaasAuthorityGranter implements AuthorityGranter {
         // The class-name check covers role principals added directly by native Jetty JAAS SPI
         // login modules (e.g. JDBCLoginModule's org.eclipse.jetty.security.jaas.JAASRole), which
         // never produce a RundeckRole. See ContainerPrincipalRoleSource for the same convention.
-        if (principal instanceof RundeckRole || principal.class.name.contains('Role')) {
+        if (principal instanceof RundeckRole || principal?.class?.name?.endsWith('Role')) {
             return [rolePrefix + principal.name] as Set
         } else {
             return null

--- a/rundeckapp/src/main/groovy/org/rundeck/security/RundeckJaasAuthorityGranter.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/security/RundeckJaasAuthorityGranter.groovy
@@ -28,12 +28,15 @@ class RundeckJaasAuthorityGranter implements AuthorityGranter {
 
     @Override
     Set<String> grant(final Principal principal) {
-        if( principal instanceof RundeckRole){
-            return [rolePrefix+ principal.name] as Set
-        }else{
+        // RundeckRole covers Rundeck's own AbstractLoginModule subclasses (property file, LDAP).
+        // The class-name check covers role principals added directly by native Jetty JAAS SPI
+        // login modules (e.g. JDBCLoginModule's org.eclipse.jetty.security.jaas.JAASRole), which
+        // never produce a RundeckRole. See ContainerPrincipalRoleSource for the same convention.
+        if (principal instanceof RundeckRole || principal.class.name.contains('Role')) {
+            return [rolePrefix + principal.name] as Set
+        } else {
             return null
         }
-
     }
 
     public String getRolePrefix() { return rolePrefix }

--- a/rundeckapp/src/test/groovy/org/rundeck/security/RundeckJaasAuthorityGranterTest.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/security/RundeckJaasAuthorityGranterTest.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.rundeck.security
+
+import org.rundeck.jaas.RundeckPrincipal
+import org.rundeck.jaas.RundeckRole
+import spock.lang.Specification
+
+import java.security.Principal
+
+class RundeckJaasAuthorityGranterTest extends Specification {
+
+    def "grants RundeckRole principals"() {
+        given:
+        RundeckJaasAuthorityGranter granter = new RundeckJaasAuthorityGranter()
+
+        when:
+        def result = granter.grant(new RundeckRole("admin"))
+
+        then:
+        result == ["ROLE_admin"] as Set
+    }
+
+    def "grants role-like principals from native Jetty JAAS SPI login modules (e.g. JDBCLoginModule)"() {
+        given: "a Principal whose class name follows the *Role convention, mirroring org.eclipse.jetty.security.jaas.JAASRole"
+        RundeckJaasAuthorityGranter granter = new RundeckJaasAuthorityGranter()
+
+        when:
+        def result = granter.grant(new FakeJAASRole("dataadmin"))
+
+        then:
+        result == ["ROLE_dataadmin"] as Set
+    }
+
+    def "does not grant non-role principals"() {
+        given:
+        RundeckJaasAuthorityGranter granter = new RundeckJaasAuthorityGranter()
+
+        when:
+        def result = granter.grant(new RundeckPrincipal("someuser"))
+
+        then:
+        result == null
+    }
+
+    def "honors a custom rolePrefix"() {
+        given:
+        RundeckJaasAuthorityGranter granter = new RundeckJaasAuthorityGranter()
+        granter.setRolePrefix("CUSTOM_")
+
+        expect:
+        granter.grant(new RundeckRole("admin")) == ["CUSTOM_admin"] as Set
+        granter.grant(new FakeJAASRole("dataadmin")) == ["CUSTOM_dataadmin"] as Set
+    }
+
+    static class FakeJAASRole implements Principal {
+        private final String name
+
+        FakeJAASRole(String name) {
+            this.name = name
+        }
+
+        @Override
+        String getName() {
+            return name
+        }
+    }
+}


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Bugfix. Fixes #10423.

`RundeckJaasAuthorityGranter.grant()` (the only `AuthorityGranter` Rundeck registers with
Spring Security's JAAS provider) only recognized `org.rundeck.jaas.RundeckRole` principals.
Any login module that never goes through `org.rundeck.jaas.AbstractLoginModule` — notably
Jetty's own native `org.eclipse.jetty.security.jaas.spi.JDBCLoginModule`, configured directly
in `jaas-loginmodule.conf` — adds role principals as `org.eclipse.jetty.security.jaas.JAASRole`
instead. Since `grant()` returned `null` for those, users authenticated successfully via JDBC
JAAS but were granted zero roles, so every project access was rejected
(`REJECTED_NO_SUBJECT_OR_ENV_FOUND`, "You have no authorized access to projects").

Verified locally end-to-end: reproduced the exact symptom against a real MySQL-backed
`JDBCLoginModule` config, confirmed the fix resolves it, and confirmed no regression against
the related LDAP fix in #10308 (`AbstractLoginModule.commit()`/`logout()`), which covers a
different code path (Rundeck's own LDAP subclasses that override `login()`).

**Describe the solution you've implemented**
`RundeckJaasAuthorityGranter.grant()` now also recognizes role principals by class-name
convention (`*Role`), in addition to the existing `RundeckRole` check — mirroring the same
convention already used by `ContainerPrincipalRoleSource` for container-managed auth. This
covers `JDBCLoginModule` and any other native Jetty JAAS SPI module (`LdapLoginModule`,
`PropertyFileLoginModule`) used directly, without reintroducing a hard compile dependency on
`jetty-jaas` (deliberately removed — Jetty 12 folded that support into `jetty-security`).

Also added:
- A `JDBCLoginModule` branch to the official Docker image's remco JAAS template
  (`docker/official/remco/templates/jaas-loginmodule.conf`), which previously had no support
  for this module at all.
- A new functional test task `:functional-test:jdbcTest` (`JdbcRolesApiSpec`), modeled on the
  existing `:functional-test:ldapTest` (`LdapRolesApiSpec`) from #10308: spins up Rundeck with
  `JDBCLoginModule` against a real MySQL container seeded with `jaas_users`/`jaas_roles`
  tables, logs in via `j_security_check`, and asserts `/api/{version}/user/roles` returns the
  expected roles instead of an empty list.
- A unit test (`RundeckJaasAuthorityGranterTest`) covering `RundeckRole`, a simulated native
  Jetty role principal, a non-role principal, and the custom `rolePrefix`.

**Describe alternatives you've considered**
Re-adding `org.eclipse.jetty:jetty-jaas` as a dependency and doing
`instanceof org.eclipse.jetty.security.jaas.JAASRole` directly. Rejected: that artifact no
longer exists as a separate module in Jetty 12 (its classes moved into `jetty-security`,
already a dependency), and a hardcoded `instanceof` on one Jetty package is exactly the kind
of brittleness that caused this regression in the first place (see commit `5c01e5b7fa`, which
narrowed the original `org.eclipse.jetty.jaas.JAASRole` check to `RundeckRole` only). The
class-name convention is more robust to future Jetty package renames and already has
precedent in this codebase.

**Additional context**
- Fixes #10423.
- Related to #10288 / #10308, which fixed the analogous LDAP case in a different code path
  (`AbstractLoginModule`). This PR fixes the counterpart for login modules that bypass that
  class entirely.

## Release Notes

Fixed a bug where users authenticating via JAAS with a native Jetty login module (e.g.
`JDBCLoginModule`) could log in successfully but were assigned no roles, blocking all project
access. Roles are now correctly granted for these login modules, matching the behavior already
restored for LDAP in 6.0.1.
