### PR TITLE
[RUN-4831] Fix flaky Selenium waits in BasicJobsSpec page objects

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobCreatePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobCreatePage.groovy
@@ -419,9 +419,9 @@ class JobCreatePage extends BasePage {
         el nodeFilterInputBy
     }
 
-    WebElement addNotificationButtonByType(NotificationEvent notificationType) {
-        waitForElementToBeClickable notificationType.notificationEvent
-        el notificationType.notificationEvent
+    WebElement addNotificationButtonByType(NotificationEvent notificationEvent) {
+        waitForElementToBeClickable notificationEvent.notificationEvent
+        el notificationEvent.notificationEvent
     }
 
     WebElement getNotificationDropDown() {

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobCreatePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobCreatePage.groovy
@@ -420,14 +420,17 @@ class JobCreatePage extends BasePage {
     }
 
     WebElement addNotificationButtonByType(NotificationEvent notificationType) {
+        waitForElementToBeClickable notificationType.notificationEvent
         el notificationType.notificationEvent
     }
 
     WebElement getNotificationDropDown() {
+        waitForElementToBeClickable notificationDropDownBy
         el notificationDropDownBy
     }
 
     WebElement notificationByType(NotificationType notificationType) {
+        waitForElementToBeClickable notificationType.notificationType
         el notificationType.notificationType
     }
 
@@ -438,6 +441,7 @@ class JobCreatePage extends BasePage {
     }
 
     WebElement getNotificationSaveButton() {
+        waitForElementToBeClickable notificationSaveBy
         el notificationSaveBy
     }
 

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobShowPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobShowPage.groovy
@@ -290,7 +290,9 @@ class JobShowPage extends BasePage implements ActivityListTrait {
     }
 
     WebElement optionInputText(String name) {
-        el By.cssSelector("#optionSelect #_commandOptions input[type=text][name='extra.option.${name}']")
+        def by = By.cssSelector("#optionSelect #_commandOptions input[type=text][name='extra.option.${name}']")
+        waitForElementVisible(by)
+        el by
     }
 
     WebElement runJobLink(String uuid) {


### PR DESCRIPTION
## Summary
- `BasicJobsSpec."edit job and set notifications"` and `BasicJobsSpec."create valid job basic options"` (legacyUi/nextUi) were intermittently failing in CI (e.g. `NoSuchElementException`) due to missing explicit waits before interacting with dynamically-rendered UI in the Selenium page objects.
- `JobCreatePage`'s notification-editing click chain (`addNotificationButtonByType`, `notificationDropDown`, `notificationByType`, `notificationSaveButton`) used bare `el(By).click()` with no wait for visibility/clickability. The likely main offender is `notificationByType`, which clicks a Bootstrap dropdown option immediately after opening the dropdown, before its open animation/render finishes.
- `JobShowPage.optionInputText()` used a bare `el(By)` with no wait for an element in the dynamically-rendered "Run Job" options form.

## Fix
- Added `waitForElementToBeClickable(...)` before each click in the notification methods above.
- Added `waitForElementVisible(...)` before the `el(...)` lookup in `optionInputText()`.

Both follow the explicit-wait pattern already used elsewhere in these same page objects.

## Test plan
- [x] Ran `./gradlew :functional-test:seleniumCoreTest --tests "org.rundeck.tests.functional.selenium.jobs.BasicJobsSpec"` locally, multiple times — all 24 tests pass consistently (`BUILD SUCCESSFUL`), including the two previously-flaky tests.