### PR TITLE
[RUN-4753] Add Linux to node.metadata.OsFamily.defaults suggestion list

### DIFF
--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -341,7 +341,7 @@ node.metadata.type=Type
 node.metadata.username=Username
 node.metadata.tags=Tags
 
-node.metadata.OsFamily.defaults=unix,windows,cygwin
+node.metadata.OsFamily.defaults=unix,windows,cygwin,Linux
 node.metadata.OsName.defaults=FreeBSD,Linux,Mac OS X,SunOS,Windows XP,Windows 2003
 node.metadata.OsArch.defaults=i386,i686,ppc,sparc,x86,x86_64
 

--- a/rundeckapp/grails-app/i18n/messages_de.properties
+++ b/rundeckapp/grails-app/i18n/messages_de.properties
@@ -337,7 +337,7 @@ node.metadata.type=Type
 node.metadata.username=Username
 node.metadata.tags=Tags
 
-node.metadata.OsFamily.defaults=unix,windows,cygwin
+node.metadata.OsFamily.defaults=unix,windows,cygwin,Linux
 node.metadata.OsName.defaults=FreeBSD,Linux,Mac OS X,SunOS,Windows XP,Windows 2003
 node.metadata.OsArch.defaults=i386,i686,ppc,sparc,x86,x86_64
 

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -324,7 +324,7 @@ node.metadata.type=Tipo
 node.metadata.username=Nombre de usuario
 node.metadata.tags=Etiquetas
 
-node.metadata.OsFamily.defaults=unix,windows,cygwin
+node.metadata.OsFamily.defaults=unix,windows,cygwin,Linux
 node.metadata.OsName.defaults=FreeBSD,Linux,Mac OS X,SunOS,Windows XP,Windows 2003
 node.metadata.OsArch.defaults=i386,i686,ppc,sparc,x86,x86_64
 

--- a/rundeckapp/grails-app/i18n/messages_fr_FR.properties
+++ b/rundeckapp/grails-app/i18n/messages_fr_FR.properties
@@ -337,7 +337,7 @@ node.metadata.type=Type
 node.metadata.username=Nom d\u02bcutilisateur
 node.metadata.tags=Mots cl\u00e9s
 
-node.metadata.OsFamily.defaults=unix, windows, cygwin
+node.metadata.OsFamily.defaults=unix, windows, cygwin, Linux
 node.metadata.OsName.defaults=FreeBSD, Linux, Mac OS X, SunOS, Windows XP, Windows 2003
 node.metadata.OsArch.defaults=i386, i686, ppc, sparc, x86, x86_64
 

--- a/rundeckapp/grails-app/i18n/messages_ja.properties
+++ b/rundeckapp/grails-app/i18n/messages_ja.properties
@@ -312,7 +312,7 @@ node.metadata.type=\u30bf\u30a4\u30d7
 node.metadata.username=\u30e6\u30fc\u30b6\u30fc\u540d
 node.metadata.tags=\u30bf\u30b0
 
-node.metadata.OsFamily.defaults=unix,windows,cygwin
+node.metadata.OsFamily.defaults=unix,windows,cygwin,Linux
 node.metadata.OsName.defaults=FreeBSD,Linux,Mac OS X,SunOS,Windows XP,Windows 2003
 node.metadata.OsArch.defaults=i386,i686,ppc,sparc,x86,x86_64
 

--- a/rundeckapp/grails-app/i18n/messages_nl.properties
+++ b/rundeckapp/grails-app/i18n/messages_nl.properties
@@ -339,7 +339,7 @@ node.metadata.type=Type
 node.metadata.username=Gebruikersnaam
 node.metadata.tags=Tags
 
-node.metadata.OsFamily.defaults=unix,windows,cygwin
+node.metadata.OsFamily.defaults=unix,windows,cygwin,Linux
 node.metadata.OsName.defaults=FreeBSD,Linux,Mac OS X,SunOS,Windows XP,Windows 2003
 node.metadata.OsArch.defaults=i386,i686,ppc,sparc,x86,x86_64
 

--- a/rundeckapp/grails-app/i18n/messages_pt_BR.properties
+++ b/rundeckapp/grails-app/i18n/messages_pt_BR.properties
@@ -327,7 +327,7 @@ node.metadata.type=Tipo
 node.metadata.username=Nome de usu\u00e1rio
 node.metadata.tags=Tag
 
-node.metadata.OsFamily.defaults=unix, windows, cygwin
+node.metadata.OsFamily.defaults=unix, windows, cygwin, Linux
 node.metadata.OsName.defaults=FreeBSD, Linux, Mac OS X, SunOS, Windows XP, Windows 2003
 node.metadata.OsArch.defaults=i386, i686, ppc, sparc, x86, x86_64
 

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -319,7 +319,7 @@ node.metadata.type=Type
 node.metadata.username=Username
 node.metadata.tags=Tags
 
-node.metadata.OsFamily.defaults=unix,windows,cygwin
+node.metadata.OsFamily.defaults=unix,windows,cygwin,Linux
 node.metadata.OsName.defaults=FreeBSD,Linux,Mac OS X,SunOS,Windows XP,Windows 2003
 node.metadata.OsArch.defaults=i386,i686,ppc,sparc,x86,x86_64
 


### PR DESCRIPTION
## Summary
Part of the [RUN-4753](https://pagerduty.atlassian.net/browse/RUN-4753) investigation into inconsistent `osFamily` values across Node Resource plugins.

The legacy node-metadata edit UI suggests `unix, windows, cygwin` as `osFamily` values via `node.metadata.OsFamily.defaults`. Several Node Resource plugins (e.g. `rundeck-azure-plugin`) populate `osFamily` with `Linux` rather than the lowercase `unix` convention, and customers may want to distinguish Linux nodes explicitly rather than shoehorning them into `unix`.

This adds `Linux` to the suggestion list, in all locale files, without removing any existing values.

## Changes
- `node.metadata.OsFamily.defaults=unix,windows,cygwin` → `unix,windows,cygwin,Linux` in `messages.properties` and all 7 locale variants (de, es_419, fr_FR, ja, nl, pt_BR, zh_cn)

## Related
- Companion change in rundeckpro: adds `Linux`/`Cygwin` as first-class options in the Node Wizard's `osFamily` dropdown, matching this suggestion list.
- Related plugin-repo bugs filed separately: RUN-4820 (rundeck-azure-plugin), RUN-4821 (ansible-plugin)

[RUN-4753]: https://pagerduty.atlassian.net/browse/RUN-4753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ