### PR TITLE
[RUN-4859] Add rundeck.metrics.legacy.enabled to Docker remco config template

### DIFF
--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -95,6 +95,7 @@ rundeck.primaryServerId={{ getv("/rundeck/primaryserverid") }}
 
 rundeck.metrics.enabled={{ getv("/rundeck/metrics/enabled", "false") }}
 rundeck.metrics.jmxEnabled={{ getv("/rundeck/metrics/jmxenabled", "false") }}
+rundeck.metrics.legacy.enabled={{ getv("/rundeck/metrics/legacy/enabled", "false") }}
 
 {% if exists("/rundeck/projectservice/deferredprojectdelete") %}
 rundeck.projectService.deferredProjectDelete={{ getv("/rundeck/projectservice/deferredprojectdelete") }}


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. Fixes #10398. The official Docker image generates `rundeck-config.properties` from a remco template that only wires up `rundeck.metrics.enabled` and `rundeck.metrics.jmxEnabled` as configurable env vars. `rundeck.metrics.legacy.enabled` (which controls whether the legacy Dropwizard `/metrics/*` endpoints are exposed) was never added to the template, so setting `RUNDECK_METRICS_LEGACY_ENABLED=true` on the container was silently ignored — the generated config file never contained the key, and legacy metrics endpoints kept returning 404 even when explicitly enabled.

**Describe the solution you've implemented**

Added the missing line to `docker/official/remco/templates/rundeck-config.properties`, following the same pattern as the existing `rundeck.metrics.enabled`/`rundeck.metrics.jmxEnabled` lines:

```
rundeck.metrics.legacy.enabled={{ getv("/rundeck/metrics/legacy/enabled", "false") }}
```

This makes `RUNDECK_METRICS_LEGACY_ENABLED` behave the same way as the sibling metrics env vars (remco's env backend maps `RUNDECK_METRICS_LEGACY_ENABLED` → `/rundeck/metrics/legacy/enabled`), and defaults to `"false"` when unset, matching current behavior for anyone not setting it.

**Describe alternatives you've considered**

N/A — this is a one-line template gap fix; no alternative approach needed.

**Additional context**

- Fixes #10398
- Jira: [RUN-4859](https://pagerduty.atlassian.net/browse/RUN-4859)

## Release Notes

Fixed the official Docker image so that `RUNDECK_METRICS_LEGACY_ENABLED` is honored, enabling the legacy `/metrics/*` endpoints when set.



[RUN-4859]: https://pagerduty.atlassian.net/browse/RUN-4859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ