### PR TITLE
[RUN-4812] Fix rerun failed tests selecting no tests in functional jobs

### DIFF
--- a/functional-test/build.gradle
+++ b/functional-test/build.gradle
@@ -79,19 +79,30 @@ def checkWarFile(destination, fileName) {
 
 /** 
  * Returns a function that includes only the test files specified in the `testFiles` parameter.
- * The `testFiles` parameter is a string of paths to the source code of the tests to be run.
+ * The `testFiles` parameter is a string of test source paths, or of fully qualified
+ * class names, one entry per line.
  */
 def explicitTestIncluder(String testFiles) {
     // Convert test file source code paths to compiled class paths.
     // Example: `functional-test/src/test/groovy/org/rundeck/tests/functional/api/basic/BasicSpec.groovy`
     // needs to become `org/rundeck/tests/functional/api/basic/BasicSpec.class`.
+    //
+    // `circleci tests glob` yields those source paths, but when rerunning only the
+    // failed tests `circleci tests run` yields fully qualified class names instead,
+    // because Gradle's JUnit XML carries a `classname` attribute and no `file` one.
+    // Both forms must map to the same compiled class path, otherwise the include
+    // matches nothing and the task is skipped as NO-SOURCE, turning a failing job
+    // green without running a single test.
     def compiledFilesToTest = testFiles
         .split(System.lineSeparator())
-        .collect { testFilePath -> 
-            testFilePath
-            .trim()
-            .replaceFirst(".*\\/src\\/test\\/(groovy\\/|java\\/)", "")
-            .replaceFirst("(.groovy|.java)\$", ".class")
+        .collect { it.trim() }
+        .findAll { !it.isEmpty() }
+        .collect { testFileOrClass ->
+            testFileOrClass.contains("/")
+                ? testFileOrClass
+                    .replaceFirst(".*\\/src\\/test\\/(groovy\\/|java\\/)", "")
+                    .replaceFirst("(.groovy|.java)\$", ".class")
+                : testFileOrClass.replace(".", "/") + ".class"
         }
 
     logger.info("Compiled files to test: {}", compiledFilesToTest)

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/basic/BadVersionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/basic/BadVersionSpec.groovy
@@ -18,9 +18,7 @@ class BadVersionSpec extends BaseContainer {
         ErrorResponse errorResponse = ErrorResponse.fromJson(response.body().string())
 
         then:
-        // TEMPORARY - DO NOT MERGE. Deliberate failure used to validate the
-        // CircleCI "Rerun failed tests" button on T Functional API (RUN-4812).
-        errorResponse.errorCode == "deliberately.broken.to.validate.circleci.rerun"
+        errorResponse.errorCode == "api.error.api-version.unsupported"
         errorResponse.error
         errorResponse.message.contains("Unsupported API Version")
 

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/basic/BadVersionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/basic/BadVersionSpec.groovy
@@ -18,7 +18,9 @@ class BadVersionSpec extends BaseContainer {
         ErrorResponse errorResponse = ErrorResponse.fromJson(response.body().string())
 
         then:
-        errorResponse.errorCode == "api.error.api-version.unsupported"
+        // TEMPORARY - DO NOT MERGE. Deliberate failure used to validate the
+        // CircleCI "Rerun failed tests" button on T Functional API (RUN-4812).
+        errorResponse.errorCode == "deliberately.broken.to.validate.circleci.rerun"
         errorResponse.error
         errorResponse.message.contains("Unsupported API Version")
 


### PR DESCRIPTION
## Summary

Follow-up to #10482, which enabled CircleCI **Rerun failed tests** on the functional and Selenium jobs. The button appeared and CircleCI selected the right tests, but the rerun ran **nothing** and reported the job as green.

`circleci tests glob` yields test source paths, which is what `explicitTestIncluder` was written for. When rerunning only the failed tests, `circleci tests run` yields **fully qualified class names** instead, because Gradle's JUnit XML carries a `classname` attribute and no `file` one. `explicitTestIncluder` passed those through untouched, so the include matched no compiled class, the task was skipped as `NO-SOURCE`, and a failing job silently turned green.

This maps both forms to the same compiled class path. `pro-functional-test` in rundeckpro delegates to this same function, so it is covered too.

## Evidence

Branch history had a deliberate failure in `BadVersionSpec` (since reverted) to exercise the button on `T Functional API`, which globs 63 spec files across 3 containers.

Before the fix, job 303954:

```
1 test(s) failed out of 322 total tests. Rerunning tests from 1 classname
Received: org.rundeck.tests.functional.api.basic.BadVersionSpec

Compiled files to test: [org.rundeck.tests.functional.api.basic.BadVersionSpec]
> Task :functional-test:apiTest NO-SOURCE
BUILD SUCCESSFUL in 27s
```

Job status `success`, and the CircleCI test API reports `items: []`. A false green.

After the fix, job 304345 reports exactly one test and fails as it should:

```
failure | org.rundeck.tests.functional.api.basic.BadVersionSpec | test-project-bad-version
```

Two of the three containers halted with nothing assigned, and the job took 5m instead of the full suite.

## Test plan

- [x] `T Functional API` rerun executes only the previously failed spec
- [x] The rerun reports the job as failed when the spec still fails
- [x] Normal runs still receive source paths from `circleci tests glob` and are unaffected
- [x] Mapping verified for source paths, class names, `.java` files, the submodule paths used by rundeckpro, and mixed lists