### PR TITLE
[RUN-4665] Normal users are not able to see job history any more

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionsQueryViewAuthSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionsQueryViewAuthSpec.groovy
@@ -1,0 +1,86 @@
+package org.rundeck.tests.functional.api.execution
+
+import org.rundeck.util.annotations.APITest
+import org.rundeck.util.common.jobs.JobUtils
+import org.rundeck.util.container.BaseContainer
+import spock.lang.Shared
+
+/**
+ * A user granted only the job {@code view} ACL action (without {@code read} or
+ * {@code view_history}) must still see the execution list from
+ * {@code GET /project/{project}/executions}, not just the total count. Regression coverage for
+ * the fix in {@code ExecutionController.apiExecutionsQueryv14} (filterAuthorizedProjectExecutionsAny).
+ */
+@APITest
+class ExecutionsQueryViewAuthSpec extends BaseContainer {
+    static final String TEST_PROJECT = "ExecutionsQueryViewAuth"
+    static final String ACLPOLICY_FILE = "ExecutionsQueryViewAuthSpec.aclpolicy"
+    static final String VIEW_GROUP = "ExecViewOnlyGroup"
+    static final String NO_ACCESS_GROUP = "ExecNoAccessGroup"
+    static final int EXECUTION_COUNT = 3
+
+    @Shared
+    String jobId
+    @Shared
+    String viewToken
+    @Shared
+    String noAccessToken
+
+    def setupSpec() {
+        setupProject(TEST_PROJECT)
+        importSystemAcls("/${ACLPOLICY_FILE}", ACLPOLICY_FILE)
+
+        def jobXml = JobUtils.generateScheduledExecutionXml("view-only-repro-job")
+        jobId = JobUtils.createJob(TEST_PROJECT, jobXml, client).succeeded[0].id
+
+        EXECUTION_COUNT.times {
+            def execution = JobUtils.runExecuteJob(jobId, client)
+            JobUtils.waitForSuccess(execution.id as String, client)
+        }
+
+        viewToken = client.post(
+            "/tokens/exec-view-only-user",
+            [roles: [VIEW_GROUP]],
+            Map
+        ).token
+        noAccessToken = client.post(
+            "/tokens/exec-no-access-user",
+            [roles: [NO_ACCESS_GROUP]],
+            Map
+        ).token
+    }
+
+    def cleanupSpec() {
+        deleteProject(TEST_PROJECT)
+        deleteSystemAcl(ACLPOLICY_FILE)
+    }
+
+    def "user with only view sees the execution list, not just the count"() {
+        given: "a client authenticated as a user with only the view job ACL action"
+            def viewClient = clientWithToken(viewToken)
+
+        when: "querying the executions API for the job"
+            def result = viewClient.get(
+                "/project/${TEST_PROJECT}/executions?jobIdListFilter=${jobId}",
+                Map
+            )
+
+        then: "the full execution list is returned, matching the total count"
+            result.paging.total == EXECUTION_COUNT
+            result.executions.size() == EXECUTION_COUNT
+    }
+
+    def "user with neither read, view, nor view_history sees an empty execution list"() {
+        given: "a client authenticated as a user with project access but no job-level authorization"
+            def noAccessClient = clientWithToken(noAccessToken)
+
+        when: "querying the executions API for the job"
+            def result = noAccessClient.get(
+                "/project/${TEST_PROJECT}/executions?jobIdListFilter=${jobId}",
+                Map
+            )
+
+        then: "no executions are visible, regardless of the reported total"
+            result.executions.size() == 0
+    }
+}

--- a/functional-test/src/test/resources/ExecutionsQueryViewAuthSpec.aclpolicy
+++ b/functional-test/src/test/resources/ExecutionsQueryViewAuthSpec.aclpolicy
@@ -1,0 +1,29 @@
+description: functional test - project access for view-only execution history repro
+context:
+  application: rundeck
+for:
+  project:
+  - allow:
+    - read
+    equals:
+      name: ExecutionsQueryViewAuth
+by:
+  group:
+  - ExecViewOnlyGroup
+  - ExecNoAccessGroup
+---
+description: functional test - view only, no job read or view_history
+context:
+  project: ExecutionsQueryViewAuth
+for:
+  job:
+  - allow:
+    - view
+  resource:
+  - allow:
+    - read
+    equals:
+      kind: event
+by:
+  group:
+  - ExecViewOnlyGroup

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -3228,11 +3228,11 @@ if executed in cluster mode.""",
 
         def result = results.result
         def total = results.total
-        //filter query results to executions the user can view via READ or VIEW_HISTORY
+        //filter query results to executions the user can view via READ, VIEW, or VIEW_HISTORY
         def filtered = rundeckAuthContextProcessor.filterAuthorizedProjectExecutionsAny(
             authContext,
             result,
-            [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]
+            [AuthConstants.ACTION_READ, AuthConstants.ACTION_VIEW, AuthConstants.VIEW_HISTORY]
         )
 
         def controller = this

--- a/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
@@ -177,7 +177,7 @@ class JobStateService implements AuthorizingJobService {
         executions = rundeckAuthContextEvaluator.filterAuthorizedProjectExecutionsAny(
             auth,
             executions,
-            [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]
+            [AuthConstants.ACTION_READ, AuthConstants.ACTION_VIEW, AuthConstants.VIEW_HISTORY]
         )
 
         IFramework framework = frameworkService.getRundeckFramework()
@@ -423,11 +423,11 @@ class JobStateService implements AuthorizingJobService {
         def results = frameworkService.queryExecutions(query, offset, max)
         def result=results.result
         def total=results.total
-        //filter query results to executions the user can view via READ or VIEW_HISTORY
+        //filter query results to executions the user can view via READ, VIEW, or VIEW_HISTORY
         def filtered = rundeckAuthContextEvaluator.filterAuthorizedProjectExecutionsAny(
             auth,
             result,
-            [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]
+            [AuthConstants.ACTION_READ, AuthConstants.ACTION_VIEW, AuthConstants.VIEW_HISTORY]
         )
         def reflist = filtered.collect { it.asReference() }
         return [result:reflist, total:reflist.size()]

--- a/rundeckapp/src/test/groovy/org/rundeck/app/authorization/BaseAuthContextEvaluatorSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/authorization/BaseAuthContextEvaluatorSpec.groovy
@@ -335,7 +335,7 @@ class BaseAuthContextEvaluatorSpec extends Specification {
     }
 
     @Unroll
-    def "filterAuthorizedProjectExecutionsAny allows read or view_history"() {
+    def "filterAuthorizedProjectExecutionsAny allows read, view, or view_history"() {
         given:
             def test = new BaseAuthContextEvaluator()
             def auth = Mock(AuthContext)
@@ -349,6 +349,12 @@ class BaseAuthContextEvaluatorSpec extends Specification {
                     [AuthConstants.ACTION_READ].toSet(),
                     'testProject'
                 ) >> makeDecisions([readAuthorized])
+                _ * evaluate(
+                    auth,
+                    resources,
+                    [AuthConstants.ACTION_VIEW].toSet(),
+                    'testProject'
+                ) >> makeDecisions([viewAuthorized])
                 _ * evaluate(
                     auth,
                     resources,
@@ -368,17 +374,18 @@ class BaseAuthContextEvaluatorSpec extends Specification {
             def result = test.filterAuthorizedProjectExecutionsAny(
                 auth,
                 [exec],
-                [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]
+                [AuthConstants.ACTION_READ, AuthConstants.ACTION_VIEW, AuthConstants.VIEW_HISTORY]
             )
         then:
             (result.size() == 1) == expectIncluded
 
         where:
-            readAuthorized | viewHistoryAuthorized | expectIncluded
-            true           | false                 | true
-            false          | true                  | true
-            true           | true                  | true
-            false          | false                 | false
+            readAuthorized | viewAuthorized | viewHistoryAuthorized | expectIncluded
+            true           | false          | false                 | true
+            false          | true           | false                 | true
+            false          | false          | true                  | true
+            true           | true           | true                  | true
+            false          | false          | false                 | false
     }
 
     public HashSet<Decision> makeDecisions(List<Boolean> decisions) {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -167,7 +167,7 @@ class ExecutionControllerSpec extends Specification implements ControllerUnitTes
         1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_, 'test')
 
         1 * controller.executionService.queryExecutions(query, 0, 20) >> [result: [], total: 1]
-        1 * controller.rundeckAuthContextProcessor.filterAuthorizedProjectExecutionsAny(_, [], [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]) >> []
+        1 * controller.rundeckAuthContextProcessor.filterAuthorizedProjectExecutionsAny(_, [], [AuthConstants.ACTION_READ, AuthConstants.ACTION_VIEW, AuthConstants.VIEW_HISTORY]) >> []
         respondJson * controller.executionService.respondExecutionsJson(_, _, [], [total: 1, offset: 0, max: 20],_)
         respondXml * controller.executionService.respondExecutionsXml(_, _, [], [total: 1, offset: 0, max: 20])
 
@@ -207,7 +207,7 @@ class ExecutionControllerSpec extends Specification implements ControllerUnitTes
         1 * controller.apiService.requireApi(_, _) >> true
 
         1 * controller.executionService.queryExecutions(query, 0, 20) >> [result: [], total: 1]
-        1 * controller.rundeckAuthContextProcessor.filterAuthorizedProjectExecutionsAny(_, [], [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]) >> []
+        1 * controller.rundeckAuthContextProcessor.filterAuthorizedProjectExecutionsAny(_, [], [AuthConstants.ACTION_READ, AuthConstants.ACTION_VIEW, AuthConstants.VIEW_HISTORY]) >> []
         1 * controller.frameworkService.existsFrameworkProject('test') >> true
         1 * controller.apiService.requireExists(_,true,['Project','test']) >> true
     }
@@ -239,7 +239,7 @@ class ExecutionControllerSpec extends Specification implements ControllerUnitTes
         1 * controller.apiService.requireApi(_, _) >> true
 
         1 * controller.executionService.queryExecutions(query, 0, 20) >> [result: [], total: 1]
-        1 * controller.rundeckAuthContextProcessor.filterAuthorizedProjectExecutionsAny(_, [], [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]) >> []
+        1 * controller.rundeckAuthContextProcessor.filterAuthorizedProjectExecutionsAny(_, [], [AuthConstants.ACTION_READ, AuthConstants.ACTION_VIEW, AuthConstants.VIEW_HISTORY]) >> []
 
         1 * controller.frameworkService.existsFrameworkProject('test') >> true
         1 * controller.apiService.requireExists(_,true,['Project','test']) >> true

--- a/rundeckapp/src/test/groovy/rundeck/services/JobStateServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/JobStateServiceSpec.groovy
@@ -21,6 +21,10 @@ import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.AuthContextEvaluator
 import com.dtolabs.rundeck.core.authorization.SubjectAuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import com.dtolabs.rundeck.core.common.IFramework
+import com.dtolabs.rundeck.core.common.INodeSet
+import com.dtolabs.rundeck.core.common.IRundeckProject
+import com.dtolabs.rundeck.core.common.ProjectManager
 import com.dtolabs.rundeck.core.dispatcher.ExecutionState
 import com.dtolabs.rundeck.core.execution.ExecutionReference
 import com.dtolabs.rundeck.core.jobs.JobNotFound
@@ -552,7 +556,7 @@ class JobStateServiceSpec extends Specification implements ServiceUnitTest<JobSt
             }
             [result: [], total: 0]
         }
-        1 * service.rundeckAuthContextEvaluator.filterAuthorizedProjectExecutionsAny(_, _, [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]) >>
+        1 * service.rundeckAuthContextEvaluator.filterAuthorizedProjectExecutionsAny(_, _, [AuthConstants.ACTION_READ, AuthConstants.ACTION_VIEW, AuthConstants.VIEW_HISTORY]) >>
                 {authcontext, inputArr, actions ->
             return inputArr
         }
@@ -562,6 +566,38 @@ class JobStateServiceSpec extends Specification implements ServiceUnitTest<JobSt
         [adhoc:true]            | 1
         [jobonly:true]          | 0
         [jobIdListFilter:'1,2'] | 2
+    }
+
+    def "searchExecutions filters by read, view, or view_history"() {
+        given:
+        def jobUuid = 'c46e20a9-8555-4f15-acad-e5adba88906d'
+        def projectName = 'testProj'
+        def auth = Mock(AuthContext)
+        Execution exec = setTestExecutions(projectName, jobUuid)
+        def myCriteria = new Expando()
+        myCriteria.list = { Closure cls -> return [exec] }
+        Execution.metaClass.static.createCriteria = { myCriteria }
+        service.frameworkService = Mock(FrameworkService) {
+            getRundeckFramework() >> Mock(IFramework) {
+                getFrameworkProjectMgr() >> Mock(ProjectManager) {
+                    getFrameworkProject(_) >> Mock(IRundeckProject) {
+                        getNodeSet() >> Mock(INodeSet)
+                    }
+                }
+                getFrameworkNodeName() >> 'localhost'
+            }
+        }
+
+        when:
+        service.searchExecutions(auth, null, projectName, null, null, null)
+
+        then:
+        1 * service.rundeckAuthContextEvaluator.filterAuthorizedProjectExecutionsAny(
+                _, [exec], [AuthConstants.ACTION_READ, AuthConstants.ACTION_VIEW, AuthConstants.VIEW_HISTORY]
+        ) >> { authcontext, execs, actions -> execs }
+
+        cleanup:
+        GroovySystem.metaClassRegistry.removeMetaClass(Execution)
     }
 
 


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. Fixes #10336 — users whose ACL grants only the job `view` action (not `read` or
`view_history`) still can't see job execution history via
`GET /project/{project}/executions` (or `rd executions query`) on 6.0.0+. The endpoint reports
the correct total count, but the returned execution list is empty. This is a regression from
5.x, where `view` + a project-level `event`/`read` grant was sufficient.

A prior fix in this area added `VIEW_HISTORY` as an accepted action alongside `READ` in the
bulk authorization filter used to list executions, but never added `VIEW`. As a result, the
`view`-only case reported here still reproduces.

**Describe the solution you've implemented**

Added `AuthConstants.ACTION_VIEW` to the action list passed to
`filterAuthorizedProjectExecutionsAny(...)` in the three places that were still missing it:

- `ExecutionController.apiExecutionsQueryv14` (`GET /api/$api_version/project/$project/executions`)
- `JobStateService.searchExecutions(...)`
- `JobStateService.queryExecutions(AuthContext, Map)`

This mirrors `ReportService.authorizeViewHistoryJob`, which already treats
`[READ, VIEW, VIEW_HISTORY]` as sufficient for the GUI history/reports page. Since
`filterAuthorizedProjectExecutionsAny` evaluates actions as "any of," widening the list can't
remove access from anyone currently authorized — it only restores access for `view`-only users
who were incorrectly excluded.

Added/updated Spock coverage:
- `BaseAuthContextEvaluatorSpec` — extended the existing truth-table test with a `view`-only
  authorized case
- `ExecutionControllerSpec` / `JobStateServiceSpec` — updated the interaction assertions to
  expect the corrected action list, and added a new test for `searchExecutions` (which had no
  prior coverage)
- `ExecutionsQueryViewAuthSpec` (functional/API test) — end-to-end coverage against a real
  server: a `view`-only user sees the full execution list, while a user with none of
  `read`/`view`/`view_history` still sees an empty list

**Describe alternatives you've considered**

Also considered replicating the two-tier check used by the (unaffected) single-job endpoint
`ScheduledExecutionController.apiJobExecutions` — a job-resource action check plus a
project-level `event` resource `read` check — into this code path for full consistency between
the two "list executions" endpoints. Scoped that out as a separate, deeper inconsistency rather
than bundling it into this regression fix.

**Additional context**

Manually verified against a local build: created a group with only `job: allow:[view]` +
`resource: kind:event allow:[read]` (no `read`/`view_history`) on a test project, and confirmed
`GET /project/{project}/executions?jobIdListFilter=...` returned the execution instead of an
empty list with a nonzero total.

## Release Notes

Fixed a bug where users whose ACL granted only the job `view` action (without `read` or
`view_history`) could not see execution history from the executions API, even though the
correct total count was reported.
