### PR TITLE
[RUN-4671] Fix remaining path validation gaps flagged in review

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -3416,10 +3416,33 @@ Since: v23''',
                  args  : ["POST to readonly project source index $index"]]
             )
         }
+
+        def framework = frameworkService.rundeckFramework
+
+        // Path validation before writing (RUN-4671): apiSourceWriteContent is the API
+        // counterpart of saveProjectNodeSourceFile (writes via the same writeData()), and
+        // must enforce the same containment check to prevent writing a valid node document
+        // to an arbitrary/cross-project path.
+        try {
+            Map<String, Object> configProps = buildConfigPropertiesForValidation()
+            source.writeableSource.validateWriteableSource(
+                configProps,
+                framework,
+                project
+            )
+        } catch (ConfigurationException e) {
+            log.warn("Node source path validation failed for project=${project} index=${index}: ${e.message}")
+            return apiService.renderErrorFormat(
+                response,
+                [status: HttpServletResponse.SC_FORBIDDEN,
+                 code  : 'api.error.item.unauthorized',
+                 args  : ['Write Resource Model Source', 'Project', project]]
+            )
+        }
+
         def format = source.writeableSource.syntaxMimeType
         def inputStream = request.getInputStream()
         //validate
-        def framework = frameworkService.rundeckFramework
         if (format != contentType) {
             //attempt to convert to expected format
             ResourceFormatParser parser
@@ -3741,8 +3764,14 @@ Since: v23''',
         // Path validation for writeable sources (RUN-4671): this is the nextUi (legacyUi=false)
         // counterpart of editProjectNodeSourceFile, used by the Vue node source editor to fetch
         // raw source content, and must enforce the same containment check.
-        WriteableModelSource writeableModelSource = source.source.writeable
-        if (writeableModelSource) {
+        //
+        // Check `instanceof WriteableModelSource` directly rather than `source.source.writeable`
+        // (getWriteable()): a FileResourceModelSource always implements WriteableModelSource
+        // regardless of its configured writeable flag, but getWriteable() returns null when
+        // writeable=false, which previously let a source bypass path validation entirely just by
+        // setting writeable=false.
+        if (source.source instanceof WriteableModelSource) {
+            WriteableModelSource writeableModelSource = (WriteableModelSource) source.source
             try {
                 Map<String, Object> configProps = buildConfigPropertiesForValidation()
                 writeableModelSource.validateWriteableSource(

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -73,6 +73,9 @@ class FrameworkControllerSpec extends Specification implements ControllerUnitTes
     private static class FakeWriteableFileSource implements ResourceModelSource, WriteableModelSource {
         Closure onValidate
         Closure onGetNodes
+        // Mirrors FileResourceModelSource: the source always implements WriteableModelSource,
+        // but getWriteable() advertises write capability based on the configured writeable flag.
+        boolean writeable = true
 
         @Override
         INodeSet getNodes() throws ResourceModelSourceException {
@@ -92,7 +95,7 @@ class FrameworkControllerSpec extends Specification implements ControllerUnitTes
         long writeData(InputStream data) throws IOException, ResourceModelSourceException { 0 }
 
         @Override
-        WriteableModelSource getWriteable() { this }
+        WriteableModelSource getWriteable() { writeable ? this : null }
 
         @Override
         void validateWriteableSource(
@@ -1250,6 +1253,7 @@ class FrameworkControllerSpec extends Specification implements ControllerUnitTes
     def "POST project source resources,  writeable, catch IO Exception"() {
         setup:
             def source =Mock(WriteableModelSource){
+                1 * validateWriteableSource(_, _, _) >> { /* validation passes */ }
                 1 * writeData(_)>>{
                     throw new IOException("expected error")
                 }
@@ -1313,6 +1317,58 @@ class FrameworkControllerSpec extends Specification implements ControllerUnitTes
                 'application/json; charset=utf8'
             ]
     }
+
+    def "POST project source resources, writeable, path validation fails, returns 403"() {
+        setup:
+        def writeableSource = new FakeWriteableFileSource(
+            onValidate: {
+                throw new com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException(
+                    "File path must be within the project directory"
+                )
+            }
+        )
+        controller.frameworkService = Mock(FrameworkService) {
+            1 * existsFrameworkProject('test') >> true
+            1 * getFrameworkProject('test') >> Mock(IRundeckProject) {
+                1 * getProjectNodes() >> Mock(IProjectNodes) {
+                    1 * getWriteableResourceModelSources() >> [
+                            Mock(IProjectNodes.WriteableProjectNodes) {
+                                getWriteableSource() >> writeableSource
+                                getIndex() >> 1
+                                getType() >> 'file'
+                            }
+                    ]
+                }
+            }
+            1 * getRundeckFramework() >> Mock(com.dtolabs.rundeck.core.common.Framework)
+            0 * _(*_)
+        }
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+            1 * authorizeProjectConfigure(_, 'test') >> true
+            1 * getAuthContextForSubject(_)
+        }
+        controller.apiService = Mock(ApiService) {
+            1 * requireApi(_, _, 23) >> true
+            1 * requireParameters(_, _, ['project', 'index']) >> true
+            1 * requireExists(_, _, ['project', 'test']) >> true
+            1 * requireExists(_, 1, ['source index', '1']) >> true
+            1 * requireAuthorized(_, _, ['configure', 'Project', 'test']) >> true
+            1 * renderErrorFormat(_, { it.status == 403 }) >> { it[0].status = it[1].status }
+            0 * _(*_)
+        }
+
+        params.project = "test"
+        params.index = "1"
+        request.method = 'POST'
+        request.contentType = 'application/xml'
+
+        when:
+        controller.apiSourceWriteContent()
+
+        then:
+        response.status == 403
+    }
+
     protected void setupFormTokens(params) {
         def token = SynchronizerTokensHolder.store(session)
         params[SynchronizerTokensHolder.TOKEN_KEY] = token.generateToken('/test')
@@ -2548,6 +2604,59 @@ project.label=A Label
             getIndex() >> 1
             getType() >> 'file'
             getSource() >> writeableSource
+        }
+        controller.frameworkService = Mock(FrameworkService) {
+            1 * existsFrameworkProject('test') >> true
+            1 * getFrameworkProject('test') >> Mock(IRundeckProject) {
+                1 * getProjectNodes() >> Mock(IProjectNodes) {
+                    1 * listResourceModelConfigurations() >> [[:]]
+                    1 * getResourceModelSources() >> [readableSource]
+                }
+            }
+            1 * getRundeckFramework() >> Mock(com.dtolabs.rundeck.core.common.Framework)
+            0 * _(*_)
+        }
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+            1 * authorizeProjectConfigure(_, 'test') >> true
+            1 * getAuthContextForSubject(_)
+        }
+        controller.apiService = Mock(ApiService) {
+            1 * requireApi(_, _, 23) >> true
+            1 * requireParameters(_, _, ['project', 'index']) >> true
+            1 * requireExists(_, _, ['project', 'test']) >> true
+            1 * requireExists(_, { it instanceof Integer }, ['source index', '1']) >> true
+            1 * requireExists(_, { !(it instanceof Integer) }, ['source index', '1']) >> true
+            0 * _(*_)
+        }
+
+        params.project = "test"
+        params.index = "1"
+        request.method = 'GET'
+
+        when:
+        controller.apiSourceGetContent()
+
+        then:
+        response.status == 204
+    }
+
+    def "GET project source resources, writeable=false, path validation still enforced, returns 204"() {
+        // Regression test: getWriteable() returns null when the source's writeable config
+        // flag is false, which previously let `source.source.writeable` (falsy) skip path
+        // validation entirely. Validation must run regardless of the writeable flag.
+        setup:
+        def nonWriteableSource = new FakeWriteableFileSource(
+            writeable: false,
+            onValidate: {
+                throw new com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException(
+                    "File path must be within the project directory"
+                )
+            }
+        )
+        def readableSource = Mock(IProjectNodes.ReadableProjectNodes) {
+            getIndex() >> 1
+            getType() >> 'file'
+            getSource() >> nonWriteableSource
         }
         controller.frameworkService = Mock(FrameworkService) {
             1 * existsFrameworkProject('test') >> true


### PR DESCRIPTION
## Jira Ticket

[RUN-4671](https://pagerduty.atlassian.net/browse/RUN-4671)

## Summary

Follow-up to #10437 (merged). Post-merge review comment on RUN-4671 flagged two remaining gaps where `validateWriteableSource` (the path-containment check added to fix the arbitrary file read) wasn't being enforced:

- **`apiSourceWriteContent`** had no `validateWriteableSource` call at all — a configure-only user could write an arbitrary valid node document to any writable path via the API write endpoint (the same route the Vue node source editor saves through). Added the same containment check used by `saveProjectNodeSourceFile`, returning 403 on failure.
- **`apiSourceGetContent`** gated validation on `source.source.writeable` (`getWriteable()`), which returns `null` when the source's `writeable` config flag is `false` — letting a source bypass path validation entirely just by setting `writeable=false`. Fixed by checking `instanceof WriteableModelSource` directly, since `FileResourceModelSource` always implements that interface regardless of the writeable flag.

A third, deeper gap from the same review (path validation never runs in the core node-loading pipeline, e.g. Nodes page / `apiResourcev14` / job dispatch) is scoped out of this PR — it requires plumbing a `Framework` reference into `ProjectNodeSupport`, has no admin-bypass concept at that layer, and needs a bridge for `allowedBasePaths` into core config. Tracked separately; not included here.

## Test plan

- [x] `./gradlew :rundeckapp:test --tests "rundeck.controllers.FrameworkControllerSpec"` passes, including two new regression tests for these gaps

[RUN-4671]: https://pagerduty.atlassian.net/browse/RUN-4671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ