### PR TITLE
[PS-1689] Auto-enable Secure flag on JSESSIONID cookie for https deployments

### DIFF
--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -399,6 +399,9 @@ server:
             cookie:
                 http-only: true
                 same-site: "Lax"
+                # secure is intentionally left unset here: JettyServletContainerCustomizer auto-enables
+                # it when grails.serverURL uses https, so HTTP-only deployments keep working. Set this
+                # explicitly (true/false) to override that auto-detection.
             tracking-modes: 'cookie'
 rundeck:
     web:

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -923,6 +923,12 @@ beans={
         serverUrl = grailsApplication.config.getProperty('grails.serverURL', String.class)
     }
 
+    // HSTS is only ever added when the connector has a secure port configured (see
+    // JettyServletHstsCustomizer#checkSSL), so these properties only take effect for TLS deployments.
+    // A negative stsMaxAgeSeconds (the default) disables the Strict-Transport-Security header.
+    // For TLS-terminated-at-Rundeck deployments, operators should set:
+    //   rundeck.web.jetty.servlet.stsMaxAgeSeconds: 31536000 (1 year)
+    //   rundeck.web.jetty.servlet.stsIncludeSubdomains: true (only if all subdomains are also served over HTTPS)
     def stsMaxAgeSeconds = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsMaxAgeSeconds",Integer.class,-1)
     def stsIncludeSubdomains = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsIncludeSubdomains",Boolean.class,false)
     jettyServletHstsCustomizer(JettyServletHstsCustomizer,stsMaxAgeSeconds,stsIncludeSubdomains)

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
@@ -66,6 +66,28 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
         }
         factory.addConfigurations(new JettyConfigPropsInitParameterConfiguration(initParams))
         factory.useForwardHeaders=useForwardHeaders
+        applySecureSessionCookieDefault(factory)
+    }
+
+    /**
+     * Auto-enables the {@code Secure} flag on the session cookie when the configured
+     * {@code grails.serverURL} uses the {@code https} scheme, unless the operator has
+     * already set {@code server.servlet.session.cookie.secure} explicitly.
+     * @param factory the servlet web server factory being customized
+     */
+    void applySecureSessionCookieDefault(final JettyServletWebServerFactory factory) {
+        def cookie = factory.session?.cookie
+        if (cookie != null && cookie.secure == null && isHttpsUrl(serverUrl)) {
+            cookie.secure = true
+        }
+    }
+
+    /**
+     * @param url a URL string, may be null
+     * @return true if the URL scheme is {@code https} (case-insensitive)
+     */
+    static boolean isHttpsUrl(final String url) {
+        url != null && url.trim().toLowerCase().startsWith("https://")
     }
 }
 

--- a/rundeckapp/src/test/groovy/rundeckapp/init/servlet/JettyServletContainerCustomizerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeckapp/init/servlet/JettyServletContainerCustomizerSpec.groovy
@@ -1,0 +1,77 @@
+package rundeckapp.init.servlet
+
+import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class JettyServletContainerCustomizerSpec extends Specification {
+
+    def "applySecureSessionCookieDefault enables secure flag when serverUrl is https and cookie secure is unset"() {
+        given:
+        JettyServletContainerCustomizer customizer = new JettyServletContainerCustomizer(
+                serverUrl: 'https://rundeck.example.com/rundeck'
+        )
+        JettyServletWebServerFactory factory = new JettyServletWebServerFactory()
+
+        when:
+        customizer.applySecureSessionCookieDefault(factory)
+
+        then:
+        factory.session.cookie.secure == true
+    }
+
+    def "applySecureSessionCookieDefault leaves cookie secure unset when serverUrl is http"() {
+        given:
+        JettyServletContainerCustomizer customizer = new JettyServletContainerCustomizer(
+                serverUrl: 'http://rundeck.example.com/rundeck'
+        )
+        JettyServletWebServerFactory factory = new JettyServletWebServerFactory()
+
+        when:
+        customizer.applySecureSessionCookieDefault(factory)
+
+        then:
+        factory.session.cookie.secure == null
+    }
+
+    def "applySecureSessionCookieDefault does not override an explicit secure=false setting"() {
+        given:
+        JettyServletContainerCustomizer customizer = new JettyServletContainerCustomizer(
+                serverUrl: 'https://rundeck.example.com/rundeck'
+        )
+        JettyServletWebServerFactory factory = new JettyServletWebServerFactory()
+        factory.session.cookie.secure = false
+
+        when:
+        customizer.applySecureSessionCookieDefault(factory)
+
+        then:
+        factory.session.cookie.secure == false
+    }
+
+    def "applySecureSessionCookieDefault is a no-op when serverUrl is not set"() {
+        given:
+        JettyServletContainerCustomizer customizer = new JettyServletContainerCustomizer(serverUrl: null)
+        JettyServletWebServerFactory factory = new JettyServletWebServerFactory()
+
+        when:
+        customizer.applySecureSessionCookieDefault(factory)
+
+        then:
+        factory.session.cookie.secure == null
+    }
+
+    @Unroll
+    def "isHttpsUrl(#url) == #expected"() {
+        expect:
+        JettyServletContainerCustomizer.isHttpsUrl(url) == expected
+
+        where:
+        url                                     | expected
+        'https://rundeck.example.com/rundeck'   | true
+        'HTTPS://rundeck.example.com/rundeck'   | true
+        'http://rundeck.example.com/rundeck'    | false
+        null                                    | false
+        ''                                      | false
+    }
+}


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Security bugfix. Ref: [PS-1689](https://pagerduty.atlassian.net/browse/PS-1689) — the `JSESSIONID` cookie is set with `HttpOnly` and `SameSite=Lax` but never `Secure`. On an HTTP-served instance (default `server.port: 4440`, default `http://` `serverURL`, HSTS off by default), the session cookie can be transmitted in cleartext and captured by an on-path attacker.

**Describe the solution you've implemented**
- `JettyServletContainerCustomizer` now auto-enables the `Secure` flag on the session cookie when `grails.serverURL` uses `https`, unless the operator has already set `server.servlet.session.cookie.secure` explicitly (that setting is respected either way). This fixes TLS deployments without breaking default HTTP-only deployments (forcing `Secure` unconditionally would stop the cookie being sent back to the browser over `http://`, breaking login).
- Added `JettyServletContainerCustomizerSpec` covering: https → secure enabled, http → unchanged, explicit `secure: false` respected, no `serverUrl` configured, and the `isHttpsUrl` scheme parsing helper.
- Added a comment in `application.yml` documenting the auto-detection behavior and how to override it.
- Documented the existing (previously unexplained) `rundeck.web.jetty.servlet.stsMaxAgeSeconds` / `stsIncludeSubdomains` properties in `resources.groovy`, including recommended values for TLS deployments, and clarified that HSTS is only ever added when the connector has a secure port (per `JettyServletHstsCustomizer#checkSSL`).

**Describe alternatives you've considered**
- Setting `server.servlet.session.cookie.secure: true` unconditionally in `application.yml` — rejected because it would break the still-common default HTTP-only deployment (browser won't return a `Secure` cookie over plain HTTP, breaking session/login).
- Changing the default HSTS `stsMaxAgeSeconds` from `-1` to a positive value for all TLS deployments — rejected as out of scope for this PR; forcing HSTS on by default is a larger behavior change (risk of lockout if TLS is later misconfigured/rolled back) that deserves its own discussion. Left as documented, opt-in guidance instead.
- Hardening-guide documentation update (remediation item 3 from the finding) — the hardening guide lives in the separate `rundeck-docs` repo, not in this codebase, so it's not included here.

**Additional context**
Verified locally: `./gradlew :rundeckapp:test --tests "rundeckapp.init.servlet.JettyServletContainerCustomizerSpec" --tests "rundeckapp.init.servlet.JettyServletHstsCustomizerSpec"` — 13 tests, 0 failures.

## Release Notes
Session cookies are now automatically marked `Secure` when Rundeck's configured server URL uses `https`, closing a gap where session cookies could be transmitted over an insecure connection. HTTP-only deployments are unaffected.

[PS-1689]: https://pagerduty.atlassian.net/browse/PS-1689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ