### PR TITLE
[RUN-0000] Bump plugin versions to latest releases

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -134,13 +134,13 @@ protobufVersion=3.25.9
 plexusUtilsVersion=4.1.0
 commonsLang3Version=3.20.0
 # Third-party plugin versions (org.rundeck.plugins bundled in Core)
-ansiblePluginVersion=5.1.0
+ansiblePluginVersion=5.1.1
 awsS3ModelSourceVersion=2.0.3
 pyWinrmPluginVersion=3.3.0
 opensshNodeExecutionVersion=3.0.2
 multilineRegexDatacaptureFilterVersion=2.0.3
 attributeMatchNodeEnhancerVersion=1.0.5
-sshjPluginVersion=1.0.7
+sshjPluginVersion=1.0.8
 jaxbApiVersion=2.3.1
 jaxbRuntimeVersion=2.3.9
 owaspHtmlSanitizerVersion=20260313.1


### PR DESCRIPTION
## What

Bumps the following bundled plugin versions to their latest GitHub Release:

| Plugin | Old | New |
|--------|-----|-----|
| [ansible-plugin](https://github.com/rundeck-plugins/ansible-plugin/releases/tag/5.1.1) | 5.1.0 | 5.1.1 |
| [sshj-plugin](https://github.com/rundeck-plugins/sshj-plugin/releases/tag/1.0.8) | 1.0.7 | 1.0.8 |

## Why

Generated by the rundeck-plugin-versions skill's pre-release sweep (scripts/bump-versions-pr.sh in rundeck-plugins/.github) - closes the gap between each plugin's latest release and what this repo has pinned. Review each version's own release notes before merging; this script does not evaluate functional/breaking-change impact itself.

This branch/PR is regenerated on every run of this script - don't hand-edit the branch, just merge or close the PR.
