### PR TITLE
[RUN-4838] Fix git-export SSH fetch failing with ConnectionException: Stream closed

### DIFF
--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/ssh/SshjSession.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/ssh/SshjSession.groovy
@@ -154,7 +154,20 @@ class SshjSession implements RemoteSession {
 
         void closeOutputStream() {
             if (outputStream != null) {
-                outputStream.close()
+                try {
+                    outputStream.close()
+                } catch (IOException ignored) {
+                    // Closing/flushing the process output stream after the underlying SSH
+                    // channel has already been torn down (see destroy(), which closes the
+                    // command before this) can throw - e.g. SSHJ's ChannelOutputStream throws
+                    // ConnectionException("Stream closed") if any buffered bytes remain
+                    // in the timeout>0 BufferedOutputStream/IsolatedOutputStream wrapper
+                    // (see setupStreams()) when the channel is no longer open. At this point
+                    // the process/channel is already being abandoned, so a failure to flush
+                    // leftover output is not an actionable error. JGit's own reference
+                    // RemoteSession implementation (JschSession.JSchProcess) swallows this
+                    // exact case the same way; do the same here.
+                }
             }
         }
     }


### PR DESCRIPTION
## Release Notes

Fixed an intermittent issue where Git SCM export and import operations over SSH could fail with a "Stream closed" connection error during fetch or remote listing, preventing synchronization with Git repositories used for project jobs and configuration.

## PR Details

## Summary

The git-export/git-import SCM plugin's SSH transport (`SshjSession`) can fail SSH-based fetches/ls-remote with:

```
net.schmizz.sshj.connection.ConnectionException: Stream closed
```

This was originally suspected to be an SSHJ/GitHub SSH handshake compatibility issue (e.g. Terrapin/strict-kex negotiation), but that's a red herring — see investigation notes below. The actual bug is a use-after-close ordering issue in `SshjSession` itself.

## Root cause

`SshjSession.SshjProcess.destroy()` closes the SSH exec channel (`cmd.close()`) *before* closing the process's output stream (`closeOutputStream()`). When `exec()` is called with a timeout > 0, `setupStreams()` wraps the channel's output stream in `BufferedOutputStream(16KB)` over `IsolatedOutputStream`. If any bytes are still buffered (unflushed) at `destroy()` time, closing that stream tries to flush them through the already-closed channel, and SSHJ's `ChannelOutputStream` throws `ConnectionException("Stream closed")`, which propagates up through JGit's transport cleanup and fails the whole git operation.

JGit's own reference `RemoteSession` implementation, `JschSession` (`org.eclipse.jgit.transport.ssh.jsch.JschSession.JSchProcess`), has the *identical* stream-wrapping and close ordering (same `IsolatedOutputStream`/`BufferedOutputStream(16384)`, same channel-then-stream close order) — but wraps `outputStream.close()` in `try/catch(IOException)` in its `closeOutputStream()`, precisely because a failed flush at destroy time is expected and not actionable (the channel is already being abandoned). `SshjSession` was clearly modeled on `JschSession` but dropped that catch.

This explains the intermittency reported (varies by exact negotiation size/timing depending on whether bytes happen to be sitting unflushed in the buffer at teardown), and why the SSH banner-to-disconnect log gap looked suspicious: SSHJ logs all KEX/auth/exec/wire-protocol activity at `DEBUG`, so the `INFO`-level `Disconnected - BY_APPLICATION` teardown line sits right after the banner exchange in the log on *every* run, successful or not — it's not evidence the failure happened that early.

## Fix

Wrap `outputStream.close()` in `try/catch(IOException)` in `SshjSession.SshjProcess.closeOutputStream()`, matching JGit's own `JschSession` behavior.

## Verification

- Directly reproduced the exact reported exception deterministically by calling `SshjSession.exec()` with a timeout, writing unflushed bytes to the process output stream, then calling `Process.destroy()` — matches the reported stack trace exactly. Confirmed the fix suppresses it.
- Confirmed no regression: full `ls-remote` + `clone` against a local git-over-ssh server using the actual (unmodified except for this fix) plugin classes still completes successfully.
- Ruled out an SSHJ/GitHub incompatibility: a standalone SSHJ 0.40.0 client (with and without the BouncyCastle 1.85 override from RUN-4336) negotiates and completes the handshake against real `github.com:22` cleanly, including strict-kex.
- `./gradlew :plugins:git-plugin:test` — BUILD SUCCESSFUL, all existing tests pass.

## Jira

[RUN-4838](https://pagerduty.atlassian.net/browse/RUN-4838)


[RUN-4838]: https://pagerduty.atlassian.net/browse/RUN-4838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ