### PR TITLE
[RUN-4579] Optional shell-quoting of SSH exported variable values

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -167,6 +167,15 @@ public class RundeckConfigBase {
          */
         Boolean rejectUndeclaredOptions;
 
+        /**
+         * RUN-4579: opt-in (default false). When true, values exported to remote nodes via the node's
+         * {@code ssh-variable-export-pattern} are POSIX shell-quoted, preventing command injection
+         * through option values. Left false by default to preserve the current behavior. Bound from
+         * {@code rundeck.execution.sshExportQuoting} so it is resolvable via ConfigurationService and
+         * editable in the System Configuration UI.
+         */
+        Boolean sshExportQuoting;
+
         @Data
         public static class RetryConfig {
             Integer retryMax;

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/NodeExecutorUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/NodeExecutorUtils.java
@@ -1,7 +1,9 @@
 package com.dtolabs.rundeck.core.execution;
 
+import com.dtolabs.rundeck.core.cli.CLIUtils;
 import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.dispatcher.DataContextUtils;
+import com.dtolabs.rundeck.core.execution.component.SshExportQuotingConfig;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -33,14 +35,24 @@ public class NodeExecutorUtils {
             List<String> envArgs = new ArrayList<>();
             String replacementPattern = node.getAttributes().get(RD_VARIABLE_PATTERN);
             final Map<String, String> envVars = DataContextUtils.generateEnvVarsFromContext(nodeContext.getDataContext());
+            // RUN-4579: option values reach the remote sh -c through this export prefix; without shell
+            // quoting a value containing metacharacters (;, $(), backticks, ...) is a command-injection
+            // sink. Quoting is opt-in and gated by a component resolved in the application layer
+            // (project/system config); default false (legacy unquoted behavior) when absent. When
+            // enabled, quoteUnixShellArg is a no-op for benign values, so ordinary configurations are
+            // unaffected.
+            final boolean quoteExport = nodeContext.componentForType(SshExportQuotingConfig.class)
+                    .map(SshExportQuotingConfig::isQuoteExportedValues)
+                    .orElse(false);
             envVars.forEach((k,v)->{
+                final String value = quoteExport ? CLIUtils.quoteUnixShellArg(v) : v;
                 if(node.getAttributes().get(RD_VARIABLE_PATTERN_EXCLUDE_NODES) != null
                         && Boolean.TRUE.equals(Boolean.valueOf(node.getAttributes().get(RD_VARIABLE_PATTERN_EXCLUDE_NODES)))){
                     if(!k.startsWith(RD_VARIABLE_PATTERN_EXCLUDE_NODES_PATTERN)){
-                        envArgs.add(replacementPattern.replace("{key}", k).replace("{value}", v));
+                        envArgs.add(replacementPattern.replace("{key}", k).replace("{value}", value));
                     }
                 }else{
-                    envArgs.add(replacementPattern.replace("{key}", k).replace("{value}", v));
+                    envArgs.add(replacementPattern.replace("{key}", k).replace("{value}", value));
                 }
             });
             if(!envArgs.isEmpty()){

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/NodeExecutorUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/NodeExecutorUtils.java
@@ -38,9 +38,9 @@ public class NodeExecutorUtils {
             // RUN-4579: option values reach the remote sh -c through this export prefix; without shell
             // quoting a value containing metacharacters (;, $(), backticks, ...) is a command-injection
             // sink. Quoting is opt-in and gated by a component resolved in the application layer
-            // (project/system config); default false (legacy unquoted behavior) when absent. When
-            // enabled, quoteUnixShellArg is a no-op for benign values, so ordinary configurations are
-            // unaffected.
+            // (system config); default false (legacy unquoted behavior) when absent. When enabled,
+            // quoteUnixShellArg only adds quotes to values that contain whitespace or shell
+            // metacharacters; values without those are emitted unchanged.
             final boolean quoteExport = nodeContext.componentForType(SshExportQuotingConfig.class)
                     .map(SshExportQuotingConfig::isQuoteExportedValues)
                     .orElse(false);

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/component/SshExportQuotingConfig.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/component/SshExportQuotingConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.core.execution.component;
+
+/**
+ * RUN-4579: execution-context component carrying the resolved decision of whether exported node
+ * variable values (the {@code ssh-variable-export-pattern} prefix) should be POSIX shell-quoted.
+ *
+ * <p>Values flow into the {@code export {key}={value}} prefix that is prepended to the remote SSH
+ * command. Without quoting, shell metacharacters in an option value are parsed as command separators
+ * (command injection). The value is resolved in the application (Grails) layer via
+ * {@code ConfigurationService} (the system-level {@code rundeck.execution.sshExportQuoting} setting),
+ * attached to the execution context, and read by
+ * {@code NodeExecutorUtils.getExportedVariablesForNode}. Opt-in: defaults to {@code false} (legacy
+ * unquoted behavior) when no component is present.
+ */
+public final class SshExportQuotingConfig {
+
+    /**
+     * Component name used when attaching to / retrieving from the execution context.
+     */
+    public static final String COMPONENT_NAME = "sshExportQuoting";
+
+    private final boolean quoteExportedValues;
+
+    public SshExportQuotingConfig(final boolean quoteExportedValues) {
+        this.quoteExportedValues = quoteExportedValues;
+    }
+
+    /**
+     * @return true when exported variable values should be POSIX shell-quoted
+     */
+    public boolean isQuoteExportedValues() {
+        return quoteExportedValues;
+    }
+}

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/NodeExecutorUtilsSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/NodeExecutorUtilsSpec.groovy
@@ -2,6 +2,7 @@ package com.dtolabs.rundeck.core.execution
 
 import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import com.dtolabs.rundeck.core.dispatcher.DataContextUtils
+import com.dtolabs.rundeck.core.execution.component.SshExportQuotingConfig
 import spock.lang.Specification
 
 class NodeExecutorUtilsSpec extends Specification {
@@ -72,5 +73,54 @@ class NodeExecutorUtilsSpec extends Specification {
         result.size() == 2
         result[0] == 'export RD_JOB_E = \'f\';'
         result[1] == 'ls'
+    }
+
+    def "getExportedVariablesForNode shell-quotes exported values to prevent injection (RUN-4579)"() {
+        given: 'a node with a bare {value} export pattern and a malicious option value'
+        def nodea = new NodeEntryImpl("nodea.host", "nodea")
+        nodea.setAttribute(NodeExecutorUtils.RD_VARIABLE_PATTERN, 'export {key}={value}')
+        nodea.setAttribute(NodeExecutorUtils.RD_VARIABLE_PATTERN_SEPARATOR, ";")
+
+        def builder = ExecutionContextImpl.builder()
+                .stepContext([1, 2])
+                .stepNumber(3)
+                .dataContext(DataContextUtils.context('b', [c: '; id']))
+        if (quotingComponent != null) {
+            builder.addComponent(SshExportQuotingConfig.COMPONENT_NAME, quotingComponent, SshExportQuotingConfig)
+        }
+        def orig = builder.build()
+        def commandList = ["ls"]
+
+        when:
+        def result = NodeExecutorUtils.getExportedVariablesForNode(nodea, orig, commandList)
+
+        then: 'when quoting is enabled the ; is inside single quotes and cannot separate commands; default/off is legacy'
+        result[0] == expected
+
+        where:
+        quotingComponent                  || expected
+        null                              || "export RD_B_C=; id;"     // default (opt-in off): legacy unquoted
+        new SshExportQuotingConfig(false) || "export RD_B_C=; id;"     // off: legacy unquoted
+        new SshExportQuotingConfig(true)  || "export RD_B_C='; id';"   // opt-in on: quoted, injection neutralized
+    }
+
+    def "getExportedVariablesForNode leaves benign values unquoted (quoting is a no-op)"() {
+        given: 'a benign value contains no shell metacharacters'
+        def nodea = new NodeEntryImpl("nodea.host", "nodea")
+        nodea.setAttribute(NodeExecutorUtils.RD_VARIABLE_PATTERN, 'export {key}={value}')
+        nodea.setAttribute(NodeExecutorUtils.RD_VARIABLE_PATTERN_SEPARATOR, ";")
+
+        def orig = ExecutionContextImpl.builder()
+                .stepContext([1, 2])
+                .stepNumber(3)
+                .dataContext(DataContextUtils.context('b', [c: 'd']))
+                .build()
+        def commandList = ["ls"]
+
+        when:
+        def result = NodeExecutorUtils.getExportedVariablesForNode(nodea, orig, commandList)
+
+        then: 'quoteUnixShellArg adds no quotes, so ordinary configurations are unaffected'
+        result[0] == 'export RD_B_C=d;'
     }
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/NodeExecutorUtilsSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/NodeExecutorUtilsSpec.groovy
@@ -104,8 +104,8 @@ class NodeExecutorUtilsSpec extends Specification {
         new SshExportQuotingConfig(true)  || "export RD_B_C='; id';"   // opt-in on: quoted, injection neutralized
     }
 
-    def "getExportedVariablesForNode leaves benign values unquoted (quoting is a no-op)"() {
-        given: 'a benign value contains no shell metacharacters'
+    def "getExportedVariablesForNode leaves values without whitespace or metacharacters unquoted even when quoting is enabled"() {
+        given: 'quoting is ENABLED and the value has no whitespace or shell metacharacters'
         def nodea = new NodeEntryImpl("nodea.host", "nodea")
         nodea.setAttribute(NodeExecutorUtils.RD_VARIABLE_PATTERN, 'export {key}={value}')
         nodea.setAttribute(NodeExecutorUtils.RD_VARIABLE_PATTERN_SEPARATOR, ";")
@@ -114,13 +114,14 @@ class NodeExecutorUtilsSpec extends Specification {
                 .stepContext([1, 2])
                 .stepNumber(3)
                 .dataContext(DataContextUtils.context('b', [c: 'd']))
+                .addComponent(SshExportQuotingConfig.COMPONENT_NAME, new SshExportQuotingConfig(true), SshExportQuotingConfig)
                 .build()
         def commandList = ["ls"]
 
         when:
         def result = NodeExecutorUtils.getExportedVariablesForNode(nodea, orig, commandList)
 
-        then: 'quoteUnixShellArg adds no quotes, so ordinary configurations are unaffected'
+        then: 'quoteUnixShellArg adds no quotes for such values, so ordinary configurations are unaffected'
         result[0] == 'export RD_B_C=d;'
     }
 }

--- a/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/SSHTaskBuilder.java
+++ b/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/SSHTaskBuilder.java
@@ -589,8 +589,9 @@ public class SSHTaskBuilder {
 
         configureSSHBase(nodeentry, project, sshConnectionInfo, sshexecTask, loglevel, logger);
 
-        //nb: args are already quoted as necessary
-
+        // nb: the job command args are quoted as necessary by ExecArgList. RUN-4579: any exported
+        // variable prefix from NodeExecutorUtils.getExportedVariablesForNode is quoted at its source
+        // (CLIUtils.quoteUnixShellArg), so joining here does not re-open a shell-injection sink.
         final String commandString = String.join(" ", args);
         sshexecTask.setCommand(commandString);
         sshexecTask.setTimeout(sshConnectionInfo.getTimeout());

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -41,6 +41,7 @@ import com.dtolabs.rundeck.core.data.SharedDataContextUtils
 import com.dtolabs.rundeck.core.dispatcher.ContextView
 import com.dtolabs.rundeck.core.dispatcher.DataContextUtils
 import com.dtolabs.rundeck.core.execution.ExecutionContextImpl
+import com.dtolabs.rundeck.core.execution.component.SshExportQuotingConfig
 import com.dtolabs.rundeck.core.execution.ExecutionListener
 import com.dtolabs.rundeck.core.execution.ExecutionReference
 import com.dtolabs.rundeck.core.execution.ExecutionValidator
@@ -1414,6 +1415,11 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             StepExecutionContext executioncontext = ExecutionContextImpl.builder(createInitContext)
                     .executionListener(multiListener)
                     .workflowExecutionListener(multiListener)
+                    .addComponent(
+                            SshExportQuotingConfig.COMPONENT_NAME,
+                            new SshExportQuotingConfig(resolveSshExportQuoting()),
+                            SshExportQuotingConfig
+                    )
                     .build()
 
             fileUploadService.executionBeforeStart(
@@ -3362,6 +3368,22 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      */
     private static boolean hasOwnValueConstraint(Option opt) {
         opt.regex || (opt.enforced && opt.optionValues)
+    }
+
+    /**
+     * RUN-4579: resolve whether values exported to remote nodes via {@code ssh-variable-export-pattern}
+     * should be POSIX shell-quoted. System-level, opt-in: read from
+     * {@link AppConstants#SYSTEM_SSH_EXPORT_QUOTING} through ConfigurationService (editable via the
+     * System Configuration UI). Defaults to {@code false} (legacy unquoted behavior) when unset.
+     * @return true when exported variable values should be shell-quoted
+     */
+    private boolean resolveSshExportQuoting() {
+        try {
+            return configurationService.getBoolean(AppConstants.SYSTEM_SSH_EXPORT_QUOTING, false)
+        } catch (Exception e) {
+            log.warn("Could not resolve ssh export quoting setting; defaulting to legacy (unquoted)", e)
+            return false
+        }
     }
 
     private Pattern resolveDefaultOptionInputPattern(String project) {
@@ -5530,6 +5552,17 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     key AppConstants.SYSTEM_REJECT_UNDECLARED_OPTIONS_KEY
                     description "Security control. When enabled (default), an execution that provides options not defined on the job is created and then failed at start. Disable ONLY if you must allow undeclared options to pass through."
                     defaultValue "true"
+                    required false
+                    datatype "Boolean"
+                    visibility 'Advanced'
+                    category 'Execution'
+                    authRequired("app_admin")
+                    build()
+                },
+                SystemConfig.builder().with {
+                    key AppConstants.SYSTEM_SSH_EXPORT_QUOTING_KEY
+                    description "Security control (opt-in; default off). When enabled, values exported to remote nodes via the node's ssh-variable-export-pattern are POSIX shell-quoted, preventing command injection through option values. Left off by default to preserve the current behavior. Note: when enabling, node export patterns should reference {value} without surrounding quotes."
+                    defaultValue "false"
                     required false
                     datatype "Boolean"
                     visibility 'Advanced'

--- a/rundeckapp/src/main/groovy/org/rundeck/app/AppConstants.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/AppConstants.groovy
@@ -53,4 +53,18 @@ class AppConstants {
      * as exposed in the System Configuration UI via SysConfigProp.
      */
     static final String SYSTEM_REJECT_UNDECLARED_OPTIONS_KEY = "rundeck." + SYSTEM_REJECT_UNDECLARED_OPTIONS
+
+    /**
+     * Opt-in (default false). When true, values exported to remote nodes via the node's
+     * {@code ssh-variable-export-pattern} are POSIX shell-quoted, preventing command injection through
+     * option values (RUN-4579). Left false by default to preserve the current behavior. Resolved
+     * through ConfigurationService; this constant holds the sub-key (without the {@code rundeck.}
+     * prefix) used with {@code ConfigurationService.getBoolean}.
+     */
+    static final String SYSTEM_SSH_EXPORT_QUOTING = "execution.sshExportQuoting"
+    /**
+     * Full config key (with {@code rundeck.} prefix) of {@link #SYSTEM_SSH_EXPORT_QUOTING}, as exposed
+     * in the System Configuration UI via SysConfigProp.
+     */
+    static final String SYSTEM_SSH_EXPORT_QUOTING_KEY = "rundeck." + SYSTEM_SSH_EXPORT_QUOTING
 }


### PR DESCRIPTION
## Summary

Fixes the command-injection sink reported in RUN-4579 (HackerOne): job **option values** exported to remote nodes via a node's `ssh-variable-export-pattern` reach the remote `sh -c` **unquoted**. A `run`-only user can inject shell metacharacters (`;`, `$()`, backticks, …) into an option value and execute arbitrary commands on the managed node (CWE-78) — an ACL-boundary privilege escalation.

Taint path: option value → `RD_OPTION_*` → `NodeExecutorUtils.getExportedVariablesForNode` (`export {key}={value}`, raw) → `SSHTaskBuilder` `String.join(" ", args)` → JSch `ChannelExec.setCommand` → remote `sh -c`.

**Precondition:** only nodes with the (non-default, admin-configured) `ssh-variable-export-pattern` attribute are affected.

## Change

Quote `{value}` at its source in `NodeExecutorUtils.getExportedVariablesForNode` (both branches) with the existing `CLIUtils.quoteUnixShellArg`, gated by a new **system-level, opt-in** control:

- `rundeck.execution.sshExportQuoting` (system config, UI-editable via `RundeckConfigBase` + `SysConfigProp`).
- **Default `false`** — preserves the current behavior; no regression out of the box. Set `true` to enable quoting.
- Resolved in `ExecutionService` and carried to the core sink via a typed execution-context component (`SshExportQuotingConfig`), which propagates from the workflow context to the node context.
- `SSHTaskBuilder`: corrected the misleading "args are already quoted as necessary" comment.

`CLIUtils.quoteUnixShellArg` is a **no-op for benign values**, so enabling the control does not affect ordinary configurations. When enabling, node export patterns should reference `{value}` **without** surrounding quotes (a self-quoting `'{value}'` pattern would double-quote).

## Tests

`NodeExecutorUtilsSpec`:
- Enabled → `; id` is quoted (`export RD_B_C='; id';`), injection neutralized.
- Benign value → unchanged (quoting is a no-op).
- Default / explicit-off → legacy unquoted behavior.
- Pre-existing tests pass unchanged.

## Notes

- Being opt-in (default off), this does **not** close the P1 by default — enabling the control is required. This matches the team's preference to avoid any behavior change unless configured.
- Docs for the new property and a functional PoC test can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)