### PR TITLE
[RUN-4857] Sync remco fork to fix golang.org/x/crypto, x/net, grpc CVEs

### DIFF
--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -2,12 +2,9 @@
 ###################################################
 FROM golang:1.27.0 AS remco
 
-# Pinned to rundeck/remco @ HEAD (synced to upstream HeavyHorst/remco).
-# Includes fixes through this commit: golang.org/x/crypto 0.52.0,
-# golang.org/x/net 0.55.0, google.golang.org/grpc 1.82.1 - addresses
-# CVE-2026-39827 through -39835, CVE-2026-42508, CVE-2026-46595,
-# CVE-2026-46597, CVE-2026-46598, CVE-2026-25680, CVE-2026-39821,
-# and GHSA-hrxh-6v49-42gf.
+# Pinned to a rundeck/remco commit synced with upstream HeavyHorst/remco.
+# Fixes golang.org/x/crypto 0.52.0, golang.org/x/net 0.55.0, and
+# google.golang.org/grpc 1.82.1 - see RUN-4857 for the full CVE list.
 ENV REMCO_COMMIT=bbc9243fec2e05c2fc8bf8a66bd9e24f04a2762b
 
 RUN git clone https://github.com/rundeck/remco.git /tmp/remco && \

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -2,11 +2,13 @@
 ###################################################
 FROM golang:1.27.0 AS remco
 
-# Pinned to rundeck/remco @ v0.12.6 (synced to upstream HeavyHorst/remco).
-# Includes CVE fixes through v0.12.6: go-jose/go-jose/v4 4.1.4 for
-# CVE-2026-34986 (GHSA-78h2-9frx-2jm8), plus CVE-2025-47914,
-# CVE-2025-61727, CVE-2026-33186 (grpc v1.79.3).
-ENV REMCO_COMMIT=777d12eaff303faa220f7686cdfa583a84f9bda4
+# Pinned to rundeck/remco @ HEAD (synced to upstream HeavyHorst/remco).
+# Includes fixes through this commit: golang.org/x/crypto 0.52.0,
+# golang.org/x/net 0.55.0, google.golang.org/grpc 1.82.1 - addresses
+# CVE-2026-39827 through -39835, CVE-2026-42508, CVE-2026-46595,
+# CVE-2026-46597, CVE-2026-46598, CVE-2026-25680, CVE-2026-39821,
+# and GHSA-hrxh-6v49-42gf.
+ENV REMCO_COMMIT=bbc9243fec2e05c2fc8bf8a66bd9e24f04a2762b
 
 RUN git clone https://github.com/rundeck/remco.git /tmp/remco && \
     cd /tmp/remco && \


### PR DESCRIPTION
## Summary
- Fast-forwards the pinned `rundeck/remco` commit in `docker/ubuntu-base/Dockerfile` from `777d12eaff30` to upstream `HeavyHorst/remco` HEAD (`bbc9243fec2e`)
- Resolves 16 CVEs flagged by the "Rundeck vulnerabilities policy" CircleCI scan against `/usr/local/bin/remco`:
  - `golang.org/x/crypto` 0.46.0 -> 0.52.0 (CVE-2026-39827..39835, CVE-2026-42508, CVE-2026-46595)
  - `golang.org/x/net` 0.48.0 -> 0.55.0 (CVE-2026-25680, CVE-2026-39821)
  - `google.golang.org/grpc` 1.79.3 -> 1.82.1 (GHSA-hrxh-6v49-42gf)
- `rundeck/remco`'s `master` was verified to have zero divergence from upstream at the previous pin (clean fast-forward, no fork-specific patches lost); the new tip also includes one unrelated upstream bugfix (#119, avoids a panic on tokenless `exec_command`)
- The Go builder image (`golang:1.27.0`) already satisfies the bumped `go 1.25.0` directive in remco's `go.mod` - no Dockerfile builder-stage change needed beyond the pin

## Test plan
- [ ] CI image build succeeds
- [ ] Rundeck vulnerabilities policy scan no longer flags the 16 CVEs against `/usr/local/bin/remco`
- [ ] Smoke test: container starts, remco renders config as before

Fixes RUN-4857