### PR TITLE
[RUN-4851] Add EXEC_IDX_SCHED_DATE_STARTED index for misfire recovery counts

### DIFF
--- a/rundeckapp/grails-app/migrations/core/ExecutionIndexes.groovy
+++ b/rundeckapp/grails-app/migrations/core/ExecutionIndexes.groovy
@@ -10,4 +10,20 @@ databaseChangeLog = {
         }
     }
 
+    // Misfire recovery counts executions per job within a date window
+    // (countByScheduledExecutionAndDateStartedBetween). No existing index covers
+    // (scheduled_execution_id, date_started), and the MySQL 8.0 optimizer picks a
+    // plan that can exceed the client socket timeout on large execution tables.
+    changeSet(author: "lalamo", id: "5.15.0-add-sched-date-started-index") {
+        preConditions(onFail: "MARK_RAN") {
+            not {
+                indexExists(tableName: "execution", indexName: "EXEC_IDX_SCHED_DATE_STARTED")
+            }
+        }
+        createIndex(indexName: "EXEC_IDX_SCHED_DATE_STARTED", tableName: "execution", unique: false) {
+            column(name: "scheduled_execution_id")
+            column(name: "date_started")
+        }
+    }
+
 }


### PR DESCRIPTION
## Problem

The misfire recovery check counts executions per job within a date window:

```sql
SELECT count(*) FROM execution
WHERE scheduled_execution_id = ? AND date_started BETWEEN ? AND ?
```

No existing index covers `(scheduled_execution_id, date_started)` — the closest are `EXEC_IDX_5 (scheduled_execution_id, status)` and `EXEC_IDX_2 (date_started, status)`. After upgrading Aurora MySQL 5.7 → 8.0 (3.12.0), the 8.0 optimizer picks a plan that can exceed the JDBC client socket timeout (28s) on large `execution` tables. The AWS Advanced JDBC Wrapper then treats the timeout as a connection failure and enters a spurious writer-failover loop, breaking instance startup:

```
ERROR services.MisfireManagerService - failed to handle the misfire
org.hibernate.exception.JDBCConnectionException: could not extract ResultSet
Caused by: software.amazon.jdbc.plugin.failover.FailoverSuccessSQLException
```

## Fix

New Liquibase changeset in `core/ExecutionIndexes.groovy` adding `EXEC_IDX_SCHED_DATE_STARTED` on `execution(scheduled_execution_id, date_started)`.

- `indexExists` precondition with `MARK_RAN` (idempotent; no-op where the index was pre-created manually)
- Portable `createIndex` (MySQL/MariaDB, PostgreSQL, H2, Oracle, MSSQL)
- Liquibase auto-rollback (dropIndex)
- MySQL 8.0 creates the index with online DDL (INPLACE), allowing concurrent DML
- No existing changesets modified

Makes the misfire count plan-stable regardless of optimizer version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)