### PR TITLE
[RUN-4693] Harden job option input validation (enforced fail-closed, undeclared-option rejection, OptsUtil quoting)

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -159,6 +159,13 @@ public class RundeckConfigBase {
         RetryConfig finalize;
         RetryConfig status;
         ExecutionLogs logs;
+        /**
+         * RUN-4693: when true (default), an execution that provides options not declared on the job
+         * is created and then failed at start. Set false to restore the legacy passthrough. Bound
+         * from {@code rundeck.execution.rejectUndeclaredOptions} so it is resolvable via
+         * ConfigurationService and editable in the System Configuration UI.
+         */
+        Boolean rejectUndeclaredOptions;
 
         @Data
         public static class RetryConfig {

--- a/core/src/main/java/com/dtolabs/rundeck/core/utils/OptsUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/utils/OptsUtil.java
@@ -88,7 +88,12 @@ public class OptsUtil {
     }
 
     public static void escapeChars(StringBuilder out, String str) {
-        if (StringUtils.containsNone(str, CSV_SEARCH_CHARS) && !"".equals(str)) {
+        // A value is only safe to emit unquoted if it contains none of the CSV search chars AND no
+        // control/whitespace char with code <= 32. QuotedStringTokenizer.burst() splits on any char
+        // <= 32 (StrMatcher.trimMatcher()), so a value containing e.g. a TAB that is not quoted here
+        // would be re-split on burst() — breaking the join()/burst() round-trip and allowing extra
+        // tokens (arg smuggling). Quoting such values keeps the round-trip intact. See RUN-4693.
+        if (StringUtils.containsNone(str, CSV_SEARCH_CHARS) && !"".equals(str) && !containsControlChar(str)) {
             if (str != null) {
                 out.append(str);
             }
@@ -103,6 +108,25 @@ public class OptsUtil {
             out.append(c);
         }
         out.append(DBL_QUOTE);
+    }
+
+    /**
+     * @param str input (may be null)
+     * @return true if the string contains any character with code point &lt;= 32 (space and control
+     * characters such as TAB, VT, FF), which {@link QuotedStringTokenizer} treats as a delimiter.
+     * Only ASCII control/whitespace is matched; all non-ASCII text (e.g. Japanese, full-width space
+     * U+3000) is above 32 and is not affected.
+     */
+    private static boolean containsControlChar(final String str) {
+        if (str == null) {
+            return false;
+        }
+        for (int i = 0; i < str.length(); i++) {
+            if (str.charAt(i) <= 32) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/core/src/test/java/com/dtolabs/rundeck/core/utils/TestOptsUtil.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/utils/TestOptsUtil.java
@@ -201,5 +201,40 @@ public class TestOptsUtil extends TestCase {
         );
     }
 
+    /**
+     * RUN-4693: a value containing a TAB (or any char <= 32 not already covered) must be quoted by
+     * join() so burst() does not re-split it into extra tokens.
+     */
+    public void testJoinQuotesTab() {
+        assertEquals("-arg \"a\tb\"",
+                OptsUtil.join(new String[]{"-arg", "a\tb"})
+        );
+    }
+
+    /**
+     * RUN-4693: burst(join(x)) must round-trip. Values containing whitespace/control chars <= 32
+     * must survive as single tokens; non-ASCII text (Japanese, full-width space U+3000) is above 32
+     * and must be unaffected.
+     */
+    public void testJoinBurstRoundTrip() {
+        String[][] cases = new String[][]{
+                {"-arg", "plain"},
+                {"-arg", "a b"},
+                {"-arg", "a\tb"},                 // TAB
+                {"-arg", "a\r\nb"},               // CR/LF
+                {"-x", "foo\t-inject\tvalue"},    // smuggling attempt: must stay ONE token
+                {"-arg", "あ　日"},   // Japanese あ　日 incl. full-width space U+3000
+        };
+        for (String[] input : cases) {
+            String joined = OptsUtil.join(input);
+            String[] burst = OptsUtil.burst(joined);
+            assertEquals(
+                    "round-trip failed for " + Arrays.asList(input) + " joined=[" + joined + "]",
+                    Arrays.asList(input),
+                    Arrays.asList(burst)
+            );
+        }
+    }
+
 }
 

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
@@ -868,6 +868,11 @@ class JobExecutionSpec extends BaseContainer {
                     "    <uuid>165ef9b9-61dc-470c-91aa-3f6dc248249d</uuid>\n" +
                     "  </job>\n" +
                     "  <job>\n" +
+                    "    <context>\n" +
+                    "      <options>\n" +
+                    "        <option name='opt2' />\n" +
+                    "      </options>\n" +
+                    "    </context>\n" +
                     "    <defaultTab>summary</defaultTab>\n" +
                     "    <description></description>\n" +
                     "    <executionEnabled>true</executionEnabled>\n" +

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionStatusSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionStatusSpec.groovy
@@ -55,6 +55,11 @@ class JobExecutionStatusSpec extends BaseContainer {
                       <group>api-test/job-run-timeout</group>
                       <description></description>
                       <loglevel>INFO</loglevel>
+                      <context>
+                        <options>
+                          <option name='opt2' />
+                        </options>
+                      </context>
                       <timeout>3s</timeout>
                       <dispatch>
                         <threadcount>1</threadcount>
@@ -95,6 +100,11 @@ class JobExecutionStatusSpec extends BaseContainer {
                           <group>api-test/job-run-timeout-retry</group>
                           <description></description>
                           <loglevel>INFO</loglevel>
+                          <context>
+                            <options>
+                              <option name='opt2' />
+                            </options>
+                          </context>
                           <timeout>3s</timeout>
                           <retry>1</retry>
                           <dispatch>
@@ -137,5 +147,53 @@ class JobExecutionStatusSpec extends BaseContainer {
             responseExec1.status == 'timedout'
             response.retriedExecution != null
         }
+    }
+
+    def "job/id/run rejects options not declared on the job (RUN-4693)"() {
+        setup: "a job that declares NO options"
+        def projectName = UUID.randomUUID().toString()
+        setupProject(projectName)
+        def xml = """
+                <joblist>
+                   <job>
+                      <name>no-options job</name>
+                      <group>api-test/job-run-undeclared</group>
+                      <description></description>
+                      <loglevel>INFO</loglevel>
+                      <sequence>
+                        <command>
+                        <exec>echo hello</exec>
+                        </command>
+                      </sequence>
+                   </job>
+                </joblist>
+            """
+        def path = JobUtils.generateFileToImport(xml, 'xml')
+        def jobId = JobUtils.jobImportFile(projectName, path, client).succeeded[0].id
+
+        when: "the job is run with an option it does not declare (option injection attempt)"
+        def jobRun = JobUtils.executeJobWithArgs(jobId, client, "-ghost pwned")
+        def execId = jsonValue(jobRun.body()).id
+
+        then: "the execution is created"
+        execId != null
+
+        when: "the execution finishes"
+        def execFinal = JobUtils.waitForExecution(
+                ExecutionStatus.FAILED.state,
+                execId as String,
+                client,
+                WaitingTime.EXCESSIVE)
+
+        then: "it is failed at start because the option is not declared on the job"
+        execFinal.status == 'failed'
+
+        when:
+        def output = JobUtils.getExecutionOutput(execId as String, client)
+        def logs = output.entries.collect { it.log }
+
+        then: "the rejection is reported in the log and the job step never ran"
+        logs.any { it.contains('Execution rejected') && it.contains('ghost') }
+        !logs.any { it.contains('hello') }
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/input/OptionInputValidationSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/input/OptionInputValidationSpec.groovy
@@ -1,0 +1,110 @@
+package org.rundeck.tests.functional.api.job.input
+
+import org.rundeck.util.annotations.APITest
+import org.rundeck.util.api.responses.execution.Execution
+import org.rundeck.util.common.WaitingTime
+import org.rundeck.util.common.jobs.JobUtils
+import org.rundeck.util.container.BaseContainer
+import org.testcontainers.shaded.org.yaml.snakeyaml.Yaml
+
+/**
+ * RUN-4693: end-to-end coverage for the opt-in option-value allowlist
+ * ({@code project.option.input.validation.default.pattern}) against the Inline Script sink.
+ *
+ * <p>The Inline Script step expands {@code @option.x@} verbatim into the executed temp script, so an
+ * option value carrying shell metacharacters is a command-injection vector. These tests run the
+ * actual PoC through a real execution:
+ * <ul>
+ *   <li>with the allowlist configured, the malicious value is rejected before any execution runs;</li>
+ *   <li>with no allowlist (the default), the same value is executed — documenting that the control is
+ *   opt-in and the sink is still vulnerable by default.</li>
+ * </ul>
+ */
+@APITest
+class OptionInputValidationSpec extends BaseContainer {
+
+    // Project WITH the allowlist configured — malicious option values must be rejected.
+    public static final String BLOCKED_PROJECT = 'OptionInputValidationBlocked'
+    // Project WITHOUT the allowlist — the default, still-vulnerable configuration.
+    public static final String CONTROL_PROJECT = 'OptionInputValidationControl'
+
+    // Allowlist that permits only benign characters; shell metacharacters (" ; etc.) are rejected.
+    public static final String ALLOWLIST = '[a-zA-Z0-9 ._-]+'
+
+    // Project-level config key for the allowlist (mirrors AppConstants.PROJECT_OPTION_INPUT_DEFAULT_PATTERN;
+    // duplicated here to avoid the test module depending on server-side classes).
+    public static final String PROJECT_PATTERN_KEY = 'project.option.input.validation.default.pattern'
+
+    // Inline Script step that echoes the option value through the vulnerable @option.x@ sink.
+    public static final String SCRIPT = '''#!/bin/bash
+echo "target=@option.target@"
+'''
+
+    def setupSpec() {
+        startEnvironment()
+        setupProject(BLOCKED_PROJECT, [(PROJECT_PATTERN_KEY): ALLOWLIST])
+        setupProject(CONTROL_PROJECT)
+    }
+
+    private static Map<String, Object> inlineScriptJob(String name, String uuid) {
+        return [
+            name            : name,
+            uuid            : uuid,
+            description     : '',
+            executionEnabled: true,
+            loglevel        : 'INFO',
+            options         : [
+                [name: 'target', type: 'text']
+            ],
+            sequence        : [
+                commands : [
+                    [script: SCRIPT]
+                ],
+                keepgoing: false,
+                strategy : 'node-first'
+            ]
+        ]
+    }
+
+    def "option value violating the configured allowlist is rejected before any execution (RUN-4693 PoC)"() {
+        given: 'a job whose Inline Script step references @option.target@, in a project with the allowlist enabled'
+            String jobUuid = UUID.randomUUID().toString()
+            def yamlJob = new Yaml().dump([inlineScriptJob('inline script option injection - blocked', jobUuid)])
+            JobUtils.createJob(BLOCKED_PROJECT, yamlJob, client, 'application/yaml')
+
+        when: 'the H1 PoC payload is submitted as the option value'
+            def response = JobUtils.executeJobWithOptions(jobUuid, client, [options: [target: '"; id; echo "']])
+            def body = response.body().string()
+
+        then: 'the run is rejected by the allowlist and no execution is started'
+            response.code() == 400
+            body.contains('options-invalid') || body.toLowerCase().contains('validation pattern')
+    }
+
+    def "without an allowlist the inline-script sink executes the injected command (RUN-4693 default is vulnerable)"() {
+        given: 'the same job in a project with NO allowlist configured (the default)'
+            String jobUuid = UUID.randomUUID().toString()
+            def yamlJob = new Yaml().dump([inlineScriptJob('inline script option injection - control', jobUuid)])
+            JobUtils.createJob(CONTROL_PROJECT, yamlJob, client, 'application/yaml')
+
+        when: 'an option value that injects a second command is submitted'
+            def execResponse = JobUtils.executeJobWithOptions(jobUuid, client, [options: [target: 'x; echo INJECTED']])
+            Execution exec = jsonValue(execResponse.body(), Execution.class)
+
+        then: 'the execution is accepted and starts'
+            exec.status == 'running'
+
+        when:
+            def execFinal = waitForExecutionFinish(exec.id as String, WaitingTime.EXCESSIVE)
+
+        then: 'it succeeds'
+            execFinal.status == 'succeeded'
+
+        when:
+            def output = JobUtils.getExecutionOutput(exec.id, client)
+            def logs = output.entries.collect { it.log }
+
+        then: 'the injected command ran — proving the sink is still exploitable without the allowlist'
+            logs.any { it.contains('INJECTED') }
+    }
+}

--- a/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
@@ -36,6 +36,7 @@ import grails.util.Environment
 import groovy.sql.Sql
 import org.grails.plugins.metricsweb.CallableGauge
 import org.quartz.Scheduler
+import org.rundeck.app.AppConstants
 import rundeck.services.LogFileStorageService
 import rundeck.services.feature.FeatureService
 import rundeckapp.cli.CommandLineSetup
@@ -329,6 +330,18 @@ class BootStrap {
             log.warn("=" * 80)
         }else{
             log.info("RSS feeds disabled")
+        }
+
+        // RUN-4693: warn at startup when the undeclared-option reject control is turned off. This is a
+        // security control (it stops option values that are not declared on a job from reaching the
+        // option data context and RD_OPTION_* environment variables without validation); disabling it
+        // re-opens that passthrough, so make the weakened posture visible in the logs.
+        if (!configurationService.getBoolean(AppConstants.SYSTEM_REJECT_UNDECLARED_OPTIONS, true)) {
+            log.warn("=" * 80)
+            log.warn("SECURITY: ${AppConstants.SYSTEM_REJECT_UNDECLARED_OPTIONS_KEY}=false")
+            log.warn("Undeclared job options are ALLOWED to pass through to executions.")
+            log.warn("Option values not defined on a job will reach the option data context and")
+            log.warn("RD_OPTION_* environment variables WITHOUT server-side validation.")
         }
 
         //Setup the correct authentication provider for the configured authentication mechanism

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1243,7 +1243,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             // (default true; set false to restore the legacy passthrough, e.g. re-running a job whose
             // option set has since changed).
             if (scheduledExecution != null
-                    && configurationService.getBoolean("execution.rejectUndeclaredOptions", true)) {
+                    && configurationService.getBoolean(AppConstants.SYSTEM_REJECT_UNDECLARED_OPTIONS, true)) {
                 Set<String> declaredOptionNames = (scheduledExecution.options?.collect { it.name } ?: []) as Set
                 Set<String> providedOptionNames = OptionsParserUtil.parseOptsFromString(execution.argString)?.keySet() ?: ([] as Set)
                 List<String> undeclaredOptionNames = providedOptionNames.findAll { !declaredOptionNames.contains(it) }.sort()
@@ -5468,7 +5468,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     build()
                 },
                 SystemConfig.builder().with {
-                    key "rundeck.execution.rejectUndeclaredOptions"
+                    key AppConstants.SYSTEM_REJECT_UNDECLARED_OPTIONS_KEY
                     description "When enabled (default), an execution that provides options not defined on the job is created and then failed at start, with a message in the execution log. Disable to allow undeclared options to pass through (e.g. re-running a job whose option set has since changed)."
                     defaultValue "true"
                     required false

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -5467,6 +5467,17 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     authRequired("app_admin")
                     build()
                 },
+                SystemConfig.builder().with {
+                    key "rundeck.execution.rejectUndeclaredOptions"
+                    description "When enabled (default), an execution that provides options not defined on the job is created and then failed at start, with a message in the execution log. Disable to allow undeclared options to pass through (e.g. re-running a job whose option set has since changed)."
+                    defaultValue "true"
+                    required false
+                    datatype "Boolean"
+                    visibility 'Advanced'
+                    category 'Execution'
+                    authRequired("app_admin")
+                    build()
+                },
         ] as List<SysConfigProp>
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3340,10 +3340,13 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      * property {@link AppConstants#PROJECT_OPTION_INPUT_DEFAULT_PATTERN} takes precedence over the
      * system-wide {@link AppConstants#SYSTEM_OPTION_INPUT_DEFAULT_PATTERN}. The system value is read
      * through ConfigurationService so it is editable via the System Configuration UI. Returns null
-     * when no pattern is configured, the configured value is blank, or the value is not a valid regex
-     * (in which case a warning is logged and no default validation is applied).
+     * when no pattern is configured or the configured value is blank (validation is simply not
+     * applied). If a pattern IS configured but is not a valid regular expression, this fails closed:
+     * it logs an error and throws {@link ExecutionServiceValidationException} so executions are
+     * blocked, rather than silently disabling the control (RUN-4693).
      * @param project project name
-     * @return compiled {@link Pattern} or null
+     * @return compiled {@link Pattern}, or null when no pattern is configured
+     * @throws ExecutionServiceValidationException when a configured pattern is not a valid regex
      */
     /**
      * RUN-4693: whether an option value is already constrained by the option's own definition — it
@@ -3377,8 +3380,17 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         try {
             return Pattern.compile(pattern)
         } catch (PatternSyntaxException e) {
-            log.warn("Ignoring invalid default option input validation pattern '${pattern}'", e)
-            return null
+            // RUN-4693: fail closed. A configured-but-invalid pattern must NOT silently disable the
+            // control — an operator typo would otherwise leave option values unvalidated while the
+            // setting still appears to be "on". Refuse to run instead, and point at the
+            // misconfiguration in the log. The user-facing message deliberately omits the pattern
+            // string to avoid leaking configuration to job runners.
+            log.error("Invalid default option input validation pattern '${pattern}'; refusing to run (fail closed). Fix or unset the pattern.", e)
+            throw new ExecutionServiceValidationException(
+                    "Option input validation is misconfigured: the configured validation pattern is not a valid " +
+                    "regular expression. Executions are blocked until an administrator fixes or removes it.",
+                    [:], [:]
+            )
         }
     }
 
@@ -5469,7 +5481,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 },
                 SystemConfig.builder().with {
                     key AppConstants.SYSTEM_REJECT_UNDECLARED_OPTIONS_KEY
-                    description "When enabled (default), an execution that provides options not defined on the job is created and then failed at start, with a message in the execution log. Disable to allow undeclared options to pass through (e.g. re-running a job whose option set has since changed)."
+                    description "Security control. When enabled (default), an execution that provides options not defined on the job is created and then failed at start. Disable ONLY if you must allow undeclared options to pass through."
                     defaultValue "true"
                     required false
                     datatype "Boolean"

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1251,7 +1251,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     loghandler.logError(
                             "Execution rejected: option(s) not defined on this job were provided: " +
                             "${undeclaredOptionNames}. Update the job definition or remove these options, " +
-                            "or set rundeck.execution.rejectUndeclaredOptions=false to allow them. (RUN-4693)"
+                            "or set rundeck.execution.rejectUndeclaredOptions=false to allow them."
                     )
                     throw new ExecutionServiceException(
                             "Options not defined on this job were provided: ${undeclaredOptionNames}",

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3152,7 +3152,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         // execution time (checked per-option via hasOwnValueConstraint after the remote load).
         // Null when unset/empty/invalid.
         boolean anyDefaultValidatable = scheduledExecution.options?.any { Option o ->
-            !o.regex && optparams[o.name]
+            !o.regex && !o.typeFile && optparams[o.name]
         }
         Pattern defaultInputPattern = anyDefaultValidatable ?
                 resolveDefaultOptionInputPattern(scheduledExecution.project) : null
@@ -3219,7 +3219,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 }
                 if (opt.multivalued) {
                     boolean multivaluedOptionEvalFailed = false
-                    if (opt.regex && !opt.enforced && optparams[opt.name]) {
+                    if (opt.regex && optparams[opt.name]) {
                         def val
                         if (optparams[opt.name] instanceof Collection) {
                             val = [optparams[opt.name]].flatten();
@@ -3238,7 +3238,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                             return
                         }
                     }
-                    if (!hasOwnValueConstraint(opt) && defaultInputPattern && optparams[opt.name]) {
+                    if (!hasOwnValueConstraint(opt) && !opt.typeFile && defaultInputPattern && optparams[opt.name]) {
                         def val
                         if (optparams[opt.name] instanceof Collection) {
                             val = [optparams[opt.name]].flatten();
@@ -3273,7 +3273,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                         }
                     }
                 } else {
-                    if (opt.regex && !opt.enforced && optparams[opt.name]) {
+                    if (opt.regex && optparams[opt.name]) {
                         if (!(optparams[opt.name] ==~ opt.regex)) {
                             invalidOpt opt, opt.secureInput ?
                                     lookupMessage("domain.Option.validation.secure.invalid",[opt.name])
@@ -3282,7 +3282,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                             return
                         }
                     }
-                    if (!hasOwnValueConstraint(opt) && defaultInputPattern && optparams[opt.name]) {
+                    if (!hasOwnValueConstraint(opt) && !opt.typeFile && defaultInputPattern && optparams[opt.name]) {
                         if (!defaultInputPattern.matcher(optparams[opt.name].toString()).matches()) {
                             invalidOpt opt, opt.secureInput ?
                                     lookupMessage("domain.Option.validation.secure.invalid",[opt.name])

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3145,11 +3145,14 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             sb << msg
             failedkeys[opt.name] += msg
         }
-        // RUN-4693: project/system-wide default allowlist applied to option values that have no
-        // per-option regex. Only resolved when at least one option would actually be validated by
-        // it, to avoid a config lookup on executions that cannot use it. Null when unset/empty/invalid.
+        // RUN-4693: project/system-wide default allowlist applied to option values that are not
+        // already constrained by the option's own definition. Only resolved when at least one
+        // option could need it, to avoid a config lookup on executions that cannot use it. Enforced
+        // options are included here because their remote/plugin value list may fail to resolve at
+        // execution time (checked per-option via hasOwnValueConstraint after the remote load).
+        // Null when unset/empty/invalid.
         boolean anyDefaultValidatable = scheduledExecution.options?.any { Option o ->
-            !o.regex && !o.enforced && optparams[o.name]
+            !o.regex && optparams[o.name]
         }
         Pattern defaultInputPattern = anyDefaultValidatable ?
                 resolveDefaultOptionInputPattern(scheduledExecution.project) : null
@@ -3235,7 +3238,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                             return
                         }
                     }
-                    if (!opt.regex && defaultInputPattern && !opt.enforced && optparams[opt.name]) {
+                    if (!hasOwnValueConstraint(opt) && defaultInputPattern && optparams[opt.name]) {
                         def val
                         if (optparams[opt.name] instanceof Collection) {
                             val = [optparams[opt.name]].flatten();
@@ -3279,7 +3282,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                             return
                         }
                     }
-                    if (!opt.regex && defaultInputPattern && !opt.enforced && optparams[opt.name]) {
+                    if (!hasOwnValueConstraint(opt) && defaultInputPattern && optparams[opt.name]) {
                         if (!defaultInputPattern.matcher(optparams[opt.name].toString()).matches()) {
                             invalidOpt opt, opt.secureInput ?
                                     lookupMessage("domain.Option.validation.secure.invalid",[opt.name])
@@ -3317,6 +3320,20 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      * @param project project name
      * @return compiled {@link Pattern} or null
      */
+    /**
+     * RUN-4693: whether an option value is already constrained by the option's own definition — it
+     * has a per-option regex, or it is enforced AND its allowed values actually resolved (static
+     * list, or remote/plugin values that loaded successfully). An enforced option whose remote
+     * value list errors or returns empty leaves {@code optionValues} null and is therefore NOT
+     * constrained; such values must fall through to the default input allowlist instead of skipping
+     * server-side validation entirely.
+     * @param opt option
+     * @return true when the option constrains its own value
+     */
+    private static boolean hasOwnValueConstraint(Option opt) {
+        opt.regex || (opt.enforced && opt.optionValues)
+    }
+
     private Pattern resolveDefaultOptionInputPattern(String project) {
         String pattern = null
         try {

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1235,6 +1235,31 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             def jobcontext=exportContextForExecution(execution, grailsLinkGenerator)
             loghandler.openStream()
 
+            // RUN-4693: reject options that are not declared on the job. Undeclared option values
+            // bypass all server-side validation (validateOptionValues only iterates the job's declared
+            // options) yet are still parsed into the option DataContext and exported as RD_OPTION_*
+            // env vars. Fail the (already created) execution here — before any workflow step runs —
+            // with a clear message in the log output. Gated by rundeck.execution.rejectUndeclaredOptions
+            // (default true; set false to restore the legacy passthrough, e.g. re-running a job whose
+            // option set has since changed).
+            if (scheduledExecution != null
+                    && configurationService.getBoolean("execution.rejectUndeclaredOptions", true)) {
+                Set<String> declaredOptionNames = (scheduledExecution.options?.collect { it.name } ?: []) as Set
+                Set<String> providedOptionNames = OptionsParserUtil.parseOptsFromString(execution.argString)?.keySet() ?: ([] as Set)
+                List<String> undeclaredOptionNames = providedOptionNames.findAll { !declaredOptionNames.contains(it) }.sort()
+                if (undeclaredOptionNames) {
+                    loghandler.logError(
+                            "Execution rejected: option(s) not defined on this job were provided: " +
+                            "${undeclaredOptionNames}. Update the job definition or remove these options, " +
+                            "or set rundeck.execution.rejectUndeclaredOptions=false to allow them. (RUN-4693)"
+                    )
+                    throw new ExecutionServiceException(
+                            "Options not defined on this job were provided: ${undeclaredOptionNames}",
+                            "options-not-declared"
+                    )
+                }
+            }
+
             // Before execute the job, check if there is any pre execution check error. If there is some error throw a JobLifecycleComponentException
             // This will let the loghandler save the error message into the execution log file.
             String preExecutionCheckError = execution.getExtraMetadataMap().get(JobPreExecutionEvent.getName())

--- a/rundeckapp/src/main/groovy/org/rundeck/app/AppConstants.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/AppConstants.groovy
@@ -41,4 +41,16 @@ class AppConstants {
      * regex of their own. Takes precedence over {@link #SYSTEM_OPTION_INPUT_DEFAULT_PATTERN}.
      */
     static final String PROJECT_OPTION_INPUT_DEFAULT_PATTERN = "project.option.input.validation.default.pattern"
+
+    /**
+     * When true (default), an execution that provides options not declared on the job is created and
+     * then failed at start. Resolved through ConfigurationService; this constant holds the sub-key
+     * (without the {@code rundeck.} prefix) used with {@code ConfigurationService.getBoolean}.
+     */
+    static final String SYSTEM_REJECT_UNDECLARED_OPTIONS = "execution.rejectUndeclaredOptions"
+    /**
+     * Full config key (with {@code rundeck.} prefix) of {@link #SYSTEM_REJECT_UNDECLARED_OPTIONS},
+     * as exposed in the System Configuration UI via SysConfigProp.
+     */
+    static final String SYSTEM_REJECT_UNDECLARED_OPTIONS_KEY = "rundeck." + SYSTEM_REJECT_UNDECLARED_OPTIONS
 }

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -6786,6 +6786,50 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
 
     @Unroll
+    def "executeAsyncBegin rejects options not declared on the job when flag enabled (RUN-4693 #4)"() {
+        given: "an execution whose argString carries an option not declared on the job"
+        def project = 'TestProject'
+        def execution = new Execution(
+                project: project,
+                user: 'testuser',
+                dateStarted: new Date(),
+                status: 'running',
+                loglevel: 'INFO',
+                argString: '-declared x -ghost y',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec([adhocRemoteString: 'echo hi'])]
+                )
+        )
+        execution.save(flush: true)
+        def scheduledExecution = new ScheduledExecution(jobName: 'j', project: project, workflow: execution.workflow)
+        scheduledExecution.addToOptions(new Option(name: 'declared', enforced: false))
+        scheduledExecution.save(flush: true)
+
+        def framework = Mock(IFramework) { getFrameworkNodeName() >> 'n' }
+        def authContext = Mock(UserAndRolesAuthContext)
+        def loghandler = Mock(ExecutionLogWriter) {
+            filepath >> new File('/tmp/test.log')
+            openStream() >> {}
+        }
+        service.loggingService = Mock(LoggingService) { openLogWriter(_, _, _, _) >> loghandler }
+        service.frameworkService = Mock(FrameworkService) { getDefaultInputCharsetForProject(_) >> 'UTF-8' }
+        service.configurationService = Mock(ConfigurationService) {
+            getBoolean('execution.rejectUndeclaredOptions', true) >> true
+        }
+        service.grailsLinkGenerator = Mock(LinkGenerator)
+        service.metricService = Mock(MetricService)
+        service.sysThreadBoundOut = new ThreadBoundOutputStream(System.out)
+        service.sysThreadBoundErr = new ThreadBoundOutputStream(System.err)
+
+        when:
+        def result = service.executeAsyncBegin(framework, authContext, execution, scheduledExecution)
+
+        then: "the execution fails to start and the undeclared option is reported in the log output"
+        result == null
+        1 * loghandler.logError({ String m -> m.contains('Execution rejected') && m.contains('ghost') })
+    }
+
     def "executeAsyncBegin workflow modification - workflow updated when isUpdateWorkflowDataValues is #updateWorkflowDataValues"() {
         given: "an execution with scheduled job"
         def project = 'TestProject'

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -2112,6 +2112,20 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         ['test1': 'PlainVal'] | _
     }
 
+    def "validate option values, invalid configured pattern fails closed (RUN-4693)"() {
+        given: 'a configured default input pattern that is not a valid regex (operator typo)'
+        ScheduledExecution se = new ScheduledExecution(project: 'AProject')
+        se.addToOptions(new Option(name: 'test1', enforced: false))
+        stubProjectOptionPattern('[unclosed')
+
+        when: 'a value is validated'
+        service.validateOptionValues(se, ['test1': 'anything'])
+
+        then: 'the execution is blocked rather than silently allowed (control not disabled)'
+        ExecutionServiceValidationException e = thrown()
+        e.message.contains('misconfigured')
+    }
+
     def "validate option values, default input pattern failure"() {
         given:
         ScheduledExecution se = new ScheduledExecution(project: 'AProject')
@@ -2306,8 +2320,8 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         e.message == 'domain.Option.validation.default.pattern.invalid'
     }
 
-    def "validate option values, blank or invalid default input pattern is ignored"() {
-        given:
+    def "validate option values, blank default input pattern is ignored"() {
+        given: 'a blank/whitespace pattern means the control is simply not configured'
         ScheduledExecution se = new ScheduledExecution(project: 'AProject')
         se.addToOptions(new Option(name: 'test1', enforced: false))
         stubProjectOptionPattern(pattern)
@@ -2315,14 +2329,13 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         when:
         def validation = service.validateOptionValues(se, ['test1': 'any value ; here'])
 
-        then:
+        then: 'validation is not applied (an invalid — non-blank — pattern is handled separately, fail-closed)'
         validation
 
         where:
         pattern    | _
         ''         | _
         '   '      | _
-        '[unclosed'| _
     }
 
     def "validate option values, enforced valid"() {

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -6815,7 +6815,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         service.loggingService = Mock(LoggingService) { openLogWriter(_, _, _, _) >> loghandler }
         service.frameworkService = Mock(FrameworkService) { getDefaultInputCharsetForProject(_) >> 'UTF-8' }
         service.configurationService = Mock(ConfigurationService) {
-            getBoolean('execution.rejectUndeclaredOptions', true) >> true
+            getBoolean(AppConstants.SYSTEM_REJECT_UNDECLARED_OPTIONS, true) >> true
         }
         service.grailsLinkGenerator = Mock(LinkGenerator)
         service.metricService = Mock(MetricService)

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -2224,6 +2224,31 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         validation
     }
 
+    def "validate option values does NOT validate options not declared on the job (RUN-4693 #4 characterization)"() {
+        given:
+        ScheduledExecution se = new ScheduledExecution(project: 'AProject')
+        se.addToOptions(new Option(name: 'declared', enforced: false))
+        stubProjectOptionPattern('[A-Za-z0-9]+')   // a strict allowlist IS configured
+
+        when: 'the request injects an option that does not exist in the job definition, with shell metacharacters'
+        def validation = service.validateOptionValues(se, ['declared': 'clean', 'ghost': '"; id; echo "'])
+
+        then: 'validateOptionValues only iterates declared options, so the injected option bypasses validation entirely (current behavior)'
+        validation
+    }
+
+    def "generateJobArgline carries through options not declared on the job (RUN-4693 #4 characterization)"() {
+        given:
+        ScheduledExecution se = new ScheduledExecution(project: 'AProject')
+        se.addToOptions(new Option(name: 'declared', enforced: false))
+
+        when: 'opts include a declared option plus an injected one not in the job definition'
+        String argline = ExecutionService.generateJobArgline(se, [declared: 'x', ghost: 'y'])
+
+        then: 'the injected option is preserved in the generated argline (passthrough "to preserve information")'
+        argline == '-declared x -ghost y'
+    }
+
     def "validate option values, default input pattern multivalued failure"() {
         given:
         ScheduledExecution se = new ScheduledExecution(project: 'AProject')

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -2187,6 +2187,43 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         e.message == 'domain.Option.validation.default.pattern.invalid'
     }
 
+    def "validate option values, enforced option with its own regex now validates the regex"() {
+        given:
+        ScheduledExecution se = new ScheduledExecution(project: 'AProject')
+        // enforced AND has a regex; 'a b' is an allowed value but violates the regex (space)
+        final Option option = new Option(name: 'test1', enforced: true, regex: '[A-Za-z0-9]+')
+        option.valuesList = 'a b,c'
+        se.addToOptions(option)
+        service.messageSource = Mock(MessageSource) {
+            getMessage(_, _, _) >> { it[0] }
+        }
+
+        when: 'a value that is in the enforced list but violates the regex'
+        service.validateOptionValues(se, ['test1': 'a b'])
+
+        then: 'the per-option regex is now enforced even though the option is enforced'
+        ExecutionServiceException e = thrown()
+        e.message == 'domain.Option.validation.regex.invalid'
+    }
+
+    def "validate option values, default input pattern does not apply to typeFile options"() {
+        given:
+        ScheduledExecution se = new ScheduledExecution(project: 'AProject')
+        // a plain option (triggers pattern resolution) plus a typeFile option that must be exempt
+        se.addToOptions(new Option(name: 'plain', enforced: false))
+        se.addToOptions(new Option(name: 'thefile', enforced: false, optionType: 'file'))
+        stubProjectOptionPattern('[A-Za-z0-9]+')
+        service.fileUploadService = Mock(FileUploadService) {
+            validateFileRefForJobOption(*_) >> [valid: true]
+        }
+
+        when: 'the file-ref value contains dashes (would fail the pattern) while the plain value is clean'
+        def validation = service.validateOptionValues(se, ['plain': 'clean', 'thefile': 'abc-123-def-456'])
+
+        then: 'the typeFile option is exempt from the allowlist and validation passes'
+        validation
+    }
+
     def "validate option values, default input pattern multivalued failure"() {
         given:
         ScheduledExecution se = new ScheduledExecution(project: 'AProject')

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -2165,6 +2165,28 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         validation
     }
 
+    def "validate option values, default input pattern applies to enforced option when remote values fail to load"() {
+        given:
+        ScheduledExecution se = new ScheduledExecution(project: 'AProject')
+        // enforced option with no static values (dynamic remote dropdown)
+        se.addToOptions(new Option(name: 'test1', enforced: true))
+        stubProjectOptionPattern('[A-Za-z0-9]+')
+        service.messageSource = Mock(MessageSource) {
+            getMessage(_, _, _) >> { it[0] }
+        }
+        // remote value load errors → opt.optionValues stays null, so the enforced check can't fire
+        service.scheduledExecutionService = Mock(ScheduledExecutionService) {
+            loadOptionsRemoteValues(*_) >> [err: 'remote load failed']
+        }
+
+        when: 'a run-user supplies a value with shell metacharacters'
+        service.validateOptionValues(se, ['test1': '"; id; echo "'])
+
+        then: 'it falls through to the default allowlist and is rejected (fail-closed)'
+        ExecutionServiceException e = thrown()
+        e.message == 'domain.Option.validation.default.pattern.invalid'
+    }
+
     def "validate option values, default input pattern multivalued failure"() {
         given:
         ScheduledExecution se = new ScheduledExecution(project: 'AProject')


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Security-hardening follow-up for RUN-4693 (reopened), addressing review feedback from Garrett Rappaport on the merged opt-in option-input allowlist (#10429). Closes several gaps by which a `run`-only user could get unvalidated option values into the execution environment (option DataContext / `RD_OPTION_*` env vars, which also feed the `ssh-variable-export-pattern` sink of RUN-4579).

**Describe the solution you've implemented**

- **Enforced fail-closed** — an `enforced` option whose remote `valuesUrl`/plugin value list fails to load left `optionValues` null, so the enforced check never fired and the default allowlist skipped it (`!opt.enforced`) → zero validation. Introduces `hasOwnValueConstraint(opt) = opt.regex || (opt.enforced && opt.optionValues)`; the default allowlist now applies unless the option is genuinely self-constrained.
- **enforced + regex** now validates the regex (the per-option regex branches previously required `!opt.enforced`, silently ignoring the regex on enforced options).
- **typeFile exemption** — file-ref option values are system-generated UUIDs already validated by `fileUploadService`; they are now exempt from the default allowlist so a strict pattern doesn't reject them.
- **OptsUtil control-char quoting** — `escapeChars` quoted only `{space, " ' CR LF}` while `QuotedStringTokenizer.burst()` splits on any char `<= 32`; a TAB survived `join()` and was re-split by `burst()`, letting extra `-opt value` tokens be smuggled through the webhook payload → argString → runJob round-trip. `escapeChars` now also quotes values containing any char `<= 32`. Non-ASCII text (e.g. Japanese, full-width space U+3000) is above 32 and unaffected. Adds a `burst(join(x)) == x` round-trip test.
- **Reject undeclared options** — options not declared on the job bypass all server-side validation (validateOptionValues only iterates declared options) yet reach the option DataContext / `RD_OPTION_*` env vars. The execution is now **created and then failed at start** (in `executeAsyncBegin`, before any workflow step runs) with a clear message in the execution log output. Gated by `rundeck.execution.rejectUndeclaredOptions` (default `true`; System-Configuration-editable / `rundeck-config`-overridable).

**Behavior changes (default on unless noted):**
- enforced + regex: a value that is in the enforced allowed-values list but violates the regex now fails validation.
- undeclared options: an execution that provides options not defined on the job now fails at start (opt-out via `rundeck.execution.rejectUndeclaredOptions=false`). This affects re-running a job whose option set has since changed, and API/webhook callers that pass extra options.
- OptsUtil: values containing ASCII control chars (e.g. TAB) are now quoted (kept as a single token) instead of being re-split.
- Gated by an allowlist pattern being configured (no effect otherwise): enforced fail-closed, typeFile exemption.

**Describe alternatives you've considered**

Hardening the sink itself (escaping in `ReplaceTokenReader`/`ScriptVarExpander`, or gating `expandTokens`) is the only change that would close the finding by default, but it is the same class of change that caused the RUN-4175 → #10091 → revert regressions and has no context-free-correct form for a script body. Deferred as a separate, carefully-designed (likely flagged) change.

**Additional context**

- Config keys resolve through `ConfigurationService` and are registered as `SysConfigProp` (System Configuration UI): `rundeck.option.input.validation.default.pattern` (from #10429) and `rundeck.execution.rejectUndeclaredOptions`.
- Scope of undeclared-option rejection: top-level executions (UI/API/webhook/scheduled). The job-reference path (`createJobReferenceContext`) is author-controlled and left as a follow-up.
- Pending (not in this PR): sink hardening; documentation/release-note caveats (both config keys, `(?s).*` for newline matching, `\p{L}` guidance for non-ASCII/Japanese option values).

## Release Notes

Security hardening for job option input validation: enforced options whose remote value list fails to load are now validated by the configurable input allowlist; per-option regex is now applied to enforced options; `typeFile` options are exempt from the allowlist; option values containing control characters are quoted consistently to prevent argument smuggling; and executions that provide options not defined on the job now fail at start with a clear log message (configurable via `rundeck.execution.rejectUndeclaredOptions`, default enabled).