### PR TITLE
[RUN-4533] Fix plaintext password storage in JettyCompatibleSpringSecurityPasswordEncoder

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/security/JettyCompatibleSpringSecurityPasswordEncoder.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/security/JettyCompatibleSpringSecurityPasswordEncoder.groovy
@@ -20,6 +20,9 @@ import org.rundeck.jaas.PasswordCredential
 import org.rundeck.jaas.jetty.BcryptCredentialProvider
 import org.springframework.security.crypto.password.PasswordEncoder
 
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
 /**
  * Password encoder compatible with Jetty password formats.
  * Updated for JAAS refactoring - uses org.rundeck.jaas.PasswordCredential
@@ -29,36 +32,53 @@ class JettyCompatibleSpringSecurityPasswordEncoder implements PasswordEncoder {
     String getUsername() {
         WebUtils.retrieveGrailsWebRequest().getCurrentRequest().getParameter("j_username")
     }
-    
+
+    /**
+     * Encodes a raw password using BCrypt, prefixed with {@code BCRYPT:} to match the
+     * format expected by the {@code BCRYPT:} branch of {@link #matches}.
+     * @param rawPassword the raw password to encode
+     * @return a {@code BCRYPT:}-prefixed hash, never the plaintext input
+     */
     @Override
     String encode(final CharSequence rawPassword) {
-        //does not encode password
-        return rawPassword
+        return BcryptCredentialProvider.BcryptCredential.encodePassword(rawPassword.toString())
     }
-    
+
+    /**
+     * Checks a raw password against an encoded password, dispatching on the encoded
+     * password's prefix ({@code MD5:}, {@code CRYPT:}, {@code OBF:}, {@code BCRYPT:}).
+     * Encoded passwords with no recognized prefix are compared as plaintext using a
+     * constant-time comparison.
+     * @param rawPass the raw password to check
+     * @param encPass the stored encoded (or plaintext) password
+     * @return true if the raw password matches
+     */
     @Override
     boolean matches(final CharSequence rawPass, final String encPass) {
         if(!encPass || !rawPass) return false
-        
+
         // Use PasswordCredential for MD5 and CRYPT
         if(encPass.startsWith("MD5:") || encPass.startsWith("CRYPT:")) {
             PasswordCredential credential = PasswordCredential.getCredential(encPass)
             return credential.check(rawPass.toString())
         }
-        
+
         // OBF format check - fall back to false (Jetty-specific, deprecated)
         if(encPass.startsWith("OBF:")) {
             // OBF format was Jetty-specific and is no longer supported
             // Passwords should be migrated to MD5, CRYPT, or BCRYPT
             return false
         }
-        
+
         // BCRYPT uses special provider
         if(encPass.startsWith("BCRYPT:")) {
             return new BcryptCredentialProvider().getCredential(encPass).check(rawPass)
         }
-        
-        // Plain text comparison
-        return encPass == rawPass
+
+        // Plain text comparison - constant-time to avoid leaking length/content via timing
+        return MessageDigest.isEqual(
+            encPass.getBytes(StandardCharsets.UTF_8),
+            rawPass.toString().getBytes(StandardCharsets.UTF_8)
+        )
     }
 }

--- a/rundeckapp/src/test/groovy/org/rundeck/security/JettyCompatibleSpringSecurityPasswordEncoderTest.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/security/JettyCompatibleSpringSecurityPasswordEncoderTest.groovy
@@ -63,4 +63,26 @@ class JettyCompatibleSpringSecurityPasswordEncoderTest extends Specification {
         !encoder.matches(null, "MD5:7ddf32e17a6ac5ce04a8ecbf782ca509")
         !encoder.matches("somepassword", null)
     }
+
+    def "encode() returns BCRYPT-prefixed hash, not plaintext"() {
+        given:
+        def raw = "supersecret"
+
+        when:
+        def encoded = encoder.encode(raw)
+
+        then:
+        encoded.startsWith("BCRYPT:")
+        encoded != raw
+    }
+
+    def "encode() output can be verified by matches()"() {
+        given:
+        def raw = "supersecret"
+        def encoded = encoder.encode(raw)
+
+        expect:
+        encoder.matches(raw, encoded)
+        !encoder.matches("wrongpassword", encoded)
+    }
 }


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Security bugfix. `JettyCompatibleSpringSecurityPasswordEncoder.encode()` returned the raw password unchanged (a no-op), and `matches()` fell back to plaintext `String` equality for any encoded password without an `MD5:`, `CRYPT:`, or `BCRYPT:` prefix. Since no shipped account uses a hash prefix, any password set or changed via the realm.properties auth path (UI/API) was persisted and compared in plaintext. Addresses the "Long-term" and "Replace non-timing-safe comparison" remediation items from PS-1682 (public security report).

**Describe the solution you've implemented**
- `encode()` now hashes the raw password with BCrypt via the existing `BcryptCredentialProvider.BcryptCredential.encodePassword()` helper, returning a `BCRYPT:`-prefixed hash — consistent with the `BCRYPT:` branch already implemented in `matches()`. New/changed passwords are never written as plaintext.
- The plaintext-fallback branch in `matches()` (used for legacy/unprefixed entries in `realm.properties`) now uses `MessageDigest.isEqual()` for a constant-time comparison instead of `String.equals()`/`==`, closing the timing side channel called out in the report.
- Added Groovydoc to both methods per repo convention.
- Added test coverage: `encode()` returns a `BCRYPT:`-prefixed hash (not plaintext), and the encoded output round-trips correctly through `matches()`.

**Describe alternatives you've considered**
- Removing the plaintext-fallback comparison entirely was considered but not done here — it's still needed to authenticate any existing unprefixed entries in an operator's `realm.properties` until they're migrated to `BCRYPT:`. That migration is an operational (audit/rotate) task, not a code change, and is called out as a separate remediation step in the source security report.
- The audit, manual `realm.properties` hardening, and OBF-account-reset action items from the report are operational tasks for the Rundeck ops/security team, not code changes, and are out of scope for this PR.

**Additional context**
Source: PS-1682 (internal security finding, P2/Moderate, due 2026-07-15). See `rundeckapp/src/main/groovy/org/rundeck/security/JettyCompatibleSpringSecurityPasswordEncoder.groovy`.

## Release Notes

Fixed: user account passwords authenticated via the realm.properties (non-JAAS) path are now hashed with BCrypt when set/changed, instead of being stored in plaintext.