### PR TITLE
[RUN-4792] Suppress spurious BeanPostProcessorChecker startup warnings

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -187,6 +187,7 @@ import rundeck.services.workflow.DefaultStateExecutionFileProducer
 import rundeck.services.workflow.DefaultWorkflowStateDataLoader
 import rundeckapp.init.ExternalStaticResourceConfigurer
 import rundeckapp.init.PluginCachePreloader
+import rundeckapp.init.InfrastructureRoleBeanDefinitionRegistryPostProcessor
 import rundeckapp.init.RundeckConfigReloader
 import rundeckapp.init.RundeckExtendedMessageBundle
 import rundeckapp.init.servlet.JettyServletContainerCustomizer
@@ -220,6 +221,11 @@ beans={
             advisor('pointcut-ref': "rdAuthProjectAclInterceptorPointcut", 'advice-ref': "rdAuthorizeInterceptor")
         }
     }
+
+    // Marks the rdAuth* advisors above (and a couple of Grails plugin infrastructure beans) as
+    // ROLE_INFRASTRUCTURE so Spring's BeanPostProcessorChecker doesn't log spurious startup warnings
+    // for them. See the class Javadoc for details.
+    infrastructureRoleBeanDefinitionRegistryPostProcessor(InfrastructureRoleBeanDefinitionRegistryPostProcessor)
 
     rdAuthorizeInterceptor(RdAuthorizeInterceptor)
     rundeckWebDefaultParameterNamesMapper(RdWebDefaultParameterNamesMapper) {

--- a/rundeckapp/grails-app/init/rundeckapp/init/InfrastructureRoleBeanDefinitionRegistryPostProcessor.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/InfrastructureRoleBeanDefinitionRegistryPostProcessor.groovy
@@ -56,10 +56,10 @@ class InfrastructureRoleBeanDefinitionRegistryPostProcessor implements BeanDefin
      * should also be marked as infrastructure role. These are Grails plugin-owned beans
      * (grails-async, grails-events) that this application never declares or overrides directly.
      */
-    static final List<String> ADDITIONAL_INFRASTRUCTURE_BEAN_NAMES = [
+    private static final Set<String> ADDITIONAL_INFRASTRUCTURE_BEAN_NAMES = Collections.unmodifiableSet([
             'grailsPromiseFactory',
             'grailsEventBus',
-    ]
+    ] as Set)
 
     @Override
     void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {

--- a/rundeckapp/grails-app/init/rundeckapp/init/InfrastructureRoleBeanDefinitionRegistryPostProcessor.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/InfrastructureRoleBeanDefinitionRegistryPostProcessor.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rundeckapp.init
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.springframework.aop.support.DefaultBeanFactoryPointcutAdvisor
+import org.springframework.beans.BeansException
+import org.springframework.beans.factory.config.BeanDefinition
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor
+
+/**
+ * Marks the {@code rdAuth*} AOP advisor beans declared in {@code resources.groovy}, along with the
+ * Grails async/event-bus infrastructure beans ({@code grailsPromiseFactory}, {@code grailsEventBus}),
+ * with {@link BeanDefinition#ROLE_INFRASTRUCTURE}.
+ *
+ * <p>Without this, Spring's {@code PostProcessorRegistrationDelegate$BeanPostProcessorChecker} logs
+ * spurious startup warnings for these beans, e.g.:
+ * <pre>
+ * Bean 'org.springframework.aop.support.DefaultBeanFactoryPointcutAdvisor#0' ... is not eligible for
+ * getting processed by all BeanPostProcessors ... Is this bean getting eagerly injected/applied to a
+ * currently created BeanPostProcessor [meterRegistryPostProcessor]?
+ * </pre>
+ * This happens because Spring Boot's method-validation support ({@code methodValidationPostProcessor})
+ * and Micrometer's metrics auto-configuration ({@code meterRegistryPostProcessor}) both require an early
+ * {@link org.springframework.context.ApplicationContext} reference, forcing them to instantiate before
+ * the full BeanPostProcessor chain is registered. Any other bean already registered at that point gets
+ * flagged as "not eligible for post-processing" collateral, even though none of the affected beans here
+ * (AOP advisor plumbing, Grails' internal async/event-bus factories) are ever expected to be
+ * auto-proxied themselves, so marking them as infrastructure-role is safe and does not change runtime
+ * behavior — it only suppresses the diagnostic.
+ *
+ * @see BeanDefinition#ROLE_INFRASTRUCTURE
+ */
+@Slf4j
+@CompileStatic
+class InfrastructureRoleBeanDefinitionRegistryPostProcessor implements BeanDefinitionRegistryPostProcessor {
+
+    /**
+     * Bean names, beyond the auto-detected {@link DefaultBeanFactoryPointcutAdvisor} advisors, that
+     * should also be marked as infrastructure role. These are Grails plugin-owned beans
+     * (grails-async, grails-events) that this application never declares or overrides directly.
+     */
+    static final List<String> ADDITIONAL_INFRASTRUCTURE_BEAN_NAMES = [
+            'grailsPromiseFactory',
+            'grailsEventBus',
+    ]
+
+    @Override
+    void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+        int markedCount = 0
+        for (String beanName : registry.getBeanDefinitionNames()) {
+            BeanDefinition definition = registry.getBeanDefinition(beanName)
+            if (definition.beanClassName == DefaultBeanFactoryPointcutAdvisor.name ||
+                    beanName in ADDITIONAL_INFRASTRUCTURE_BEAN_NAMES) {
+                definition.role = BeanDefinition.ROLE_INFRASTRUCTURE
+                markedCount++
+                log.debug(
+                        "Marked bean [{}] (type [{}]) as ROLE_INFRASTRUCTURE to suppress " +
+                                "BeanPostProcessorChecker startup warning",
+                        beanName,
+                        definition.beanClassName
+                )
+            }
+        }
+        log.debug("Marked {} bean definitions as ROLE_INFRASTRUCTURE", markedCount)
+    }
+
+    @Override
+    void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        // no-op: all work is done in postProcessBeanDefinitionRegistry, before bean instantiation begins
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeckapp/init/InfrastructureRoleBeanDefinitionRegistryPostProcessorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeckapp/init/InfrastructureRoleBeanDefinitionRegistryPostProcessorSpec.groovy
@@ -86,7 +86,10 @@ class InfrastructureRoleBeanDefinitionRegistryPostProcessorSpec extends Specific
     }
 
     def "postProcessBeanFactory is a no-op"() {
-        expect:
-        processor.postProcessBeanFactory(null) == null
+        when:
+        processor.postProcessBeanFactory(null)
+
+        then:
+        noExceptionThrown()
     }
 }

--- a/rundeckapp/src/test/groovy/rundeckapp/init/InfrastructureRoleBeanDefinitionRegistryPostProcessorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeckapp/init/InfrastructureRoleBeanDefinitionRegistryPostProcessorSpec.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rundeckapp.init
+
+import org.springframework.aop.support.DefaultBeanFactoryPointcutAdvisor
+import org.springframework.beans.factory.config.BeanDefinition
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
+import org.springframework.beans.factory.support.GenericBeanDefinition
+import spock.lang.Specification
+
+class InfrastructureRoleBeanDefinitionRegistryPostProcessorSpec extends Specification {
+
+    def processor = new InfrastructureRoleBeanDefinitionRegistryPostProcessor()
+
+    def "DefaultBeanFactoryPointcutAdvisor beans are marked as ROLE_INFRASTRUCTURE"() {
+        given:
+        def advisorDef = new GenericBeanDefinition(beanClass: DefaultBeanFactoryPointcutAdvisor)
+        def registry = Stub(BeanDefinitionRegistry) {
+            getBeanDefinitionNames() >> ['org.springframework.aop.support.DefaultBeanFactoryPointcutAdvisor#0']
+            getBeanDefinition('org.springframework.aop.support.DefaultBeanFactoryPointcutAdvisor#0') >> advisorDef
+        }
+
+        when:
+        processor.postProcessBeanDefinitionRegistry(registry)
+
+        then:
+        advisorDef.role == BeanDefinition.ROLE_INFRASTRUCTURE
+    }
+
+    def "grailsPromiseFactory bean is marked as ROLE_INFRASTRUCTURE"() {
+        given:
+        def beanDef = new GenericBeanDefinition()
+        def registry = Stub(BeanDefinitionRegistry) {
+            getBeanDefinitionNames() >> ['grailsPromiseFactory']
+            getBeanDefinition('grailsPromiseFactory') >> beanDef
+        }
+
+        when:
+        processor.postProcessBeanDefinitionRegistry(registry)
+
+        then:
+        beanDef.role == BeanDefinition.ROLE_INFRASTRUCTURE
+    }
+
+    def "grailsEventBus bean is marked as ROLE_INFRASTRUCTURE"() {
+        given:
+        def beanDef = new GenericBeanDefinition()
+        def registry = Stub(BeanDefinitionRegistry) {
+            getBeanDefinitionNames() >> ['grailsEventBus']
+            getBeanDefinition('grailsEventBus') >> beanDef
+        }
+
+        when:
+        processor.postProcessBeanDefinitionRegistry(registry)
+
+        then:
+        beanDef.role == BeanDefinition.ROLE_INFRASTRUCTURE
+    }
+
+    def "unrelated beans are not modified"() {
+        given:
+        def beanDef = new GenericBeanDefinition(beanClass: String)
+        def registry = Stub(BeanDefinitionRegistry) {
+            getBeanDefinitionNames() >> ['someOtherBean']
+            getBeanDefinition('someOtherBean') >> beanDef
+        }
+
+        when:
+        processor.postProcessBeanDefinitionRegistry(registry)
+
+        then:
+        beanDef.role != BeanDefinition.ROLE_INFRASTRUCTURE
+    }
+
+    def "postProcessBeanFactory is a no-op"() {
+        expect:
+        processor.postProcessBeanFactory(null) == null
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `InfrastructureRoleBeanDefinitionRegistryPostProcessor`, a `BeanDefinitionRegistryPostProcessor` that marks the `rdAuth*` AOP advisor beans and Grails async/event-bus infrastructure beans (`grailsPromiseFactory`, `grailsEventBus`) as `ROLE_INFRASTRUCTURE` before bean instantiation begins.
- Registers the new bean in `resources.groovy`.
- This suppresses spurious startup warnings logged by Spring's `PostProcessorRegistrationDelegate$BeanPostProcessorChecker`, e.g.:
  ```
  Bean 'org.springframework.aop.support.DefaultBeanFactoryPointcutAdvisor#0' ... is not eligible for
  getting processed by all BeanPostProcessors ... Is this bean getting eagerly injected/applied to a
  currently created BeanPostProcessor [meterRegistryPostProcessor]?
  ```
  caused by Spring Boot's `methodValidationPostProcessor` and Micrometer's `meterRegistryPostProcessor` needing an early `ApplicationContext` reference, which forces them to instantiate before the full `BeanPostProcessor` chain is registered.
- No runtime behavior change — purely suppresses the diagnostic.

Jira: RUN-4792

## Test plan
- [ ] `./gradlew build -x check` succeeds
- [ ] Start Rundeck locally and confirm the `BeanPostProcessorChecker` warnings for the `rdAuth*` advisors / Grails infra beans no longer appear in startup logs