### PR TITLE
[RUN-4860] Explicitly request demographic/password attributes in LDAP findUser()

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
@@ -1018,6 +1018,18 @@ public class JettyCachingLdapLoginModule extends AbstractLoginModule {
         ctls.setCountLimit(1);
         ctls.setDerefLinkFlag(true);
         ctls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+        // Explicitly request the attributes this class reads off of the search result
+        // (setDemographicAttributes() and the userPassword lookup in getUserCredentials()).
+        // Some directories (e.g. Active Directory over JNDI) return null for every attribute
+        // when no returning-attribute list is set, even though the same attributes are readable
+        // via ldapsearch, so they must be requested by name.
+        ctls.setReturningAttributes(new String[]{
+            _userIdAttribute,
+            _userPasswordAttribute,
+            _userFirstNameAttribute,
+            _userLastNameAttribute,
+            _userEmailAttribute
+        });
 
         String filter = OBJECT_CLASS_FILTER;
 

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModuleTest.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModuleTest.groovy
@@ -218,6 +218,69 @@ class JettyCachingLdapLoginModuleTest extends Specification {
         username | _
         'auser'  | _
     }
+
+    def "findUser requests demographic and password attributes explicitly"() {
+        // Some directories (e.g. Active Directory over JNDI) return null for every attribute
+        // when no returning-attribute list is set on the search, even though the same
+        // attributes are readable via ldapsearch. findUser() must request them by name.
+        JettyCachingLdapLoginModule module = new JettyCachingLdapLoginModule()
+        module._debug = true
+        module._forceBindingLogin = true
+        module._contextFactory = "notnull"
+        module._providerUrl = "notnull"
+        module._forceBindingLoginUseRootContextForRoles = false
+        module._roleBaseDn = 'roleBaseDn'
+        module.rolePagination = false
+        module._roleUsernameMemberAttribute = 'roleUsernameMemberAttribute'
+        module.setCallbackHandler(Mock(CallbackHandler) {
+            1 * handle(_) >> { it[0][0].name = username; it[0][1].object = 'apassword' }
+        })  // Use setter instead of @field access (Groovy 4)
+        def found = [Mock(SearchResult) {
+            getNameInNamespace() >> "cn=$username,dc=test,dc=com"
+            getAttributes() >> Mock(Attributes) {
+                get(module._userFirstNameAttribute) >> new BasicAttribute(module._userFirstNameAttribute, "First")
+                get(module._userLastNameAttribute) >> new BasicAttribute(module._userLastNameAttribute, "Last")
+                get(module._userEmailAttribute) >> new BasicAttribute(module._userEmailAttribute, "user@example.com")
+            }
+        }]
+        def dirContext = Mock(DirContext) {
+            1 * search(
+                _,
+                JettyCachingLdapLoginModule.OBJECT_CLASS_FILTER,
+                [module._userObjectClass, module._userIdAttribute, username],
+                { SearchControls ctls ->
+                    ctls.getReturningAttributes() as List == [
+                        module._userIdAttribute,
+                        module._userPasswordAttribute,
+                        module._userFirstNameAttribute,
+                        module._userLastNameAttribute,
+                        module._userEmailAttribute,
+                    ]
+                }
+            ) >> {new EnumImpl<SearchResult>(found)}
+            0 * search(*_)
+        }
+        module._rootContext = dirContext
+        DirContext userDir = Mock(DirContext) {
+            _ * search(*_) >> {new EnumImpl<SearchResult>([])}
+        }
+        module.userBindDirContextCreator = { String user, Object pass ->
+            userDir
+        }
+        when:
+        boolean result = module.login()
+
+        then:
+        result
+        module._userFirstName == "First"
+        module._userLastName == "Last"
+        module._userEmail == "user@example.com"
+
+        where:
+        username | _
+        'auser'  | _
+    }
+
     class EnumImpl<T> implements NamingEnumeration<T>{
         List<T> list
 


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. Fixes #10469. `JettyCachingLdapLoginModule.findUser()` searches for the user entry without calling `SearchControls.setReturningAttributes(...)`, relying on the JNDI/directory default of "return all attributes."

Against Active Directory over JNDI, this can return `null` for every attribute on the search result — even though the same attributes are readable via `ldapsearch` using the exact same bind account and base DN (the reporter included a standalone JNDI repro program demonstrating this independent of Rundeck). No error is logged; the profile-sync code just silently receives `null` for every field.

This means `setDemographicAttributes()` (first/last name, email) and the `userPassword` lookup in `getUserCredentials()` — both of which read attributes off of `findUser()`'s result — never actually get populated for affected AD deployments.

**Describe the solution you've implemented**

Added an explicit returning-attributes list to `findUser()`'s `SearchControls`, covering every attribute this class reads from that particular search result: `userIdAttribute`, `userPasswordAttribute`, `userFirstNameAttribute`, `userLastNameAttribute`, `userEmailAttribute`. This matches the existing pattern already used for role searches elsewhere in the same class (see `getNonPaginatedRoles()`, which already calls `setReturningAttributes`), so it's consistent with the rest of the file rather than a new pattern.

**Describe alternatives you've considered**

- Leaving the returning-attributes list unset and instead adding a config flag to opt into requesting attributes explicitly — rejected as unnecessary complexity; explicitly requesting only the attributes this code actually reads is strictly more correct with no behavior change for directories that already worked (they'll return the same attributes, just now explicitly asked for), so no flag is needed.

**Additional context**

- Fixes #10469
- Related historical issues referenced by the reporter: #7175, #7627

## Release Notes

Fixed LDAP authentication (`JettyCachingLdapLoginModule`) so that first name, last name, and email are correctly synced from directories (e.g. Active Directory) that require attributes to be explicitly requested in the search, rather than silently syncing `null` values.
