### PR TITLE
[RUN-4829] Fix flaky JobExecutionStatusSpec timedout test

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionStatusSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionStatusSpec.groovy
@@ -76,7 +76,8 @@ class JobExecutionStatusSpec extends BaseContainer {
         def responseExec = JobUtils.waitForExecution(
                 ExecutionStatus.TIMEDOUT.state,
                 execId as String,
-                client)
+                client,
+                WaitingTime.EXCESSIVE)
 
         then:
         verifyAll {


### PR DESCRIPTION
## Summary
- `JobExecutionStatusSpec` "job/id/run should get into timedout status" intermittently fails in CI with `ResourceAcceptanceTimeoutException`, even though the execution had actually reached the expected `timedout` status.
- The test waits for the execution using the default `WaitingTime.MODERATE` (5s), which is too tight for a 3s job `<timeout>` plus the time Rundeck needs to detect it, interrupt the step, and persist the final status.
- The sibling test in the same file (`failed-with-retry`/`timedout` case) hit the identical issue and was already fixed by passing `WaitingTime.EXCESSIVE`; that fix was not applied to this earlier test method.

## Fix
Pass `WaitingTime.EXCESSIVE` to the `waitForExecution` call, matching the sibling test in the same spec.

Jira: https://pagerduty.atlassian.net/browse/RUN-4829

## Test plan
- [x] `./gradlew :functional-test:compileTestGroovy` passes
- [ ] Re-run `JobExecutionStatusSpec` in CI a few times to confirm no more intermittent timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)