### PR TITLE
Exempt stalebot:ignore label from stale-issue workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -34,7 +34,11 @@ jobs:
           # Confirmed/reproduced bugs and issues already tracked internally
           # (to-jira) must never be silently auto-closed on age alone — only
           # a deliberate version-support sweep should touch those.
-          exempt-issue-labels: 'enhancement,security,status:reproduced,to-jira'
+          # stalebot:ignore is the general escape hatch for pinned/perpetual
+          # issues (e.g. Renovate's "Dependency Dashboard", #7759 - it's old,
+          # unlabeled, and permanently open by design, so it matched every
+          # other criterion here before this label existed).
+          exempt-issue-labels: 'enhancement,security,status:reproduced,to-jira,stalebot:ignore'
           stale-issue-label: 'wontfix:stale'
 
           stale-issue-message: >


### PR DESCRIPTION
Small follow-up to #10516, found while running the one-time backlog cleanup.

Renovate's perpetual "Dependency Dashboard" issue (#7759) is old and carries no labels, so it matched every exemption criterion the bulk-close script and `stale.yml`'s `exempt-issue-labels` checked for — it would have been swept and closed with a "please file a new bug report" message had the cleanup script reached it before we caught it.

Added a general-purpose `stalebot:ignore` label for pinned/perpetual issues, applied it to #7759, and added it to `exempt-issue-labels` here so the ongoing bot respects it too (the bulk-close script already excludes it, plus a belt-and-suspenders author/title check specific to the Dependency Dashboard).