### PR TITLE
[RUN-4757] Add toggle to hide skipped steps in execution results

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -830,7 +830,10 @@ function RDNode(name, steps,flow){
      */
     self.summarize=function(){
         var currentStep=null;
-        var hideSkipped = self.flow.hideSkippedSteps && self.flow.hideSkippedSteps();
+        // Only hide skipped steps for completed successful executions
+        // NOT_STARTED could mean "never reached due to failure" not just "conditional skipped"
+        var hideSkipped = self.flow.hideSkippedSteps && self.flow.hideSkippedSteps()
+                          && self.flow.completed() && self.flow.executionState() === 'SUCCEEDED';
 
         //step summary info
         var summarydata = {
@@ -942,8 +945,9 @@ function RDNode(name, steps,flow){
         self._originalSummaryState = state;
         self._originalSummary = originalSummary;
 
-        // Check if hideSkippedSteps is enabled and adjust state accordingly
-        var hideSkipped = self.flow.hideSkippedSteps && self.flow.hideSkippedSteps();
+        // Only hide skipped steps for completed successful executions
+        var hideSkipped = self.flow.hideSkippedSteps && self.flow.hideSkippedSteps()
+                          && self.flow.completed() && self.flow.executionState() === 'SUCCEEDED';
 
         if (hideSkipped && (state === 'PARTIAL_NOT_STARTED' || state === 'NOT_STARTED')) {
             // When hiding skipped steps, show these as succeeded
@@ -1239,7 +1243,9 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
     };
 
     self.resummarizeAllNodes = function() {
-        var hideSkipped = self.hideSkippedSteps();
+        // Only hide skipped steps for completed successful executions
+        var hideSkipped = self.hideSkippedSteps()
+                          && self.completed() && self.executionState() === 'SUCCEEDED';
         ko.utils.arrayForEach(self.nodes(), function (n) {
             // Only call summarize() if the node has steps loaded
             if (n.steps() && n.steps().length > 0) {

--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -830,6 +830,7 @@ function RDNode(name, steps,flow){
      */
     self.summarize=function(){
         var currentStep=null;
+        var hideSkipped = self.flow.hideSkippedSteps && self.flow.hideSkippedSteps();
 
         //step summary info
         var summarydata = {
@@ -883,11 +884,30 @@ function RDNode(name, steps,flow){
                 self.summary("Waiting to run " + summarydata.WAITING + " " + flow.pluralize(summarydata.WAITING, "Step"));
                 self.summaryState("WAITING");
             } else if (summarydata.NOT_STARTED == summarydata.total && summarydata.pending < 1) {
-                self.summary("No steps were run");
-                self.summaryState("NOT_STARTED");
+                // All steps are NOT_STARTED (skipped)
+                if (hideSkipped) {
+                    self.summary("All Steps OK");
+                    self.summaryState("SUCCEEDED");
+                } else {
+                    self.summary("No steps were run");
+                    self.summaryState("NOT_STARTED");
+                }
             } else if (summarydata.NOT_STARTED > 0) {
-                self.summary(summarydata.NOT_STARTED + " " + flow.pluralize(summarydata.NOT_STARTED, "Step") + " not run");
-                self.summaryState("PARTIAL_NOT_STARTED");
+                // Some steps are NOT_STARTED (skipped)
+                if (hideSkipped) {
+                    // Show only the steps that ran
+                    var ranSteps = summarydata.total - summarydata.NOT_STARTED;
+                    if (ranSteps == summarydata.SUCCEEDED) {
+                        self.summary("All Steps OK");
+                        self.summaryState("SUCCEEDED");
+                    } else {
+                        self.summary(ranSteps + " " + flow.pluralize(ranSteps, "Step") + " ran");
+                        self.summaryState("PARTIAL_SUCCEEDED");
+                    }
+                } else {
+                    self.summary(summarydata.NOT_STARTED + " " + flow.pluralize(summarydata.NOT_STARTED, "Step") + " not run");
+                    self.summaryState("PARTIAL_NOT_STARTED");
+                }
             }else if(summarydata.pending > 0 ){
                 self.summary("Waiting");
                 self.summaryState("WAITING");
@@ -915,8 +935,24 @@ function RDNode(name, steps,flow){
             return;
         }
         self.lastUpdated(nodesummary.lastUpdated);
-        self.summaryState(nodesummary.summaryState);
-        self.summary(self.summaryDescriptionForState(nodesummary));
+
+        // Store original server state for restoring when toggle is off
+        var state = nodesummary.summaryState;
+        var originalSummary = self.summaryDescriptionForState(nodesummary);
+        self._originalSummaryState = state;
+        self._originalSummary = originalSummary;
+
+        // Check if hideSkippedSteps is enabled and adjust state accordingly
+        var hideSkipped = self.flow.hideSkippedSteps && self.flow.hideSkippedSteps();
+
+        if (hideSkipped && (state === 'PARTIAL_NOT_STARTED' || state === 'NOT_STARTED')) {
+            // When hiding skipped steps, show these as succeeded
+            self.summaryState('SUCCEEDED');
+            self.summary('All Steps OK');
+        } else {
+            self.summaryState(state);
+            self.summary(originalSummary);
+        }
 
         self.durationMs(nodesummary.duration);
         self.summaryStartTime(nodesummary.startTime || null);
@@ -990,6 +1026,7 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
     self.endTime=ko.observable();
     self.executionId = ko.observable(data.executionId);
     self.outputScrollOffset=0;
+    self.hideSkippedSteps = ko.observable(false);
     self.activeView = ko.observable("nodes");
     /**
      * synonym with activeView, to maintain compatibility
@@ -1200,6 +1237,31 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
     self.percentageFixed = function(a,b){
         return (b==0)?0:(100*(a/b)).toFixed(0);
     };
+
+    self.resummarizeAllNodes = function() {
+        var hideSkipped = self.hideSkippedSteps();
+        ko.utils.arrayForEach(self.nodes(), function (n) {
+            // Only call summarize() if the node has steps loaded
+            if (n.steps() && n.steps().length > 0) {
+                n.summarize();
+            } else {
+                // For collapsed nodes (no steps loaded), adjust state based on toggle
+                var currentState = n.summaryState();
+                if (hideSkipped && (currentState === 'PARTIAL_NOT_STARTED' || currentState === 'NOT_STARTED')) {
+                    n.summaryState('SUCCEEDED');
+                    n.summary('All Steps OK');
+                } else if (!hideSkipped && n._originalSummaryState) {
+                    // Restore original state when toggle is off
+                    n.summaryState(n._originalSummaryState);
+                    n.summary(n._originalSummary);
+                }
+            }
+        });
+    };
+
+    self.hideSkippedSteps.subscribe(function(newValue) {
+        self.resummarizeAllNodes();
+    });
 
     self.stopShowingOutput= function () {
         if(self.followingControl){

--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -722,6 +722,30 @@ RDNode.computeNodeDurationMs = function (durationMs, steps, execDurationMs) {
     return ms != null ? ms : -1;
 };
 
+/**
+ * Whether a node's only unrun steps were skipped, and everything that did run succeeded.
+ *
+ * A NOT_STARTED step is not proof of a skipped conditional: a step is also NOT_STARTED when it
+ * was never reached because an earlier step aborted. Reclassifying the node therefore requires
+ * the step counts, not just the summary state. Server summaries from a node whose steps have not
+ * been loaded omit these counts on older releases, in which case the node is left as reported.
+ * @param counts object with total, SUCCEEDED, NOT_STARTED and optional pending counts
+ * @returns {boolean}
+ */
+RDNode.isSkippedOnlySuccess = function (counts) {
+    if (!counts) {
+        return false;
+    }
+    var total = counts.total, succeeded = counts.SUCCEEDED, notStarted = counts.NOT_STARTED;
+    if (typeof total !== 'number' || typeof succeeded !== 'number' || typeof notStarted !== 'number') {
+        return false;
+    }
+    if (counts.pending > 0 || notStarted < 1 || total < 1) {
+        return false;
+    }
+    return total - notStarted === succeeded;
+};
+
 function RDNode(name, steps,flow){
     var self=this;
     self.flow= flow;
@@ -826,14 +850,21 @@ function RDNode(name, steps,flow){
         return null;
     };
     /**
+     * Whether the flow-level skipped-step toggle is on and applies to this execution.
+     * @returns {boolean}
+     */
+    self.ignoreSkippedActive=function(){
+        return !!(self.flow.ignoreSkippedSteps
+            && self.flow.ignoreSkippedSteps()
+            && self.flow.ignoreSkippedStepsApplies
+            && self.flow.ignoreSkippedStepsApplies());
+    };
+    /**
      * Determine summary data for the node, sets the summaryState and summary and currentStep
      */
     self.summarize=function(){
         var currentStep=null;
-        // Only hide skipped steps for completed successful executions
-        // NOT_STARTED could mean "never reached due to failure" not just "conditional skipped"
-        var hideSkipped = self.flow.hideSkippedSteps && self.flow.hideSkippedSteps()
-                          && self.flow.completed() && self.flow.executionState() === 'SUCCEEDED';
+        var ignoreSkipped = self.ignoreSkippedActive();
 
         //step summary info
         var summarydata = {
@@ -887,8 +918,7 @@ function RDNode(name, steps,flow){
                 self.summary("Waiting to run " + summarydata.WAITING + " " + flow.pluralize(summarydata.WAITING, "Step"));
                 self.summaryState("WAITING");
             } else if (summarydata.NOT_STARTED == summarydata.total && summarydata.pending < 1) {
-                // All steps are NOT_STARTED (skipped)
-                if (hideSkipped) {
+                if (ignoreSkipped && RDNode.isSkippedOnlySuccess(summarydata)) {
                     self.summary("All Steps OK");
                     self.summaryState("SUCCEEDED");
                 } else {
@@ -896,17 +926,9 @@ function RDNode(name, steps,flow){
                     self.summaryState("NOT_STARTED");
                 }
             } else if (summarydata.NOT_STARTED > 0) {
-                // Some steps are NOT_STARTED (skipped)
-                if (hideSkipped) {
-                    // Show only the steps that ran
-                    var ranSteps = summarydata.total - summarydata.NOT_STARTED;
-                    if (ranSteps == summarydata.SUCCEEDED) {
-                        self.summary("All Steps OK");
-                        self.summaryState("SUCCEEDED");
-                    } else {
-                        self.summary(ranSteps + " " + flow.pluralize(ranSteps, "Step") + " ran");
-                        self.summaryState("PARTIAL_SUCCEEDED");
-                    }
+                if (ignoreSkipped && RDNode.isSkippedOnlySuccess(summarydata)) {
+                    self.summary("All Steps OK");
+                    self.summaryState("SUCCEEDED");
                 } else {
                     self.summary(summarydata.NOT_STARTED + " " + flow.pluralize(summarydata.NOT_STARTED, "Step") + " not run");
                     self.summaryState("PARTIAL_NOT_STARTED");
@@ -932,31 +954,38 @@ function RDNode(name, steps,flow){
     self.currentStepFromData=function(data){
         self.currentStep(new RDNodeStep(data, self, self.flow));
     };
+    /**
+     * Apply the last summary reported by the server to the display, honouring the skipped-step
+     * toggle. Used for nodes whose steps have not been loaded, where summarize() has no data.
+     */
+    self.applyServerSummary=function(){
+        var data=self._serverSummary;
+        if(!data){
+            return;
+        }
+        var counts={
+            total: data.total,
+            SUCCEEDED: data.SUCCEEDED,
+            NOT_STARTED: data.NOT_STARTED,
+            pending: self.flow.pendingStepsForNode(self.name)
+        };
+        if(self.ignoreSkippedActive() && RDNode.isSkippedOnlySuccess(counts)){
+            self.summaryState('SUCCEEDED');
+            self.summary('All Steps OK');
+        }else{
+            self.summaryState(data.summaryState);
+            self.summary(self.summaryDescriptionForState(data));
+        }
+    };
     self.updateSummary=function(nodesummary){
+        //compare against the reported state, not the displayed one, which the toggle may have rewritten
         if(nodesummary.lastUpdated && self.lastUpdated()==nodesummary.lastUpdated
-            && nodesummary.summaryState==self.summaryState()){
+            && self._serverSummary && nodesummary.summaryState==self._serverSummary.summaryState){
             return;
         }
         self.lastUpdated(nodesummary.lastUpdated);
-
-        // Store original server state for restoring when toggle is off
-        var state = nodesummary.summaryState;
-        var originalSummary = self.summaryDescriptionForState(nodesummary);
-        self._originalSummaryState = state;
-        self._originalSummary = originalSummary;
-
-        // Only hide skipped steps for completed successful executions
-        var hideSkipped = self.flow.hideSkippedSteps && self.flow.hideSkippedSteps()
-                          && self.flow.completed() && self.flow.executionState() === 'SUCCEEDED';
-
-        if (hideSkipped && (state === 'PARTIAL_NOT_STARTED' || state === 'NOT_STARTED')) {
-            // When hiding skipped steps, show these as succeeded
-            self.summaryState('SUCCEEDED');
-            self.summary('All Steps OK');
-        } else {
-            self.summaryState(state);
-            self.summary(originalSummary);
-        }
+        self._serverSummary=nodesummary;
+        self.applyServerSummary();
 
         self.durationMs(nodesummary.duration);
         self.summaryStartTime(nodesummary.startTime || null);
@@ -1030,7 +1059,14 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
     self.endTime=ko.observable();
     self.executionId = ko.observable(data.executionId);
     self.outputScrollOffset=0;
-    self.hideSkippedSteps = ko.observable(false);
+    self.ignoreSkippedSteps = ko.observable(false);
+    /**
+     * Skipped steps can only be told apart from steps that were never reached once the execution
+     * has finished successfully, so the toggle has no effect on any other execution.
+     */
+    self.ignoreSkippedStepsApplies = ko.pureComputed(function () {
+        return !!self.completed() && self.executionState() === 'SUCCEEDED';
+    });
     self.activeView = ko.observable("nodes");
     /**
      * synonym with activeView, to maintain compatibility
@@ -1242,31 +1278,24 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
         return (b==0)?0:(100*(a/b)).toFixed(0);
     };
 
-    self.resummarizeAllNodes = function() {
-        // Only hide skipped steps for completed successful executions
-        var hideSkipped = self.hideSkippedSteps()
-                          && self.completed() && self.executionState() === 'SUCCEEDED';
+    self.resummarizeAllNodes = function () {
         ko.utils.arrayForEach(self.nodes(), function (n) {
-            // Only call summarize() if the node has steps loaded
             if (n.steps() && n.steps().length > 0) {
                 n.summarize();
             } else {
-                // For collapsed nodes (no steps loaded), adjust state based on toggle
-                var currentState = n.summaryState();
-                if (hideSkipped && (currentState === 'PARTIAL_NOT_STARTED' || currentState === 'NOT_STARTED')) {
-                    n.summaryState('SUCCEEDED');
-                    n.summary('All Steps OK');
-                } else if (!hideSkipped && n._originalSummaryState) {
-                    // Restore original state when toggle is off
-                    n.summaryState(n._originalSummaryState);
-                    n.summary(n._originalSummary);
-                }
+                n.applyServerSummary();
             }
         });
     };
 
-    self.hideSkippedSteps.subscribe(function(newValue) {
+    self.ignoreSkippedSteps.subscribe(function () {
         self.resummarizeAllNodes();
+    });
+    //an execution finishing while the toggle is on changes whether it applies
+    self.ignoreSkippedStepsApplies.subscribe(function () {
+        if (self.ignoreSkippedSteps()) {
+            self.resummarizeAllNodes();
+        }
     });
 
     self.stopShowingOutput= function () {

--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.test.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.test.js
@@ -130,6 +130,32 @@ jQuery(function () {
             // Actual execution duration: 457ms
             var ms = RDNode.computeNodeDurationMs(-1, steps, 457);
             this.assert('clamps to execDurationMs', ms === 457);
+        },
+        isSkippedOnlySuccessAcceptsAllStepsSkippedTest: function () {
+            this.assert('every step was skipped',
+                RDNode.isSkippedOnlySuccess({total: 3, SUCCEEDED: 0, NOT_STARTED: 3}) === true);
+        },
+        isSkippedOnlySuccessAcceptsMixOfSkippedAndSucceededTest: function () {
+            this.assert('every step that ran succeeded',
+                RDNode.isSkippedOnlySuccess({total: 3, SUCCEEDED: 2, NOT_STARTED: 1}) === true);
+        },
+        isSkippedOnlySuccessRejectsStepThatRanWithoutSucceedingTest: function () {
+            // an aborted step is counted under "other", so the ran steps no longer add up
+            this.assert('aborted step',
+                RDNode.isSkippedOnlySuccess({total: 3, SUCCEEDED: 1, NOT_STARTED: 1, other: 1}) === false);
+        },
+        isSkippedOnlySuccessRejectsPendingWorkTest: function () {
+            this.assert('node still has pending steps',
+                RDNode.isSkippedOnlySuccess({total: 3, SUCCEEDED: 2, NOT_STARTED: 1, pending: 1}) === false);
+        },
+        isSkippedOnlySuccessRejectsNodeWithoutSkippedStepsTest: function () {
+            this.assert('nothing was skipped',
+                RDNode.isSkippedOnlySuccess({total: 2, SUCCEEDED: 2, NOT_STARTED: 0}) === false);
+        },
+        isSkippedOnlySuccessRejectsSummaryWithoutCountsTest: function () {
+            this.assert('summary from a server that does not report counts',
+                RDNode.isSkippedOnlySuccess({summaryState: 'PARTIAL_NOT_STARTED'}) === false);
+            this.assert('no summary at all', RDNode.isSkippedOnlySuccess(null) === false);
         }
     });
 });

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1893,8 +1893,8 @@ execution.show.mode.column.node=Node
 execution.show.mode.column.step=Step
 execution.show.mode.inset.label=Inset
 execution.show.mode.inset.node=Node
-execution.show.nodes.hideSkippedSteps.label=Hide skipped steps
-execution.show.nodes.hideSkippedSteps.description=Hide steps that were skipped due to conditional evaluation
+execution.show.nodes.ignoreSkippedSteps.label=Ignore skipped steps
+execution.show.nodes.ignoreSkippedSteps.description=Count a node as complete when the only steps that did not run were skipped. Successful executions only.
 
 gui.admin.GetPlugins=Get Plugins
 gui.admin.InstallPlugin=Install Plugin

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1893,6 +1893,8 @@ execution.show.mode.column.node=Node
 execution.show.mode.column.step=Step
 execution.show.mode.inset.label=Inset
 execution.show.mode.inset.node=Node
+execution.show.nodes.hideSkippedSteps.label=Hide skipped steps
+execution.show.nodes.hideSkippedSteps.description=Hide steps that were skipped due to conditional evaluation
 
 gui.admin.GetPlugins=Get Plugins
 gui.admin.InstallPlugin=Install Plugin

--- a/rundeckapp/grails-app/services/rundeck/services/workflow/StateMapping.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/workflow/StateMapping.groovy
@@ -143,9 +143,17 @@ class StateMapping {
                 summary.WAITING=summarydata.WAITING;
                 summary.summaryState=("WAITING");
             } else if (summarydata.NOT_STARTED == summarydata.total && summarydata.pending < 1) {
+                summary.total=summarydata.total;
+                summary.SUCCEEDED=summarydata.SUCCEEDED;
+                summary.NOT_STARTED=summarydata.NOT_STARTED;
                 summary.summaryState=("NOT_STARTED");
             } else if (summarydata.NOT_STARTED > 0) {
                 summary.PARTIAL_NOT_STARTED=summarydata.NOT_STARTED;
+                //the summary state alone cannot tell a skipped conditional apart from a step that was
+                //never reached, so expose the counts the UI needs to make that distinction
+                summary.total=summarydata.total;
+                summary.SUCCEEDED=summarydata.SUCCEEDED;
+                summary.NOT_STARTED=summarydata.NOT_STARTED;
                 summary.summaryState=("PARTIAL_NOT_STARTED");
             }else if(summarydata.pending > 0 ){
                 summary.summaryState=("WAITING");

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -622,7 +622,7 @@ search
                           </a>
                           <!-- /ko -->
 
-                          <span data-bind="visible: activeTab()==='nodes'" class="pull-right" style="margin-left: 10px;">
+                          <div data-bind="visible: activeTab()==='nodes'" class="pull-right" style="margin-left: 10px;">
                               <div class="checkbox-inline">
                                   <input type="checkbox"
                                          data-bind="checked: hideSkippedSteps"
@@ -633,7 +633,7 @@ search
                                       <g:message code="execution.show.nodes.hideSkippedSteps.label" default="Hide skipped steps"/>
                                   </label>
                               </div>
-                          </span>
+                          </div>
 
                           <span data-bind="visible: activeTab().startsWith('output')">
 

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -625,12 +625,12 @@ search
                           <div data-bind="visible: activeTab()==='nodes'" class="pull-right" style="margin-left: 10px;">
                               <div class="checkbox-inline">
                                   <input type="checkbox"
-                                         data-bind="checked: hideSkippedSteps"
-                                         id="hide-skipped-steps"
-                                         title="${g.message(code: 'execution.show.nodes.hideSkippedSteps.description',
-                                                 default: 'Hide steps that were skipped due to conditional evaluation')}"/>
-                                  <label for="hide-skipped-steps">
-                                      <g:message code="execution.show.nodes.hideSkippedSteps.label" default="Hide skipped steps"/>
+                                         data-bind="checked: ignoreSkippedSteps, enable: ignoreSkippedStepsApplies"
+                                         id="ignore-skipped-steps"
+                                         title="${g.message(code: 'execution.show.nodes.ignoreSkippedSteps.description',
+                                                 default: 'Count a node as complete when the only steps that did not run were skipped. Successful executions only.')}"/>
+                                  <label for="ignore-skipped-steps">
+                                      <g:message code="execution.show.nodes.ignoreSkippedSteps.label" default="Ignore skipped steps"/>
                                   </label>
                               </div>
                           </div>

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -622,6 +622,18 @@ search
                           </a>
                           <!-- /ko -->
 
+                          <span data-bind="visible: activeTab()==='nodes'" class="pull-right" style="margin-left: 10px;">
+                              <div class="checkbox-inline">
+                                  <input type="checkbox"
+                                         data-bind="checked: hideSkippedSteps"
+                                         id="hide-skipped-steps"
+                                         title="${g.message(code: 'execution.show.nodes.hideSkippedSteps.description',
+                                                 default: 'Hide steps that were skipped due to conditional evaluation')}"/>
+                                  <label for="hide-skipped-steps">
+                                      <g:message code="execution.show.nodes.hideSkippedSteps.label" default="Hide skipped steps"/>
+                                  </label>
+                              </div>
+                          </span>
 
                           <span data-bind="visible: activeTab().startsWith('output')">
 


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Enhancement. Fixes RUN-4757
Syntax customer feedback: Conditionals that don't run make nodes show as "incomplete" in execution results, which can be confusing when the job actually succeeded.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
Added "Hide skipped steps" checkbox to the execution page (Nodes tab). When enabled:                                                                                               
  - Nodes with only skipped conditionals show "All Steps OK" instead of "X Step not run"                                                                                             
  - INCOMPLETE count and COMPLETE % update accordingly  

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
- Display-only approach (separate displaySummary observable) - more complex, deferred
- Persistent job setting - could be follow-up enhancement

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
- Checkbox only visible on Nodes tab
- Toggle affects overall stats (intentional per customer ask)
- Default is OFF (original behavior preserved)

## Release Notes

<!-- If you have suggested content that would describe this PR to other Rundeck community users, please enter it here.-->
Added "Hide skipped steps" toggle to execution results page, allowing users to hide incomplete status for nodes where conditional steps were skipped.