### PR TITLE
[RUN-4812] Enable CircleCI rerun-failed-tests for functional jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -702,11 +702,20 @@ jobs:
           command: |
             # circleci tests run must appear in this config.yml (not only a helper)
             # so the UI offers "Rerun failed tests" instead of "Set up rerun failed tests".
-            circleci tests glob "<< parameters.test_file_pattern >>" \
-              | circleci tests run --command="xargs -r printf '%s\n' > test_file_listing.txt" --verbose --split-by=timings
-            [ -s test_file_listing.txt ] || circleci-agent step halt
-            TEST_FILES="$(cat test_file_listing.txt)"
-            echo "${TEST_FILES}"
+            MATCHED_FILES="$(circleci tests glob "<< parameters.test_file_pattern >>" || true)"
+            if [[ -z "${MATCHED_FILES}" ]]; then
+              echo "WARNING: glob matched no files; running full Gradle task without -PtestFiles"
+              unset TEST_FILES
+            else
+              echo "${MATCHED_FILES}" | circleci tests run --command="xargs -r printf '%s\n' > test_file_listing.txt" --verbose --split-by=timings
+              if [[ ! -s test_file_listing.txt ]]; then
+                echo "No tests assigned to this node; halting."
+                circleci-agent step halt
+                exit 0
+              fi
+              TEST_FILES="$(cat test_file_listing.txt)"
+              echo "${TEST_FILES}"
+            fi
             TEST_IMAGE=<< parameters.test-image >>
             GRADLE_TASK=<< parameters.gradle-task >>
             rundeck_gradle_functional_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -700,8 +700,7 @@ jobs:
       - run-build-step:
           step-name: Runs gradle test task << parameters.gradle-task >>
           command: |
-            TEST_FILES=$(circleci tests glob "<< parameters.test_file_pattern >>" | circleci tests split)
-            echo $TEST_FILES | tee test_file_listing.txt
+            rundeck_select_functional_test_files "<< parameters.test_file_pattern >>"
             TEST_IMAGE=<< parameters.test-image >>
             GRADLE_TASK=<< parameters.gradle-task >>
             rundeck_gradle_functional_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -700,7 +700,13 @@ jobs:
       - run-build-step:
           step-name: Runs gradle test task << parameters.gradle-task >>
           command: |
-            rundeck_select_functional_test_files "<< parameters.test_file_pattern >>"
+            # circleci tests run must appear in this config.yml (not only a helper)
+            # so the UI offers "Rerun failed tests" instead of "Set up rerun failed tests".
+            circleci tests glob "<< parameters.test_file_pattern >>" \
+              | circleci tests run --command="xargs -r printf '%s\n' > test_file_listing.txt" --verbose --split-by=timings
+            [ -s test_file_listing.txt ] || circleci-agent step halt
+            TEST_FILES="$(cat test_file_listing.txt)"
+            echo "${TEST_FILES}"
             TEST_IMAGE=<< parameters.test-image >>
             GRADLE_TASK=<< parameters.gradle-task >>
             rundeck_gradle_functional_tests

--- a/scripts/circleci/build-functions.sh
+++ b/scripts/circleci/build-functions.sh
@@ -93,5 +93,12 @@ rundeck_verify_build() {
 }
 
 rundeck_gradle_functional_tests() {
-    TEST_IMAGE=${TEST_IMAGE:-} ./gradlew :functional-test:${GRADLE_TASK} -Penvironment="${ENV}" -PtestFiles="${TEST_FILES}" ${GRADLE_BUILD_OPTS} --info
+    local test_files_args=()
+    if [[ -n "${TEST_FILES:-}" ]]; then
+        test_files_args=(-PtestFiles="${TEST_FILES}")
+    fi
+    TEST_IMAGE=${TEST_IMAGE:-} ./gradlew :functional-test:${GRADLE_TASK} \
+        -Penvironment="${ENV}" \
+        "${test_files_args[@]}" \
+        ${GRADLE_BUILD_OPTS} --info
 }

--- a/scripts/circleci/helper-functions.sh
+++ b/scripts/circleci/helper-functions.sh
@@ -17,33 +17,6 @@ collect_gradle_tests() {
     find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
 }
 
-# Select the Groovy/Java specs assigned to this parallel node.
-# Uses `circleci tests run` so CircleCI can offer "Rerun failed tests" and only
-# re-execute failing files. Writes newline-separated paths (required by
-# functional-test/build.gradle explicitTestIncluder) and sets TEST_FILES.
-rundeck_select_functional_test_files() {
-    local pattern="${1}"
-    if [[ -z "${pattern}" ]]; then
-        echo "No test file glob specified"
-        return 1
-    fi
-
-    circleci tests glob "${pattern}" \
-        | circleci tests run \
-            --command="xargs -r printf '%s\n' > test_file_listing.txt" \
-            --verbose \
-            --split-by=timings
-
-    if [[ ! -s test_file_listing.txt ]]; then
-        echo "No tests assigned to this node; halting."
-        circleci-agent step halt
-    fi
-
-    TEST_FILES="$(cat test_file_listing.txt)"
-    echo "Selected test files:"
-    echo "${TEST_FILES}"
-}
-
 collect_build_artifacts() {
     shopt -s globstar
     mkdir -p "${WORKDIR}/artifacts"

--- a/scripts/circleci/helper-functions.sh
+++ b/scripts/circleci/helper-functions.sh
@@ -17,6 +17,33 @@ collect_gradle_tests() {
     find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
 }
 
+# Select the Groovy/Java specs assigned to this parallel node.
+# Uses `circleci tests run` so CircleCI can offer "Rerun failed tests" and only
+# re-execute failing files. Writes newline-separated paths (required by
+# functional-test/build.gradle explicitTestIncluder) and sets TEST_FILES.
+rundeck_select_functional_test_files() {
+    local pattern="${1}"
+    if [[ -z "${pattern}" ]]; then
+        echo "No test file glob specified"
+        return 1
+    fi
+
+    circleci tests glob "${pattern}" \
+        | circleci tests run \
+            --command="xargs -r printf '%s\n' > test_file_listing.txt" \
+            --verbose \
+            --split-by=timings
+
+    if [[ ! -s test_file_listing.txt ]]; then
+        echo "No tests assigned to this node; halting."
+        circleci-agent step halt
+    fi
+
+    TEST_FILES="$(cat test_file_listing.txt)"
+    echo "Selected test files:"
+    echo "${TEST_FILES}"
+}
+
 collect_build_artifacts() {
     shopt -s globstar
     mkdir -p "${WORKDIR}/artifacts"


### PR DESCRIPTION
## Jira Ticket
[RUN-4812](https://pagerduty.atlassian.net/browse/RUN-4812)

## Summary
- Switch `test-gradle-functional` from `circleci tests split` to `circleci tests run` so CircleCI can offer **Rerun failed tests**.
- Applies to Functional API, Plugin Blocklist, NodeExecutorSecureInput, and all Selenium jobs that share that job template.
- Keeps newline-separated file paths so `explicitTestIncluder` in `functional-test/build.gradle` still works.

## Test plan
- [ ] Confirm `build_and_test` still splits functional/Selenium specs across parallel nodes.
- [ ] After a functional or Selenium job fails, open the workflow and check that **Rerun** includes **Rerun failed tests**.
- [ ] Run that option and confirm only the failing specs re-execute (nodes with no remaining tests halt).
- [ ] Unit Gradle, Unit UI, Build, packaging, and scans are unchanged.

[RUN-4812]: https://pagerduty.atlassian.net/browse/RUN-4812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ