### PR TITLE
Require configure authorization for project configuration imports

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
@@ -415,6 +415,9 @@ class ProjectController extends ControllerBase{
             ) {
                 return null
             }
+            if (archiveParams.importConfig || archiveParams.importNodesSources || archiveParams.importScm) {
+                authorizing.authorize(RundeckAccess.Project.APP_CONFIGURE)
+            }
             //validate component input options
             archiveParams.cleanComponentOpts()
             def validations = projectService.validateAllProjectComponentImportOptions(archiveParams.importOpts)
@@ -3769,6 +3772,9 @@ Note: `other_errors` included since API v35""",
         //previous version must import nodes together with the project config
         if(request.api_version <= ApiVersions.V38) {
             archiveParams.importNodesSources = archiveParams.importConfig
+        }
+        if (archiveParams.importConfig || archiveParams.importNodesSources) {
+            authorizingProject.authorize(RundeckAccess.Project.APP_CONFIGURE)
         }
 
         if( asyncImportService.statusFileExists(project.name) ){

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectController2Spec.groovy
@@ -1756,6 +1756,98 @@ class ProjectController2Spec extends Specification implements ControllerUnitTest
             assertEquals null,response.json.errors
     }
 
+    @Unroll
+    void "apiProjectImport rejects import-only principal for #mutatingOption when configure is denied"() {
+        given:
+            assert getControllerMethodAnnotation('apiProjectImport', RdAuthorizeProject).value() ==
+                    RundeckAccess.Project.AUTH_APP_IMPORT
+            setupImportApiService('json')
+            controller.frameworkService = Stub(FrameworkService)
+            controller.asyncImportService = Stub(AsyncImportService) {
+                statusFileExists(_) >> false
+            }
+            controller.projectService = Mock(ProjectService)
+            def authorizingProject = Mock(AuthorizingProject)
+            controller.rundeckAppAuthorizer = Stub(AppAuthorizer) {
+                project(_, _) >> authorizingProject
+            }
+            controller.rundeckAuthContextProcessor = Stub(AppAuthContextProcessor)
+            def archiveParams = new ProjectArchiveParams(project: 'test1')
+            archiveParams.setProperty(mutatingOption, true)
+            request.api_version = ApiVersions.V39
+            params.project = 'test1'
+            request.content = 'archive'.bytes
+            request.format = 'application/zip'
+            response.format = 'json'
+            request.method = 'PUT'
+
+        when:
+            controller.apiProjectImport(archiveParams)
+
+        then:
+            1 * authorizingProject.getResource() >> Stub(IRundeckProject) {
+                getName() >> 'test'
+            }
+            1 * authorizingProject.authorize(RundeckAccess.Project.APP_CONFIGURE) >> {
+                throw new UnauthorizedAccess('configure', 'Project', 'test')
+            }
+            1 * controller.rundeckExceptionHandler.handleException(_, _, _ as UnauthorizedAccess)
+            0 * controller.projectService.handleApiImport(
+                    _, _, _, _, { it.is(archiveParams) && it."$mutatingOption" }
+            )
+
+        where:
+            mutatingOption << ['importConfig', 'importNodesSources']
+    }
+
+    void "apiProjectImport preserves jobs-only import for import-only principal"() {
+        given:
+            assert getControllerMethodAnnotation('apiProjectImport', RdAuthorizeProject).value() ==
+                    RundeckAccess.Project.AUTH_APP_IMPORT
+            setupImportApiService('json')
+            controller.frameworkService = Stub(FrameworkService)
+            controller.asyncImportService = Stub(AsyncImportService) {
+                statusFileExists(_) >> false
+            }
+            controller.projectService = Mock(ProjectService)
+            def authorizingProject = Mock(AuthorizingProject)
+            controller.rundeckAppAuthorizer = Stub(AppAuthorizer) {
+                project(_, _) >> authorizingProject
+            }
+            controller.rundeckAuthContextProcessor = Stub(AppAuthContextProcessor)
+            def archiveParams = new ProjectArchiveParams(
+                    project: 'test1',
+                    importConfig: false,
+                    importNodesSources: false,
+                    importScm: false
+            )
+            request.api_version = ApiVersions.V39
+            params.project = 'test1'
+            request.content = 'archive'.bytes
+            request.format = 'application/zip'
+            response.format = 'json'
+            request.method = 'PUT'
+
+        when:
+            controller.apiProjectImport(archiveParams)
+
+        then:
+            1 * authorizingProject.getResource() >> Stub(IRundeckProject) {
+                getName() >> 'test'
+            }
+            0 * authorizingProject.authorize(RundeckAccess.Project.APP_CONFIGURE)
+            1 * controller.projectService.handleApiImport(
+                    _, _, _, _, {
+                        it.is(archiveParams) &&
+                                !it.importConfig &&
+                                !it.importNodesSources &&
+                                !it.importScm
+                    }
+            ) >> [success: true]
+            response.status == HttpServletResponse.SC_OK
+            response.json == [import_status: 'successful', successful: true]
+    }
+
 
 
     void apiProjectList_json_date_v33_creation_time(){

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerSpec.groovy
@@ -2214,6 +2214,54 @@ class ProjectControllerSpec extends Specification implements ControllerUnitTest<
         request.errorArgs == [ACTION_CREATE, 'ACL for Project', 'test']
 
     }
+
+    @Unroll
+    def "importArchive rejects import-only principal for #mutatingOption when configure is denied"() {
+        given:
+            assert getControllerMethodAnnotation('importArchive', RdAuthorizeProject).value() ==
+                    RundeckAccess.Project.AUTH_APP_IMPORT
+            def project = Stub(IRundeckProject) {
+                getName() >> 'test'
+            }
+            def authorizingProject = Mock(AuthorizingProject) {
+                getResource() >> project
+                getAuthContext() >> Stub(UserAndRolesAuthContext)
+            }
+            controller.rundeckAppAuthorizer = Stub(AppAuthorizer) {
+                project(_, _) >> authorizingProject
+            }
+            controller.metaClass.getAuthorizingProject = { authorizingProject }
+            controller.rundeckAuthContextProcessor = Stub(AppAuthContextProcessor)
+            controller.frameworkService = Stub(FrameworkService) {
+                getFrameworkProject('test') >> project
+                getRundeckFramework() >> Stub(IFramework)
+            }
+            controller.projectService = Mock(ProjectService) {
+                validateAllProjectComponentImportOptions(_) >> [:]
+            }
+            setupFormTokens()
+            params.project = 'test'
+            params.importACL = 'false'
+            params."$mutatingOption" = 'true'
+            request.method = 'POST'
+            request.addFile(new GrailsMockMultipartFile('zipFile', 'archive'.bytes))
+
+        when:
+            controller.importArchive()
+
+        then:
+            1 * authorizingProject.authorize(RundeckAccess.Project.APP_CONFIGURE) >> {
+                throw new UnauthorizedAccess('configure', 'Project', 'test')
+            }
+            1 * controller.rundeckExceptionHandler.handleException(_, _, _ as UnauthorizedAccess)
+            0 * controller.projectService.importToProject(
+                    _, _, _, _, { it."$mutatingOption" }
+            )
+
+        where:
+            mutatingOption << ['importConfig', 'importNodesSources', 'importScm']
+    }
+
     def "import archive token failure"(){
         setup:
         controller.frameworkService=Mock(FrameworkService){


### PR DESCRIPTION
## Tell us about your PR

### Type and failure boundary

This is a bugfix.

Project archive imports are initially authorized by the project `import` action. When an import includes project configuration, node sources, or SCM configuration, the request can reach configuration mutation without an additional project `configure` authorization check.

Fixes #10459

### Implemented solution

Require `RundeckAccess.Project.APP_CONFIGURE` only for configuration-bearing archive imports:

- GUI archive import: `importConfig`, `importNodesSources`, or `importScm`
- API archive import: `importConfig` or `importNodesSources`, after the API v38 compatibility normalization

The existing API `importScm` authorization check and existing ACL checks remain unchanged. Jobs-only archive imports continue to require only project `import` authorization.

Controller regression coverage verifies the five denied configuration-import paths, the existing API SCM denial, and jobs-only preservation.

### Alternatives considered

Requiring `APP_CONFIGURE` for every archive import was not used because that would also change the authorization requirement for jobs-only imports.

Moving the check into the authorization framework, project service, or archive implementation was not necessary for this bounded controller-level repair.

### Verification

Passed locally with Gradle 8.14.5, Eclipse Temurin 17, and offline dependency resolution:

- Focused authorization and preservation cases: 7/7
  - `ProjectController2Spec`: 4/4
  - `ProjectControllerSpec`: 3/3
- Full affected controller specs: 198/198
  - `ProjectController2Spec`: 77/77
  - `ProjectControllerSpec`: 121/121
- `git diff --check`

The full 6,113-unit-test suite, Docker/full-application testing, functional or integration suites, and end-to-end archive verification were not run.

### AI assistance disclosure

AI assistance was used to investigate the issue and draft the patch and tests. I reviewed the final diff and take responsibility for this submission.

## Release Notes

Project archive imports that include project configuration, node sources, or SCM settings now require project `configure` authorization.
