### PR TITLE
[RUN-0000] Gate bcprov-jdk18on renovate updates on dashboard approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,8 +36,8 @@
       "groupName": "gradle minor/patch dependencies"
     },
     {
-      "description": "Grails minors have a history of real behavioral changes despite semver, and grails-plugin-spring-security-core must move in lockstep with it — pull both out of the auto-grouped minor/patch bucket for manual review",
-      "matchPackageNames": ["/^org\\.apache\\.grails:/"],
+      "description": "Grails minors have a history of real behavioral changes despite semver, and grails-plugin-spring-security-core must move in lockstep with it — pull both out of the auto-grouped minor/patch bucket for manual review. Groovy is included here too: Grails dictates which Groovy line it's built against, and bumping groovyVersion independently caused classpath skew that broke the forked :rundeckapp:assetCompile JVM (PR #10448, ExceptionInInitializerError in GroovySystem.<clinit>).",
+      "matchPackageNames": ["/^org\\.apache\\.grails:/", "/^org\\.apache\\.groovy:/"],
       "groupName": "grails framework (manual review required)",
       "dependencyDashboardApproval": true
     },

--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,11 @@
       "dependencyDashboardApproval": true
     },
     {
+      "description": "bcprov-jdk18on shares the bouncyCastleVersion property with bcpkix/bcutil/bcmail/bctls-jdk18on (git-plugin, etc.), and those siblings don't always cut a patch release together — 1.85.2 was published for bcprov-jdk18on alone, which broke git-plugin's bcpkix-jdk18on resolution when Renovate bumped the shared property (PR #10448). Gate on Dependency Dashboard approval rather than disabling outright, so this keeps surfacing instead of being silently forgotten; before approving, confirm bcpkix/bcutil/bcmail/bctls-jdk18on have all published the same version on Maven Central.",
+      "matchPackageNames": ["org.bouncycastle:bcprov-jdk18on"],
+      "dependencyDashboardApproval": true
+    },
+    {
       "description": "Keep the Jira REST client app/core artifacts in lockstep",
       "matchPackageNames": ["/^com\\.atlassian\\.jira:jira-rest-java-client-/"],
       "groupName": "atlassian jira rest client"


### PR DESCRIPTION
## Problem

[PR #10448](https://github.com/rundeck/rundeck/pull/10448) bumped `bouncyCastleVersion` 1.85 -> 1.85.2 (later manually reverted on that branch). That property is shared by `bcprov`/`bcpkix`/`bcutil`/`bcmail`/`bctls-jdk18on` across the build, including `git-plugin`.

`bcprov-jdk18on` published 1.85.2, but `bcpkix`/`bcutil`/`bcmail`/`bctls-jdk18on` have not (still capped at 1.85 on Maven Central). Bumping the shared property broke git-plugin's `pluginLibs` resolution (`Could not find org.bouncycastle:bcpkix-jdk18on:1.85.2`).

## Fix

Add a `packageRules` entry gating `org.bouncycastle:bcprov-jdk18on` on Dependency Dashboard approval, following the same pattern already used here for `grails`, `spock`, and `jetty`. This keeps the update visible on the dashboard indefinitely rather than silently disabling it and risking it being forgotten.

Mirrors the identical fix applied on the rundeckpro side (rundeckpro#4965).