### PR TITLE
[RUN-0000] Bump plugin versions to latest releases

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -127,11 +127,11 @@ commonsLang3Version=3.20.0
 # Third-party plugin versions (org.rundeck.plugins bundled in Core)
 ansiblePluginVersion=5.0.3
 awsS3ModelSourceVersion=2.0.2
-pyWinrmPluginVersion=3.2.1
+pyWinrmPluginVersion=3.3.0
 opensshNodeExecutionVersion=3.0.1
 multilineRegexDatacaptureFilterVersion=2.0.2
 attributeMatchNodeEnhancerVersion=1.0.4
-sshjPluginVersion=1.0.4
+sshjPluginVersion=1.0.7
 jaxbApiVersion=2.3.1
 jaxbRuntimeVersion=2.3.9
 owaspHtmlSanitizerVersion=20260313.1


### PR DESCRIPTION
## What

Bumps the following bundled plugin versions to their latest GitHub Release:

| Plugin | Old | New |
|--------|-----|-----|
| [py-winrm-plugin](https://github.com/rundeck-plugins/py-winrm-plugin/releases/tag/3.3.0) | 3.2.1 | 3.3.0 |
| [sshj-plugin](https://github.com/rundeck-plugins/sshj-plugin/releases/tag/1.0.7) | 1.0.4 | 1.0.7 |

The other 5 plugins tracked in this repo's `*PluginVersion` properties (ansible-plugin, aws-s3-model-source, openssh-node-execution, multiline-regex-datacapture-filter, attribute-match-node-enhancer) were already at their latest release on `main` by the time this PR was opened - most likely already picked up via Renovate or a manual bump. Original PR description overclaimed all 7 due to a bug in the generating script (it read "current" values from a stale local branch instead of `origin/main`); corrected here to match the actual diff.

## Why

Generated by the rundeck-plugin-versions skill's pre-release sweep (scripts/bump-versions-pr.sh in rundeck-plugins/.github) - closes the gap between each plugin's latest release and what this repo has pinned. Review each version's own release notes before merging; this script does not evaluate functional/breaking-change impact itself.