### PR TITLE
[RUN-4836] Stabilize EditProjectSpec after project save

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/EditProjectSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/EditProjectSpec.groovy
@@ -138,6 +138,9 @@ class EditProjectSpec extends SeleniumBase {
         projectEditPage.go("/project/${projectName}/configure")
         projectEditPage.setProjectDescription(projectDescription)
         projectEditPage.save()
+        // Save triggers POST + redirect; navigating immediately can abort the request so
+        // the new description never persists and the dashboard keeps showing the old value.
+        projectEditPage.waitForUrlToNotContain('/configure')
         then:
         projectDashboard.expectProjectDescriptionToBe(projectDescription)
 
@@ -145,6 +148,7 @@ class EditProjectSpec extends SeleniumBase {
         projectEditPage.go("/project/${projectName}/configure")
         projectEditPage.setProjectDescription(anotherProjectDescription)
         projectEditPage.save()
+        projectEditPage.waitForUrlToNotContain('/configure')
         then:
         projectDashboard.expectProjectDescriptionToBe(anotherProjectDescription)
 
@@ -172,6 +176,9 @@ class EditProjectSpec extends SeleniumBase {
         projectEditPage.go("/project/${projectName}/configure")
         projectEditPage.setProjectLabel projectLabel
         projectEditPage.save()
+        // Save triggers POST + redirect; navigating immediately can abort the request so
+        // the new label never persists and the dashboard keeps showing the old value.
+        projectEditPage.waitForUrlToNotContain('/configure')
         then:
         projectDashboard.expectProjectLabelToBe(projectLabel)
 
@@ -179,6 +186,7 @@ class EditProjectSpec extends SeleniumBase {
         projectEditPage.go("/project/${projectName}/configure")
         projectEditPage.setProjectLabel anotherProjectLabel
         projectEditPage.save()
+        projectEditPage.waitForUrlToNotContain('/configure')
         then:
         projectDashboard.expectProjectLabelToBe(anotherProjectLabel)
 


### PR DESCRIPTION
## Summary
- `EditProjectSpec` "Change project description" fails intermittently in CI (e.g. CircleCI job [302985](https://app.circleci.com/pipelines/github/rundeck/rundeck/22533/workflows/48aa9a1d-5ec8-4392-82b2-41355bb82d5f/jobs/302985)): the dashboard assertion after the second save runs before the save's POST + redirect has settled, so it reads the pre-save value for the full 10s wait window instead of eventually converging.
- `ProjectEditPage.save()` only clicks the Save button with no wait for the resulting redirect. This is the same root cause already fixed for a sibling spec in RUN-4386 / #10069 ("Stabilize ReadmeSpec after project save"), which added a `waitForUrlToNotContain('/configure')` wait after `save()` — that fix was never applied to `EditProjectSpec`'s "Change project description" / "Change project label" tests, which have the identical save-then-assert pattern.
- Adds the same wait after each `save()` call in both tests.

## Test plan
- [x] `./gradlew :functional-test:compileTestGroovy` passes
- [ ] `seleniumCoreTest` CI job passes without the previous flake (will confirm on this PR's CI run)

RUN-4836