### PR TITLE
[RUN-4791] Fix CVE-2026-64607 in httpclient5's Grails profile configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,6 +171,7 @@ allprojects {
     ext["micrometer.version"] = micrometerVersion          // CVE-2026-40983, CVE-2026-40984
     ext["spring-retry.version"] = springRetryVersion       // CVE-2026-41710
     ext["httpcore5.version"] = httpCore5Version             // CVE-2026-54399 (httpcore5-h2 HTTP/2 DoS)
+    ext["httpclient5.version"] = httpClient5Version         // CVE-2026-64607 (connection pool exhaustion DoS)
     // CVE-2026-54512, CVE-2026-54513 (jackson-databind PolymorphicTypeValidator bypass). Grails/Spring
     // Boot dependency management pins jackson to 2.21.2 and downgrades transitive 2.21.4; a plain
     // platform import or resolutionStrategy.force does NOT override it. Overriding the Boot BOM property
@@ -261,6 +262,19 @@ allprojects {
                 if (details.requested.group == 'org.apache.httpcomponents.core5') {
                     details.useVersion httpCore5Version
                     details.because 'httpcore5 5.4.2 fixes CVE-2026-54399 (httpcore5-h2 HTTP/2 DoS)'
+                }
+                // CVE-2026-64607: httpclient5's classic transport leaks the pooled connection on an
+                // invalid/unsupported Content-Encoding header (pool exhaustion DoS), fixed in 5.6.3.
+                // Every project applying org.apache.grails.gradle.grails-plugin gets an auto-created
+                // "profile" configuration (used by the Grails Shell to find profile artifacts) that
+                // independently resolves org.apache.grails.profiles:web-plugin -> ... -> grails-shell-cli
+                // -> spring-boot-cli -> httpclient5 via the grails-bom constraint (5.5.2). Like httpcore5
+                // above, the Spring Boot BOM manages httpclient5.version and overrides this useVersion
+                // call; the ext["httpclient5.version"] override above is what actually moves it, this
+                // rule is kept for defense-in-depth on any resolution path that doesn't go through the BOM.
+                if (details.requested.group == 'org.apache.httpcomponents.client5' && details.requested.name == 'httpclient5') {
+                    details.useVersion httpClient5Version
+                    details.because 'httpclient5 5.6.4 fixes CVE-2026-64607 (connection pool exhaustion DoS)'
                 }
             }
 


### PR DESCRIPTION
## Jira Ticket
[RUN-4791](https://pagerduty.atlassian.net/browse/RUN-4791)

## Follow-up to #10474

That PR (merged) fixed the `httpclient5` **buildscript classpath** occurrences. This one closes a genuinely separate, still-live path that a fresh Snyk scan caught after #10474 merged.

## What's actually vulnerable here

Every project applying `org.apache.grails.gradle.grails-plugin` gets an auto-created **`profile`** configuration ("Configuration that allows for finding profile artifacts so commands, scripts, and other helpers can be found by the Grails Shell"). It independently resolves:

```
org.apache.grails.profiles:web-plugin -> ... -> grails-shell-cli -> spring-boot-cli -> org.apache.httpcomponents.client5:httpclient5
```

via the `grails-bom` import (through Spring's `dependency-management` plugin), which pins `httpclient5` to `5.5.2` — vulnerable to CVE-2026-64607 (`<=5.6.2`, fixed in `5.6.3`).

This is a completely different resolution mechanism from the buildscript classpath fixed in #10474, and — like the neighboring `httpcore5` CVE-2026-54399 fix already in this file — plain `resolutionStrategy.force`/`eachDependency.useVersion` **cannot** move a version managed by the BOM; only overriding the BOM's own property (`ext["httpclient5.version"]`) actually works. I confirmed this the hard way (debug-logged the `eachDependency` rule firing with the correct group/name/version and calling `useVersion`, and the resolved version still came back `5.5.2` — exactly the same BOM-precedence behavior documented for `httpcore5`).

**Why only `grails-webhooks` got flagged:** it has no explicit `profile(...)` override, so it resolves the Grails plugin's *default* profile coordinate (`org.apache.grails.profiles:web-plugin`), which exists and resolves successfully. Every other `grails-*` module in this repo (`grails-metricsweb`, `grails-persistlocale`, `grails-repository`, `grails-securityheaders`, `rundeckapp`) has an explicit `profile(...)` override pointing at a defunct group id (`org.grails.profiles`, not `org.apache.grails.profiles`), so resolution fails outright there — nothing vulnerable is ever downloaded. That's pre-existing, unrelated to this CVE, and out of scope here.

## Change

- `build.gradle`: add `ext["httpclient5.version"] = httpClient5Version` to the `allprojects` block (mirroring the existing `httpcore5.version` override), plus a defense-in-depth `eachDependency` rule.

## Testing

- `./gradlew :grails-webhooks:dependencies --configuration profile` now shows `org.apache.httpcomponents.client5:httpclient5:5.5.2 -> 5.6.4`
- `compileGroovy` passes for `grails-webhooks`, `grails-metricsweb`, and `core`

[RUN-4791]: https://pagerduty.atlassian.net/browse/RUN-4791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ