### PR TITLE
[RUN-4835] Fix invalid OpenAPI schema for job id/format parameters

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2679,7 +2679,7 @@ Since: V18''',
             description = "Job ID",
             in = ParameterIn.PATH,
             required = true,
-            content = @Content(schema = @Schema(implementation = String))
+            schema = @Schema(type = 'string')
         )
     )
     @ApiResponse(
@@ -3373,7 +3373,7 @@ Since: v14
                 name = "format",
                 description = '''can be "yaml" or "json" (API v44+) to specify the output format''',
                 in = ParameterIn.QUERY,
-                content = @Content(schema = @Schema(implementation = String,allowableValues = ['json','yaml']))
+                schema = @Schema(type = 'string', allowableValues = ['json', 'yaml'])
             )
         ]
     )

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -1277,7 +1277,7 @@ Since: V14''',
             description = "Job ID",
             in = ParameterIn.PATH,
             required = true,
-            content = @Content(schema = @Schema(implementation = String))
+            schema = @Schema(type = 'string')
         )
     )
     @ApiResponse(
@@ -1313,7 +1313,7 @@ Since: V14''',
             description = "Job ID",
             in = ParameterIn.PATH,
             required = true,
-            content = @Content(schema = @Schema(implementation = String))
+            schema = @Schema(type = 'string')
         )
     )
     @ApiResponse(
@@ -1403,7 +1403,7 @@ Since: V14''',
             description = "Job ID",
             in = ParameterIn.PATH,
             required = true,
-            content = @Content(schema = @Schema(implementation = String))
+            schema = @Schema(type = 'string')
         )
     )
     @ApiResponse(
@@ -1439,7 +1439,7 @@ Since: V14''',
             description = "Job ID",
             in = ParameterIn.PATH,
             required = true,
-            content = @Content(schema = @Schema(implementation = String))
+            schema = @Schema(type = 'string')
         )
     )
     @ApiResponse(
@@ -4242,13 +4242,13 @@ Authorization required: `read` for the Job.''',
                 description = "Job ID",
                 in = ParameterIn.PATH,
                 required = true,
-                content = @Content(schema = @Schema(implementation = String))
+                schema = @Schema(type = 'string')
             ),
             @Parameter(
                 name = "format",
                 description = '''can be "yaml" or "json" (API v44+) to specify the output format''',
                 in = ParameterIn.QUERY,
-                content = @Content(schema = @Schema(implementation = String))
+                schema = @Schema(type = 'string')
             )
         ]
     )
@@ -5161,7 +5161,7 @@ Since: v19''',
             description = "File ID",
             in = ParameterIn.PATH,
             required = true,
-            content = @Content(schema = @Schema(implementation = String))
+            schema = @Schema(type = 'string')
         )
     )
     @ApiResponse(
@@ -5322,7 +5322,7 @@ Authorization required: `delete` for the job.''',
                 description = "Job ID",
                 in = ParameterIn.PATH,
                 required = true,
-                content = @Content(schema = @Schema(implementation = String))
+                schema = @Schema(type = 'string')
             )
         ]
     )


### PR DESCRIPTION
## Problem

The generated OpenAPI spec emits 10 parameters (across 9 job-related endpoints) as invalid Parameter Objects:

```yaml
- name: id
  in: path
  description: Job ID
  required: true
  content:
    schema: {}
```

`content` is meant to map media-type strings to Media Type Objects — it is mutually exclusive with `schema` on a `@Parameter`/Parameter Object, and using it this way leaves the parameter with no resolvable schema. This crashes standard OpenAPI tooling that expects every parameter to resolve to a type: confirmed `openapi-generator` 7.25.0 throws a `NullPointerException` in `getParameterDataType()` when processing this spec.

This is currently blocking an external SDK regeneration (go-rundeck, API v56 → v59).

## Root cause

Each affected `@Parameter` annotation used:

```groovy
content = @Content(schema = @Schema(implementation = String))
```

instead of the correct form already used for every other plain string parameter in the same files:

```groovy
schema = @Schema(type = 'string')
```

There is no shared/composed annotation behind these — it's the same buggy snippet copy-pasted independently at 9 call sites (10 parameters, since `apiJobExport` has two).

## Fix

Replaced the buggy `content = @Content(...)` snippet with a direct `schema = @Schema(type = 'string')` on the `@Parameter` for:

- `apiJobExport` (`GET /job/{id}`) — `id`, `format`
- `apiJobDelete` (`DELETE /job/{id}`) — `id`
- `apiFlipExecutionDisabled` (`POST /job/{id}/execution/disable`) — `id`
- `apiFlipExecutionEnabled` (`POST /job/{id}/execution/enable`) — `id`
- `apiJobDetail` (`GET /job/{id}/info`) — `id`
- `apiFlipScheduleDisabled` (`POST /job/{id}/schedule/disable`) — `id`
- `apiFlipScheduleEnabled` (`POST /job/{id}/schedule/enable`) — `id`
- `apiJobFileInfo` (`GET /jobs/file/{id}`) — `id`
- `apiJobsExportv14` (`GET /project/{project}/jobs/export`) — `format` (preserves its `allowableValues: ['json', 'yaml']` by moving it onto the `@Schema`)

## Verification

- `./gradlew :rundeckapp:compileGroovy` succeeds and regenerates `rundeckapp/build/classes/groovy/main/META-INF/swagger/rundeck-api.yml`
- The regenerated spec has **zero** `schema: {}` occurrences (previously 10)
- All 10 target parameters now resolve to `schema: {type: string}` (the `format` param on `apiJobsExportv14` correctly retains `enum: [json, yaml]`)
- `openapi-generator generate -i rundeck-api.yml -g go -o /tmp/gen-check` completes with **exit code 0** against `openapi-generator` 7.25.0, with no exceptions

No behavior change — this only corrects the OpenAPI annotation metadata used for spec generation; the runtime parameter handling (Grails binding) is untouched.