### PR TITLE
[RUN-4816] Add native Prometheus execution metrics (Micrometer)

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -248,21 +248,17 @@ public class RundeckConfigBase {
         Api api;
         Execution execution;
 
-        // Backs rundeck.metrics.execution.dimensional.enabled and
-        // rundeck.metrics.execution.job.dimension.enabled (MicrometerExecutionMetricsService).
+        // Backs rundeck.metrics.execution.job.dimension.enabled (MicrometerExecutionMetricsService).
         // Without a declared field here, the Spring Binder that populates
         // ConfigurationService.appCfg (see rundeckpro-config's ConfigServiceRefresher.resetAppCfg)
-        // has nothing to bind these properties into, so they never appear in appCfg regardless of
-        // what's set in rundeck-config.properties.
+        // has nothing to bind this property into, so it never appears in appCfg regardless of what's
+        // set in rundeck-config.properties. There is deliberately no sibling "dimensional.enabled"
+        // field: that flag was removed from MicrometerExecutionMetricsService entirely (dimensional
+        // counter/timer/running-gauge recording is unconditional), so no config field should exist
+        // to bind it either -- a field with no corresponding check would silently do nothing.
         @Data
         public static class Execution {
-            Dimensional dimensional;
             Job job;
-
-            @Data
-            public static class Dimensional {
-                Boolean enabled;
-            }
 
             @Data
             public static class Job {

--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -246,6 +246,34 @@ public class RundeckConfigBase {
         String servletUrlPattern;
         Datasource datasource;
         Api api;
+        Execution execution;
+
+        // Backs rundeck.metrics.execution.dimensional.enabled and
+        // rundeck.metrics.execution.job.dimension.enabled (MicrometerExecutionMetricsService).
+        // Without a declared field here, the Spring Binder that populates
+        // ConfigurationService.appCfg (see rundeckpro-config's ConfigServiceRefresher.resetAppCfg)
+        // has nothing to bind these properties into, so they never appear in appCfg regardless of
+        // what's set in rundeck-config.properties.
+        @Data
+        public static class Execution {
+            Dimensional dimensional;
+            Job job;
+
+            @Data
+            public static class Dimensional {
+                Boolean enabled;
+            }
+
+            @Data
+            public static class Job {
+                Dimension dimension;
+
+                @Data
+                public static class Dimension {
+                    Boolean enabled;
+                }
+            }
+        }
 
         @Data
         public static class Api {

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -164,6 +164,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     def LoggingService loggingService
     def WorkflowService workflowService
     def StorageService storageService
+    MicrometerExecutionMetricsService micrometerExecutionMetricsService
 
     def ThreadBoundOutputStream sysThreadBoundOut
     def ThreadBoundOutputStream sysThreadBoundErr
@@ -1444,6 +1445,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
             thread.start()
             log.debug("started thread")
+            micrometerExecutionMetricsService?.recordExecutionStart(execution)
             return new AsyncStarted(
                     thread            : thread,
                     loghandler        : loghandler,
@@ -3496,6 +3498,15 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             jobUuid = scheduledExecution.uuid
         }
         if(execSaved) {
+            // execution now carries its final persisted state (status, dateCompleted, cancelled,
+            // timedOut, ...) via `execution.properties = props` above -- unlike execmap.execution,
+            // which is the pre-completion in-memory reference and never gets these fields set.
+            // This is the single convergence point for every completion path (normal finish via
+            // ExecutionJob.saveState, abort via abortExecutionDirect, stale cleanup via
+            // cleanupExecution), so recording here (rather than in
+            // ExecutionUtilService.finishExecutionMetrics) captures all of them exactly once.
+            micrometerExecutionMetricsService?.recordExecution(execution)
+
             //summarize node success
             String node=null
             int sucCount=-1;

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
@@ -89,6 +89,12 @@ class ExecutionUtilService {
         } else {
             metricService.markMeter(ExecutionService.name, 'executionSuccessMeter')
         }
+        // NOTE: dimensional execution metrics are NOT recorded here. execMap.execution is the
+        // pre-completion in-memory reference from executeAsyncBegin -- its dateCompleted/status
+        // are never mutated in place; the real final state only exists on the fresh instance
+        // ExecutionService.saveCompletedExecution_currentTransaction loads via Execution.get(exId)
+        // after execution.save(flush:true). See MicrometerExecutionMetricsService.recordExecution
+        // call there instead.
     }
     @CompileStatic
     def finishExecutionLogging(ExecutionService.AsyncStarted execMap) {

--- a/rundeckapp/grails-app/services/rundeck/services/MicrometerExecutionMetricsService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/MicrometerExecutionMetricsService.groovy
@@ -1,0 +1,201 @@
+package rundeck.services
+
+import com.dtolabs.rundeck.plugins.scm.JobChangeEvent
+import grails.core.GrailsApplication
+import grails.events.annotation.Subscriber
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.Meter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tag
+import io.micrometer.core.instrument.Timer
+import org.springframework.beans.factory.annotation.Autowired
+import rundeck.Execution
+import rundeck.ScheduledExecution
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.Function
+import java.util.function.IntUnaryOperator
+import java.util.function.Supplier
+import java.util.function.ToDoubleFunction
+
+/**
+ * Emits dimensional (project/status) execution metrics directly on the Micrometer
+ * {@link MeterRegistry}, so they appear natively on /monitoring/prometheus.
+ *
+ * This registers meters directly against the Micrometer registry -- it does NOT go through
+ * {@link DropwizardMicrometerBridgeService}, which only mirrors pre-existing flat Dropwizard
+ * meters and cannot carry tags/dimensions.
+ */
+@Slf4j
+@CompileStatic
+class MicrometerExecutionMetricsService {
+
+    // NOTE: no 'rundeck.' prefix here. ConfigurationService.getBoolean(String, boolean) resolves
+    // against appCfg, which is already grailsApplication.config.getProperty("rundeck", Map.class)
+    // -- i.e. already scoped to the "rundeck" subtree. Passing the full "rundeck.xxx" string here
+    // makes getValueFromRoot look for a nonexistent nested "rundeck" key *inside* that subtree and
+    // silently fall through to the default (see ApiController's working
+    // configurationService.getBoolean("metrics.monitoring.enabled", true) for the established
+    // convention). The property set in rundeck-config.properties still needs the "rundeck." prefix
+    // (e.g. rundeck.metrics.execution.job.dimension.enabled=true) -- only the lookup key here omits it.
+    static final String JOB_DIMENSION_ENABLED_PROPERTY = 'metrics.execution.job.dimension.enabled'
+
+    @Autowired
+    MeterRegistry meterRegistry
+    ConfigurationService configurationService
+    GrailsApplication grailsApplication
+    FrameworkService frameworkService
+    ExecutionService executionService
+
+    // Backs the in-memory "currently running" gauge: incremented in recordExecutionStart(),
+    // decremented in recordExecution() (finish). Event-driven, zero DB/scrape cost -- unlike a
+    // live COUNT(*) query, this only reflects executions this JVM itself started, so cluster-wide
+    // totals need summing across instances in PromQL (sum by (project) (...)).
+    private final ConcurrentHashMap<List<Tag>, AtomicInteger> runningCounters = new ConcurrentHashMap<>()
+
+    /**
+     * Marks an execution as started for the "currently running" gauge. Must be paired with the
+     * matching {@link #recordExecution} call when it finishes. No-op under the same conditions as
+     * recordExecution.
+     */
+    void recordExecutionStart(Execution execution) {
+        if (!meterRegistry || !execution) {
+            return
+        }
+        runningCounterFor(runningTags(execution)).incrementAndGet()
+    }
+
+    /**
+     * Records a finished execution as a tagged counter increment and duration timer, and
+     * decrements the matching "currently running" gauge.
+     * No-op when the registry is unavailable or the execution is null.
+     */
+    void recordExecution(Execution execution) {
+        if (!meterRegistry || !execution) {
+            return
+        }
+
+        String project = execution.project
+        String status = execution.getExecutionState()
+        // job_id/job_name are only added for scheduled (non-ad-hoc) executions -- ad-hoc runs have
+        // no stable job identity worth tagging, and are deliberately excluded from this dimension
+        // entirely rather than given a sentinel value.
+        List<Tag> jobTags = jobTags(execution)
+
+        List<Tag> tags = [Tag.of('project', project), Tag.of('status', status)]
+        tags.addAll(jobTags)
+
+        meterRegistry.counter('rundeck.executions', tags).increment()
+
+        Date started = execution.dateStarted
+        Date completed = execution.dateCompleted
+        if (started && completed) {
+            long millis = completed.time - started.time
+            durationTimer(tags).record(millis, TimeUnit.MILLISECONDS)
+        }
+
+        AtomicInteger runningCounter = runningCounters.get(runningTagsOf(project, jobTags))
+        runningCounter?.updateAndGet({ int v -> Math.max(0, v - 1) } as IntUnaryOperator)
+    }
+
+    private List<Tag> jobTags(Execution execution) {
+        ScheduledExecution job = execution.scheduledExecution
+        if (!jobDimensionEnabled() || !job?.uuid) {
+            return Collections.<Tag>emptyList()
+        }
+        String jobName = job.groupPath ? job.generateFullName() : job.jobName
+        [Tag.of('job_id', job.uuid), Tag.of('job_name', jobName ?: 'unknown')]
+    }
+
+    private List<Tag> runningTags(Execution execution) {
+        runningTagsOf(execution.project, jobTags(execution))
+    }
+
+    private List<Tag> runningTagsOf(String project, List<Tag> jobTags) {
+        List<Tag> tags = [Tag.of('project', project)]
+        tags.addAll(jobTags)
+        tags
+    }
+
+    private AtomicInteger runningCounterFor(List<Tag> tags) {
+        runningCounters.computeIfAbsent(tags, { List<Tag> key ->
+            AtomicInteger counter = new AtomicInteger(0)
+            Gauge.builder(
+                'rundeck.executions.running',
+                counter,
+                { AtomicInteger c -> c.get() as double } as ToDoubleFunction<AtomicInteger>
+            ).tags(key).register(meterRegistry)
+            counter
+        } as Function<List<Tag>, AtomicInteger>)
+    }
+
+    private Timer durationTimer(List<Tag> tags) {
+        // Deliberately no publishPercentileHistogram(): that requires HdrHistogram + LatencyUtils
+        // on the runtime classpath (optional micrometer-core deps, not currently in this project),
+        // and would throw NoClassDefFoundError without them. This means only _count/_sum/_max are
+        // exposed -- no _bucket series, so no histogram_quantile() percentiles in Grafana, only
+        // average (_sum/_count) and max duration by project/status.
+        Timer.builder('rundeck.execution.duration')
+             .tags(tags)
+             .register(meterRegistry)
+    }
+
+    private boolean jobDimensionEnabled() {
+        configurationService != null && configurationService.getBoolean(JOB_DIMENSION_ENABLED_PROPERTY, false)
+    }
+
+    /**
+     * Removes job_id-tagged meters for a deleted job so they don't accumulate as zombie series.
+     * No-op for non-DELETE job changes, or when the job dimension was never enabled (no meters to
+     * find). Ad-hoc executions never carry a job_id tag, so there's nothing to clean up for them.
+     */
+    @Subscriber('jobChanged')
+    void onJobChanged(JobChangeEvent event) {
+        if (!meterRegistry || event?.eventType != JobChangeEvent.JobChangeEventType.DELETE) {
+            return
+        }
+        String jobId = event.jobReference?.id
+        if (!jobId) {
+            return
+        }
+        [ 'rundeck.executions', 'rundeck.execution.duration', 'rundeck.executions.running' ].each { String name ->
+            List<Meter> matched = new ArrayList<Meter>(meterRegistry.find(name).tag('job_id', jobId).meters())
+            matched.each { Meter meter -> meterRegistry.remove(meter.getId()) }
+        }
+        // deleteScheduledExecution refuses to delete a job with executions still running, so the
+        // running gauge for this job_id is already at 0 here -- this only drops the now-unused
+        // AtomicInteger reference from the local map, it's not correcting a nonzero count.
+        runningCounters.keySet().removeIf { List<Tag> tags -> tags.any { it.key == 'job_id' && it.value == jobId } }
+    }
+
+    @Subscriber("rundeck.bootstrap")
+    void initialize() {
+        if (!meterRegistry) {
+            log.warn("Cannot initialize execution metrics: meterRegistry is null")
+            return
+        }
+
+        String version = grailsApplication?.metadata?.get('info.app.version') as String
+        String build = grailsApplication?.metadata?.get('build.ident') as String
+        String nodeUuid = frameworkService?.getServerUUID()
+
+        Gauge.builder('rundeck.system.info', { -> 1.0d } as Supplier<Number>)
+             .tag('version', version ?: 'unknown')
+             .tag('build', build ?: 'unknown')
+             .tag('node_uuid', nodeUuid ?: 'unknown')
+             .register(meterRegistry)
+
+        if (executionService) {
+            Gauge.builder(
+                'rundeck.execution.mode.active',
+                { -> executionService.getExecutionsAreActive() ? 1.0d : 0.0d } as Supplier<Number>
+            ).register(meterRegistry)
+        }
+
+        log.info("Registered native Micrometer execution metrics (system.info, execution.mode.active)")
+    }
+}

--- a/rundeckapp/grails-app/services/rundeck/services/MicrometerExecutionMetricsService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/MicrometerExecutionMetricsService.groovy
@@ -10,6 +10,9 @@ import io.micrometer.core.instrument.Meter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.Timer
+import org.rundeck.app.config.SysConfigProp
+import org.rundeck.app.config.SystemConfig
+import org.rundeck.app.config.SystemConfigurable
 import org.springframework.beans.factory.annotation.Autowired
 import rundeck.Execution
 import rundeck.ScheduledExecution
@@ -32,7 +35,7 @@ import java.util.function.ToDoubleFunction
  */
 @Slf4j
 @CompileStatic
-class MicrometerExecutionMetricsService {
+class MicrometerExecutionMetricsService implements SystemConfigurable {
 
     // NOTE: no 'rundeck.' prefix here. ConfigurationService.getBoolean(String, boolean) resolves
     // against appCfg, which is already grailsApplication.config.getProperty("rundeck", Map.class)
@@ -146,6 +149,35 @@ class MicrometerExecutionMetricsService {
 
     private boolean jobDimensionEnabled() {
         configurationService != null && configurationService.getBoolean(JOB_DIMENSION_ENABLED_PROPERTY, false)
+    }
+
+    /**
+     * Exposes {@code rundeck.metrics.execution.job.dimension.enabled} on the admin System
+     * Configuration page, so it's discoverable/editable without hand-editing
+     * rundeck-config.properties. Same pattern as ExecutionService's
+     * rundeck.executionDailyMetrics.enabled entry.
+     */
+    @Override
+    List<SysConfigProp> getSystemConfigProps() {
+        [
+            SystemConfig.builder().with {
+                key "rundeck.metrics.execution.job.dimension.enabled"
+                label "Execution Metrics: job_id/job_name dimension"
+                description "Tag rundeck_executions_total/rundeck_execution_duration_seconds/" +
+                    "rundeck_executions_running with job_id and job_name (scheduled jobs only, " +
+                    "ad-hoc executions excluded). Off by default: cardinality is bounded by the " +
+                    "job catalog size, not execution volume, but large job catalogs should size " +
+                    "this before enabling."
+                defaultValue "false"
+                required false
+                restart false
+                datatype "Boolean"
+                visibility 'Advanced'
+                category 'Execution'
+                authRequired "app_admin"
+                build()
+            }
+        ] as List<SysConfigProp>
     }
 
     /**

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -6273,6 +6273,70 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         ""                      | 1     | [node1: [summaryState:'SUCCEEDED'], node2: [summaryState:'SUCCEEDED'], node3: [summaryState:'SUCCEEDED']]   | ["node2","node3","node1"] | true
     }
 
+    def "saveExecutionState records dimensional metrics with the final persisted execution state"() {
+        given:
+        def project = 'AProject'
+        ScheduledExecution job = new ScheduledExecution(
+                jobName: 'abc',
+                project: project,
+                groupPath: 'path',
+                description: 'a job',
+                argString: '-args b',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec([adhocRemoteString: 'test buddy'])]
+                ),
+                uuid: 'bd80d431-b70a-42ad-8ea8-37ad4885ea01'
+        )
+        job.save()
+        Execution e1 = new Execution(
+                project: project,
+                user: 'bob',
+                dateStarted: new Date(),
+                workflow: job.workflow
+        )
+        e1.scheduledExecution = job
+        e1.save() != null
+
+        service.fileUploadService = Mock(FileUploadService)
+        service.executionUtilService = Mock(ExecutionUtilService)
+        service.storageService = Mock(StorageService)
+        service.jobStateService = Mock(JobStateService)
+        service.frameworkService = Mock(FrameworkService)
+        service.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor)
+        service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService)
+        service.workflowService = Mock(WorkflowService)
+        service.notificationService = Mock(NotificationService)
+        service.reportService = Mock(ReportService) {
+            reportExecutionResult(_) >> [:]
+        }
+        service.micrometerExecutionMetricsService = Mock(MicrometerExecutionMetricsService)
+
+        def dateCompleted = new Date()
+        Map resultMap = [
+                status       : ExecutionState.succeeded.toString(),
+                dateCompleted: dateCompleted,
+                cancelled    : false,
+                timedOut     : false,
+        ]
+        ExecutionService.AsyncStarted execmap = new ExecutionService.AsyncStarted(
+                execution         : e1,
+                scheduledExecution: job
+        )
+
+        when:
+        service.saveExecutionState(job.uuid, e1.id, resultMap, execmap, [:])
+
+        then:
+        // must fire with the freshly-saved Execution.get(exId) instance, which carries the real
+        // final state -- not execmap.execution, whose dateCompleted/status are never mutated.
+        1 * service.micrometerExecutionMetricsService.recordExecution({ Execution saved ->
+            saved.id == e1.id &&
+            saved.getExecutionState() == ExecutionState.succeeded.toString() &&
+            saved.dateCompleted == dateCompleted
+        })
+    }
+
     def "opt enforced allowed values from Remote Url with sending the username"() {
         given:
         ScheduledExecution se = new ScheduledExecution()
@@ -6814,6 +6878,93 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         true         | false
         false        | true
         false        | false
+    }
+
+    def "executeAsyncBegin records the execution start for the running-executions gauge"() {
+        given: "an execution with scheduled job"
+        def project = 'TestProject'
+        def execution = new Execution(
+                project: project,
+                user: 'testuser',
+                dateStarted: new Date(),
+                status: 'running',
+                loglevel: 'INFO',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec([adhocRemoteString: 'original command'])]
+                )
+        )
+        execution.save(flush: true)
+
+        def scheduledExecution = new ScheduledExecution(
+                jobName: 'testJob',
+                project: project,
+                workflow: execution.workflow
+        )
+        scheduledExecution.save(flush: true)
+
+        and: "mocked services"
+        def framework = Mock(IFramework) {
+            getFrameworkNodeName() >> 'testNode'
+        }
+        def authContext = Mock(UserAndRolesAuthContext)
+
+        service.loggingService = Mock(LoggingService) {
+            openLogWriter(_, _, _, _) >> Mock(ExecutionLogWriter) {
+                filepath >> new File('/tmp/test.log')
+                openStream() >> {}
+            }
+        }
+        service.pluginService = Mock(PluginService) {
+            getRundeckPluginRegistry() >> Mock(PluginRegistry) {
+                createPluggableService(_) >> Mock(PluggableProviderService)
+            }
+            createSimplePluginLoader(_, _, _) >> Mock(SimplePluginProviderLoader)
+        }
+        service.frameworkService = Mock(FrameworkService) {
+            getDefaultInputCharsetForProject(_) >> 'UTF-8'
+            getProjectProperties(_) >> [:]
+            getFrameworkPropertiesMap() >> [:]
+        }
+        service.executionUtilService = Mock(ExecutionUtilService) {
+            createExecutionItemForWorkflow(_,_) >> Mock(WorkflowExecutionItem) {
+                getWorkflow() >> Mock(IWorkflow)
+            }
+        }
+        service.workflowService = Mock(WorkflowService) {
+            createWorkflowStateListenerForExecution(*_) >> Mock(WorkflowExecutionListener)
+        }
+        service.logFileStorageService = Mock(LogFileStorageService) {
+        }
+        service.metricService = Mock(MetricService)
+        service.configurationService = Mock(ConfigurationService)
+        service.grailsLinkGenerator   = Mock(LinkGenerator)
+        service.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor)
+        service.storageService = Mock(StorageService)
+        service.jobStateService = Mock(JobStateService)
+        service.notificationService = Mock(NotificationService)
+        service.fileUploadService = Mock(FileUploadService)
+        service.sysThreadBoundOut = new ThreadBoundOutputStream(System.out)
+        service.sysThreadBoundErr = new ThreadBoundOutputStream(System.err)
+        service.micrometerExecutionMetricsService = Mock(MicrometerExecutionMetricsService)
+
+        and: "execution lifecycle handler setup"
+        service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService) {
+            getExecutionLifecyclePluginConfigSetForJob(_) >> Mock(PluginConfigSet)
+            getExecutionHandler(_, _) >> Mock(ExecutionLifecycleComponentHandler) {
+                beforeWorkflowIsSet(_, _) >> Optional.empty()
+            }
+        }
+
+        when: "executeAsyncBegin is called"
+        def result = service.executeAsyncBegin(framework, authContext, execution, scheduledExecution)
+
+        then: "the execution start is recorded, using the same execution reference passed in"
+        result != null
+        1 * service.micrometerExecutionMetricsService.recordExecutionStart(execution)
+
+        cleanup:
+        result?.thread?.interrupt()
     }
 
     def "executeAsyncBegin workflow modification - execution context updated when useNewValues is true"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/ExecutionUtilServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ExecutionUtilServiceSpec.groovy
@@ -39,6 +39,7 @@ class ExecutionUtilServiceSpec extends Specification implements ServiceUnitTest<
             false   | 'executionFailureMeter'
     }
 
+
     /**
      * Finish logging when no error cause
      */

--- a/rundeckapp/src/test/groovy/rundeck/services/ExecutionUtilServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ExecutionUtilServiceSpec.groovy
@@ -39,7 +39,6 @@ class ExecutionUtilServiceSpec extends Specification implements ServiceUnitTest<
             false   | 'executionFailureMeter'
     }
 
-
     /**
      * Finish logging when no error cause
      */

--- a/rundeckapp/src/test/groovy/rundeck/services/MicrometerExecutionMetricsServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/MicrometerExecutionMetricsServiceSpec.groovy
@@ -91,7 +91,7 @@ class MicrometerExecutionMetricsServiceSpec extends Specification {
             meterRegistry.meters.size() == registrySize
     }
 
-    void "recordExecution never emits execution_id, job_name, or user tags"() {
+    void "recordExecution never emits execution_id or user tags, and omits job_name when the job dimension flag is disabled (default)"() {
         given:
             def exec = execution([:])
 

--- a/rundeckapp/src/test/groovy/rundeck/services/MicrometerExecutionMetricsServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/MicrometerExecutionMetricsServiceSpec.groovy
@@ -1,0 +1,265 @@
+package rundeck.services
+
+import com.dtolabs.rundeck.core.jobs.JobRevReference
+import com.dtolabs.rundeck.plugins.scm.JobChangeEvent
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import rundeck.Execution
+import rundeck.ScheduledExecution
+import spock.lang.Specification
+
+class MicrometerExecutionMetricsServiceSpec extends Specification {
+
+    MicrometerExecutionMetricsService service
+    MeterRegistry meterRegistry
+    ConfigurationService configurationService
+    FrameworkService frameworkService
+    ExecutionService executionService
+
+    def setup() {
+        meterRegistry = new SimpleMeterRegistry()
+        configurationService = Mock(ConfigurationService)
+        frameworkService = Mock(FrameworkService)
+        executionService = Mock(ExecutionService)
+
+        service = new MicrometerExecutionMetricsService()
+        service.meterRegistry = meterRegistry
+        service.configurationService = configurationService
+        service.frameworkService = frameworkService
+        service.executionService = executionService
+    }
+
+    private Execution execution(Map props) {
+        new Execution([
+            project     : 'p1',
+            status      : 'true',
+            cancelled   : false,
+            willRetry   : false,
+            timedOut    : false,
+            dateStarted : new Date(1000L),
+            dateCompleted: new Date(6000L),
+        ] + props)
+    }
+
+    void "recordExecution increments counter and records duration timer with project/status tags"() {
+        given:
+            def exec = execution(project: project, status: rawStatus, cancelled: cancelled, timedOut: timedOut)
+
+        when:
+            service.recordExecution(exec)
+
+        then:
+            meterRegistry.get('rundeck.executions').tag('project', project).tag('status', status).counter().count() == 1.0d
+            meterRegistry.get('rundeck.execution.duration').tag('project', project).tag('status', status).timer().count() == 1L
+
+        where:
+            project | rawStatus | cancelled | timedOut | status
+            'p1'    | 'true'    | false     | false    | 'succeeded'
+            'p1'    | 'false'   | false     | false    | 'failed'
+            'p2'    | 'false'   | true      | false    | 'aborted'
+            'p2'    | 'false'   | false     | true     | 'timedout'
+    }
+
+    void "recordExecution skips the duration timer when start or completed timestamp is missing"() {
+        given:
+            // dateCompleted == null means Execution.getExecutionState() reports 'running' regardless
+            // of the started timestamp -- only the "no timer" behavior is under test here.
+            def exec = execution(dateStarted: startedDate, dateCompleted: completedDate)
+
+        when:
+            service.recordExecution(exec)
+
+        then:
+            meterRegistry.meters.find { it.id.name == 'rundeck.executions' } != null
+            meterRegistry.meters.find { it.id.name == 'rundeck.execution.duration' } == null
+
+        where:
+            startedDate  | completedDate
+            null         | new Date(6000L)
+            new Date(1000L) | null
+    }
+
+    void "recordExecution is a no-op when execution is null"() {
+        given:
+            def registrySize = meterRegistry.meters.size()
+
+        when:
+            service.recordExecution(null)
+
+        then:
+            0 * configurationService.getBoolean(*_)
+            meterRegistry.meters.size() == registrySize
+    }
+
+    void "recordExecution never emits execution_id, job_name, or user tags"() {
+        given:
+            def exec = execution([:])
+
+        when:
+            service.recordExecution(exec)
+
+        then:
+            // meterRegistry.find(...).tag(k, '_').counter()/.timer() returns null when no meter
+            // carries that tag key at all -- this stays on the Search API (proven safe above),
+            // instead of reflecting over the concrete Timer/Counter via meter.id.tags.
+            meterRegistry.find('rundeck.executions').tag('execution_id', '_').counter() == null
+            meterRegistry.find('rundeck.executions').tag('job_name', '_').counter() == null
+            meterRegistry.find('rundeck.executions').tag('user', '_').counter() == null
+            meterRegistry.find('rundeck.executions').tag('node', '_').counter() == null
+            meterRegistry.find('rundeck.execution.duration').tag('execution_id', '_').timer() == null
+            meterRegistry.find('rundeck.execution.duration').tag('job_name', '_').timer() == null
+    }
+
+    void "recordExecution adds job_id and job_name tags when the job dimension flag is enabled and the execution is scheduled"() {
+        given:
+            configurationService.getBoolean(MicrometerExecutionMetricsService.JOB_DIMENSION_ENABLED_PROPERTY, false) >> true
+            def job = new ScheduledExecution(uuid: 'job-uuid-1', jobName: 'my-job', groupPath: null)
+            def exec = execution(scheduledExecution: job)
+
+        when:
+            service.recordExecution(exec)
+
+        then:
+            meterRegistry.get('rundeck.executions')
+                .tag('project', 'p1').tag('status', 'succeeded').tag('job_id', 'job-uuid-1').tag('job_name', 'my-job')
+                .counter().count() == 1.0d
+            meterRegistry.get('rundeck.execution.duration')
+                .tag('project', 'p1').tag('status', 'succeeded').tag('job_id', 'job-uuid-1').tag('job_name', 'my-job')
+                .timer().count() == 1L
+    }
+
+    void "recordExecution excludes job_id and job_name tags for ad-hoc executions even when the job dimension flag is enabled"() {
+        given:
+            configurationService.getBoolean(MicrometerExecutionMetricsService.JOB_DIMENSION_ENABLED_PROPERTY, false) >> true
+            def exec = execution(scheduledExecution: null)
+
+        when:
+            service.recordExecution(exec)
+
+        then:
+            meterRegistry.get('rundeck.executions').tag('project', 'p1').tag('status', 'succeeded').counter().count() == 1.0d
+            meterRegistry.find('rundeck.executions').tag('job_id', '_').counter() == null
+            meterRegistry.find('rundeck.executions').tag('job_name', '_').counter() == null
+    }
+
+    void "recordExecution excludes the job_id and job_name tags when the job dimension flag is disabled (default)"() {
+        given:
+            def job = new ScheduledExecution(uuid: 'job-uuid-1', jobName: 'my-job')
+            def exec = execution(scheduledExecution: job)
+
+        when:
+            service.recordExecution(exec)
+
+        then:
+            meterRegistry.get('rundeck.executions').tag('project', 'p1').tag('status', 'succeeded').counter().count() == 1.0d
+            meterRegistry.find('rundeck.executions').tag('job_id', 'job-uuid-1').counter() == null
+            meterRegistry.find('rundeck.executions').tag('job_name', 'my-job').counter() == null
+    }
+
+    void "recordExecutionStart increments the running gauge, recordExecution decrements it back to zero"() {
+        given:
+            def exec = execution([:])
+
+        when:
+            service.recordExecutionStart(exec)
+
+        then:
+            meterRegistry.get('rundeck.executions.running').tag('project', 'p1').gauge().value() == 1.0d
+
+        when:
+            service.recordExecution(exec)
+
+        then:
+            meterRegistry.get('rundeck.executions.running').tag('project', 'p1').gauge().value() == 0.0d
+    }
+
+    void "recordExecutionStart tracks job_id/job_name on the running gauge when the job dimension flag is enabled"() {
+        given:
+            configurationService.getBoolean(MicrometerExecutionMetricsService.JOB_DIMENSION_ENABLED_PROPERTY, false) >> true
+            def job = new ScheduledExecution(uuid: 'job-uuid-1', jobName: 'my-job')
+            def exec = execution(scheduledExecution: job)
+
+        when:
+            service.recordExecutionStart(exec)
+
+        then:
+            meterRegistry.get('rundeck.executions.running')
+                .tag('project', 'p1').tag('job_id', 'job-uuid-1').tag('job_name', 'my-job')
+                .gauge().value() == 1.0d
+    }
+
+    void "recordExecutionStart is a no-op when execution is null"() {
+        given:
+            def registrySize = meterRegistry.meters.size()
+
+        when:
+            service.recordExecutionStart(null)
+
+        then:
+            meterRegistry.meters.size() == registrySize
+    }
+
+    void "onJobChanged removes job_id-tagged meters, including the running gauge, when a job is deleted"() {
+        given:
+            configurationService.getBoolean(MicrometerExecutionMetricsService.JOB_DIMENSION_ENABLED_PROPERTY, false) >> true
+            def deletedJob = new ScheduledExecution(uuid: 'job-uuid-1')
+            def keptJob = new ScheduledExecution(uuid: 'job-uuid-2')
+            service.recordExecutionStart(execution(scheduledExecution: deletedJob))
+            service.recordExecution(execution(scheduledExecution: deletedJob))
+            service.recordExecution(execution(scheduledExecution: keptJob))
+            def event = Stub(JobChangeEvent) {
+                getEventType() >> JobChangeEvent.JobChangeEventType.DELETE
+                getJobReference() >> Stub(JobRevReference) {
+                    getId() >> 'job-uuid-1'
+                }
+            }
+
+        when:
+            service.onJobChanged(event)
+
+        then:
+            meterRegistry.find('rundeck.executions').tag('job_id', 'job-uuid-1').counter() == null
+            meterRegistry.find('rundeck.execution.duration').tag('job_id', 'job-uuid-1').timer() == null
+            meterRegistry.find('rundeck.executions.running').tag('job_id', 'job-uuid-1').gauge() == null
+            meterRegistry.get('rundeck.executions').tag('job_id', 'job-uuid-2').counter().count() == 1.0d
+    }
+
+    void "onJobChanged is a no-op for non-DELETE job change events"() {
+        given:
+            configurationService.getBoolean(MicrometerExecutionMetricsService.JOB_DIMENSION_ENABLED_PROPERTY, false) >> true
+            def job = new ScheduledExecution(uuid: 'job-uuid-1')
+            service.recordExecution(execution(scheduledExecution: job))
+            def event = Stub(JobChangeEvent) {
+                getEventType() >> JobChangeEvent.JobChangeEventType.MODIFY
+            }
+
+        when:
+            service.onJobChanged(event)
+
+        then:
+            meterRegistry.get('rundeck.executions').tag('job_id', 'job-uuid-1').counter().count() == 1.0d
+    }
+
+    void "initialize registers rundeck.system.info and rundeck.execution.mode.active gauges"() {
+        given:
+            // GrailsApplication.getMetadata() defaults to null on a bare Mock -- exercises the
+            // null-safe fallback to 'unknown' tags, since grails.util.Metadata has no public
+            // constructor usable from a unit test.
+            service.grailsApplication = Mock(grails.core.GrailsApplication)
+            frameworkService.getServerUUID() >> 'uuid-1'
+            executionService.getExecutionsAreActive() >> true
+
+        when:
+            service.initialize()
+
+        then:
+            def infoGauge = meterRegistry.get('rundeck.system.info')
+                .tag('version', 'unknown')
+                .tag('build', 'unknown')
+                .tag('node_uuid', 'uuid-1')
+                .gauge()
+            infoGauge.value() == 1.0d
+
+            meterRegistry.get('rundeck.execution.mode.active').gauge().value() == 1.0d
+    }
+}


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Enhancement. Closes the gap that today only the external [`rundeck_exporter`](https://github.com/phsmith/rundeck_exporter) sidecar fills: dimensional (per-project/status) execution metrics on the native `/monitoring/prometheus` endpoint. Tracked in [RUN-4816](https://pagerduty.atlassian.net/browse/RUN-4816).

**Describe the solution you've implemented**

New `MicrometerExecutionMetricsService`, registering meters directly against the Micrometer `MeterRegistry` (not via the Dropwizard→Micrometer bridge, which only mirrors pre-existing flat meters and can't carry tags):

- `rundeck_executions_total{project,status}` (Counter) and `rundeck_execution_duration_seconds{project,status}` (Timer — `_count`/`_sum`/`_max` only, no percentile histogram, to avoid pulling in the `HdrHistogram`/`LatencyUtils` dependencies).
- `rundeck_executions_running{project}` — an in-memory gauge incremented on execution start and decremented on finish, so "currently running" is available with zero DB/scrape cost (unlike a live `COUNT(*)`).
- `rundeck_system_info` and `rundeck_execution_mode_active` bootstrap gauges.
- Optional `job_id`/`job_name` dimension behind `rundeck.metrics.execution.job.dimension.enabled` (default off), with cleanup on job delete (via the `jobChanged` event) to bound cardinality growth. Ad-hoc (non-scheduled) executions are excluded from the job dimension entirely.
- Instrumented at `ExecutionService.saveCompletedExecution_currentTransaction` — the actual completion point with the final persisted state — rather than `ExecutionUtilService.finishExecutionMetrics`, whose `execMap.execution` reference is pre-completion and never gets `dateCompleted`/`status` mutated in place.
- `RundeckConfigBase` extended with `RundeckMetricsConfig.Execution` so the job-dimension flag is actually bindable from `rundeck-config.properties` via the Spring `Binder` that backs `ConfigurationService`.

Verified end-to-end against a local instance: scraped `/monitoring/prometheus`, confirmed series appear correctly tagged, and confirmed heap usage does not scale meaningfully with job-dimension cardinality (tested with ~170 distinct job-tagged series).

**Describe alternatives you've considered**

- Bridging through the existing Dropwizard→Micrometer bridge — rejected, since it only mirrors already-flat meters and has no way to add tags/dimensions.
- A percentile histogram on the duration `Timer` — rejected for now to avoid adding the `HdrHistogram`/`LatencyUtils` runtime dependencies; only count/sum/max are exposed.
- Live `COUNT(*)`-based running-executions gauge — rejected in favor of the event-driven in-memory gauge, which has zero per-scrape query cost.

**Additional context**

Full design rationale and exporter-parity mapping in the internal plan docs (DESIGN.md/SPEC.md under `plan/TODO/NATIVE-PROMETHEUS-EXECUTION-METRICS/`, not part of this diff).

## Release Notes

Rundeck now natively emits per-project/status execution counts and durations, a running-executions gauge, and system/execution-mode gauges on `/monitoring/prometheus`, without requiring an external exporter.

[RUN-4816]: https://pagerduty.atlassian.net/browse/RUN-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ