### PR TITLE
[RUN-0000] Give bcprov-jdk18on its own renovate groupName

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,8 +54,9 @@
       "dependencyDashboardApproval": true
     },
     {
-      "description": "bcprov-jdk18on shares the bouncyCastleVersion property with bcpkix/bcutil/bcmail/bctls-jdk18on (git-plugin, etc.), and those siblings don't always cut a patch release together — 1.85.2 was published for bcprov-jdk18on alone, which broke git-plugin's bcpkix-jdk18on resolution when Renovate bumped the shared property (PR #10448). Gate on Dependency Dashboard approval rather than disabling outright, so this keeps surfacing instead of being silently forgotten; before approving, confirm bcpkix/bcutil/bcmail/bctls-jdk18on have all published the same version on Maven Central.",
+      "description": "bcprov-jdk18on shares the bouncyCastleVersion property with bcpkix/bcutil/bcmail/bctls-jdk18on (git-plugin, etc.), and those siblings don't always cut a patch release together — 1.85.2 was published for bcprov-jdk18on alone, which broke git-plugin's bcpkix-jdk18on resolution when Renovate bumped the shared property (PR #10448). Needs its own groupName, not just dependencyDashboardApproval: without one it stayed lumped into the 'gradle minor/patch dependencies' group below and rode along anyway (same mistake re-broke rundeckpro#4922 a second time). Gate on Dependency Dashboard approval rather than disabling outright, so this keeps surfacing instead of being silently forgotten; before approving, confirm bcpkix/bcutil/bcmail/bctls-jdk18on have all published the same version on Maven Central.",
       "matchPackageNames": ["org.bouncycastle:bcprov-jdk18on"],
+      "groupName": "bouncy castle bcprov (manual review - patch cadence mismatch with siblings)",
       "dependencyDashboardApproval": true
     },
     {


### PR DESCRIPTION
## Problem

[PR #10478](https://github.com/rundeck/rundeck/pull/10478) added `dependencyDashboardApproval: true` for `org.bouncycastle:bcprov-jdk18on` without its own `groupName`. That wasn't enough: the package still matched the earlier, broader `"Group routine Gradle minor/patch dependency bumps"` rule and stayed lumped into that shared group. After the retry checkbox was ticked on [rundeckpro#4922](https://github.com/rundeckpro/rundeckpro/pull/4922), `bouncyCastleVersion` got bumped back to `1.85.2` anyway, re-breaking the build a second time.

## Fix

Add a distinct `groupName` to the bcprov-jdk18on rule, matching the pattern already used (and working) for `grails`, `spock`, and `jetty` above it -- a dedicated `groupName` is what actually splits a package out of an existing group; `dependencyDashboardApproval` alone does not.

Mirrors [rundeckpro#4967](https://github.com/rundeckpro/rundeckpro/pull/4967).