### PR TITLE
[RUN-4815] Fix flaky JobExecutionStatusSpec failed-with-retry/timedout test

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionStatusSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionStatusSpec.groovy
@@ -117,7 +117,8 @@ class JobExecutionStatusSpec extends BaseContainer {
         def response = JobUtils.waitForExecution(
                 ExecutionStatus.FAILED_WITH_RETRY.state,
                 execId as String,
-                client)
+                client,
+                WaitingTime.EXCESSIVE)
 
         then:
         verifyAll {
@@ -128,7 +129,8 @@ class JobExecutionStatusSpec extends BaseContainer {
         def responseExec1 = JobUtils.waitForExecution(
                 ExecutionStatus.TIMEDOUT.state,
                 response.retriedExecution.id as String,
-                client)
+                client,
+                WaitingTime.EXCESSIVE)
 
         then:
         verifyAll {


### PR DESCRIPTION
## Summary
- `JobExecutionStatusSpec` ("job/id/run should get into failed-with-retry and timedout status") fails intermittently in CI with a `ResourceAcceptanceTimeoutException`, even when the execution actually reached the expected state.
- Root cause: the job under test has `<timeout>3s</timeout>` + `<retry>1</retry>`, but the two `JobUtils.waitForExecution(...)` calls in this test relied on the default 5s wait budget (`WaitingTime.MODERATE`). The timeout + kill + retry-transition cycle can exceed that budget, causing a spurious timeout right as the state flips.
- Fix: pass `WaitingTime.EXCESSIVE` explicitly to both `waitForExecution` calls in this test.

Jira: RUN-4815

## Test plan
- [x] Local review of the diff (2-line change, no behavior change outside test wait budget)
- [ ] Confirm `pro-functional-test:coreApiTest` no longer flakes on this spec across a few CI reruns