### PR TITLE
[RUN-4756] Show conditional substeps in Definition modal

### DIFF
--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -231,6 +231,7 @@ Workflow.stepErrorHandler.description=The error handler will execute if the step
 Workflow.stepErrorHandler.title=Error Handler
 Workflow.stepErrorHandler.keepgoingOnSuccess.label=Keep going on success.
 Workflow.stepErrorHandler.keepgoingOnSuccess.description=If the Workflow keepgoing is false, this allows the Workflow to continue when the Error Handler is successful
+Workflow.conditional.subSteps.label=Sub-steps\:
 Workflow.stepErrorHandler.label.on.error=on error\:
 Workflow.stepErrorHandler.label.keep.going.on.success=keep going on success
 Workflow.stepErrorHandler.label.choose.the.type=Click on a Step type to add an Error Handler

--- a/rundeckapp/grails-app/views/execution/_wflistContent.gsp
+++ b/rundeckapp/grails-app/views/execution/_wflistContent.gsp
@@ -20,12 +20,23 @@
     Created: Jul 27, 2010 2:18:34 PM
     $Id$
  --%>
+<%@ page import="org.rundeck.app.data.workflow.ConditionalStep" %>
 <g:if test="${workflow && workflow?.commands}">
 <g:each in="${workflow.commands}" var="item" status="i">
     <li class="${i%2==1?'alternate':''} draggableitem droppableitem" data-wfitemnum="${i}">
         <div id="wfli_${i}">
         <g:render template="/execution/wflistitemContent" model="${[i:i,stepNum: i,item:item,workflow:workflow,edit:edit,highlight:highlight,noimgs:noimgs, project: project]}"/>
         </div>
+        <g:if test="${!edit && item instanceof ConditionalStep && item.subSteps}">
+            <g:render template="/execution/wflistSubStepsContent"
+                      model="${[steps: item.subSteps,
+                                  workflow: workflow,
+                                  edit: edit,
+                                  noimgs: noimgs,
+                                  project: project,
+                                  idPrefix: 'sub_' + i + '_',
+                                  labelPrefix: (i + 1) as String]}"/>
+        </g:if>
         <g:if test="${item.errorHandler}">
             <ul class="wfhandleritem ${item.errors?.hasFieldErrors('errorHandler') ? 'fieldError' : ''}">
 

--- a/rundeckapp/grails-app/views/execution/_wflistSubStepsContent.gsp
+++ b/rundeckapp/grails-app/views/execution/_wflistSubStepsContent.gsp
@@ -1,0 +1,64 @@
+%{--
+  - Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  --}%
+<%@ page import="org.rundeck.app.data.workflow.ConditionalStep" %>
+<div class="wfsubstepsgroup">
+    <span class="wfsubstepsheading text-strong"><g:message code="Workflow.conditional.subSteps.label"/></span>
+    <ul class="wfsubstepsitem">
+        <g:each in="${steps}" var="subItem" status="j">
+            <g:set var="subStepLabel" value="${labelPrefix ? labelPrefix + '.' + (j + 1) : (j + 1)}"/>
+            <li class="wfsubstep-entry" id="wfli_${enc(attr:idPrefix)}${j}">
+                <span class="wfsubstep-label text-muted"><g:enc>${subStepLabel}</g:enc>.</span>
+                <g:render template="/execution/wflistitemContent"
+                          model="${[i: idPrefix + j,
+                                      stepNum: null,
+                                      item: subItem,
+                                      workflow: workflow,
+                                      edit: edit,
+                                      highlight: null,
+                                      noimgs: noimgs,
+                                      project: project]}"/>
+
+                <g:if test="${subItem instanceof ConditionalStep && subItem.subSteps}">
+                    <g:render template="/execution/wflistSubStepsContent"
+                              model="${[steps: subItem.subSteps,
+                                          workflow: workflow,
+                                          edit: edit,
+                                          noimgs: noimgs,
+                                          project: project,
+                                          idPrefix: idPrefix + j + '_',
+                                          labelPrefix: subStepLabel]}"/>
+                </g:if>
+
+                <g:if test="${subItem.errorHandler}">
+                    <ul class="wfhandleritem">
+                        <li id="wfli_eh_${enc(attr:idPrefix)}${j}">
+                            <g:render template="/execution/wflistitemContent"
+                                      model="${[i: 'eh_' + idPrefix + j,
+                                                  stepNum: null,
+                                                  item: subItem.errorHandler,
+                                                  workflow: workflow,
+                                                  edit: edit,
+                                                  highlight: null,
+                                                  noimgs: noimgs,
+                                                  project: project,
+                                                  isErrorHandler: true]}"/>
+                        </li>
+                    </ul>
+                </g:if>
+            </li>
+        </g:each>
+    </ul>
+</div>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/custom/process-flow.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/custom/process-flow.scss
@@ -23,6 +23,51 @@ div {
           margin-bottom: 0;
         }
       }
+
+      .wfsubstepsgroup {
+        margin-top: 6px;
+        padding-left: 0;
+      }
+
+      .wfsubstep-entry .wfsubstepsgroup {
+        margin-top: 4px;
+        margin-left: 4px;
+      }
+
+      .wfsubstepsheading {
+        display: block;
+        margin: 0 0 4px 8px;
+        font-size: 12px;
+        color: var(--text-muted-color, #6c757d);
+      }
+
+      ul.wfsubstepsitem {
+        list-style: none;
+        padding: 0 0 0 8px;
+        margin: 0;
+      }
+
+      ul.wfsubstepsitem > li.wfsubstep-entry {
+        margin-left: 8px !important;
+        margin-bottom: 4px !important;
+        padding: 2px 0 2px 10px !important;
+        border: none !important;
+        border-left: 2px solid var(--list-item-border-color, #dee2e6) !important;
+        border-radius: 0 !important;
+        background: transparent !important;
+      }
+
+      .wfsubstep-label {
+        display: inline;
+        margin-right: 6px;
+        font-size: 12px;
+      }
+
+      ul.wfhandleritem {
+        list-style: none;
+        padding: 0 0 0 8px;
+        margin: 0;
+      }
     }
 
     &.edit {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/custom/process-flow.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/custom/process-flow.scss
@@ -48,13 +48,13 @@ div {
       }
 
       ul.wfsubstepsitem > li.wfsubstep-entry {
-        margin-left: 8px !important;
-        margin-bottom: 4px !important;
+        margin-left: 8px;
+        margin-bottom: 4px;
         padding: 2px 0 2px 10px !important;
-        border: none !important;
-        border-left: 2px solid var(--list-item-border-color, #dee2e6) !important;
-        border-radius: 0 !important;
-        background: transparent !important;
+        border: none;
+        border-left: 2px solid var(--list-item-border-color, #dee2e6);
+        border-radius: 0;
+        background: transparent;
       }
 
       .wfsubstep-label {
@@ -63,7 +63,7 @@ div {
         font-size: 12px;
       }
 
-      ul.wfhandleritem {
+      .wfsubstepsgroup ul.wfhandleritem {
         list-style: none;
         padding: 0 0 0 8px;
         margin: 0;


### PR DESCRIPTION


Syntax customer feedback: Definition tab only showed top-level conditional steps. Render nested substeps with Sub-steps label and 2.1-style numbering in read-only workflow view, matching design feedback for nested conditionals.

<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Bugfix — Syntax reported that the Definition modal on job show only displays top-level conditional steps and does not show substeps inside the conditional.
When viewing a job’s Definition tab, workflows with conditional steps only showed the conditional step itself (e.g. description nested-2), not the commands/jobs nested inside it. Customers could not read the full workflow structure from Definition.

This change renders conditional substeps in the read-only workflow list (legacy GSP), including nested conditionals, with clear hierarchy numbering per design feedback.



**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

- In _wflistContent.gsp, when edit is false and the step is a ConditionalStep with subSteps, render a new partial _wflistSubStepsContent.gsp.
- Recursive partial lists substeps under Sub-steps: with hierarchical labels (2.1, 2.1.1, etc.) based on the parent step number.
- Substep error handlers still use the existing on error: pattern.
- Scoped to read-only Definition (!edit) so the legacy job edit workflow UI is unchanged.
- Styling in process-flow.scss (nested list, left border, inline numbering) aligned with existing Definition / error-handler patterns.
- i18n: Workflow.conditional.subSteps.label=Sub-steps:
- Note: This does not add the workflow editor “If” UI from Figma; Definition still uses the legacy GSP view and shows step descriptions, not condition expressions.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

- Ticket: RUN-4756
- Customer: Syntax feedback (M3)
- UX: Design reviewed Option A (numbered substeps) vs simple nested list
- Test: Job with nested conditionals → Job show → Definition tab; verify substeps and numbering; confirm plain steps and error handlers unchanged
- ## Release Notes

<!-- If you have suggested content that would describe this PR to other Rundeck community users, please enter it here.-->