### PR TITLE
[RUN-4862] Raise default ACE code editor min lines from 12 to 20

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -510,7 +510,10 @@ public class RundeckConfigBase {
         Enabled activityDefaultTimeFilter = new Enabled();
         Enabled vueKeyStorage = new Enabled(true);
         Enabled pluginGroups = new Enabled(true);
-        int guiAceEditorMinLines = 12;
+        // RUN-4277/RUN-10321: default raised from 12 to 20 — Ace no longer supports a manual
+        // resize handle (upstream removed it), so a taller out-of-the-box default is the
+        // supported way to make the inline-script/code editor more usable without configuration.
+        int guiAceEditorMinLines = 20;
         int guiAceEditorMaxLines = 0;
 
         @Data

--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -510,7 +510,7 @@ public class RundeckConfigBase {
         Enabled activityDefaultTimeFilter = new Enabled();
         Enabled vueKeyStorage = new Enabled(true);
         Enabled pluginGroups = new Enabled(true);
-        // RUN-4277/RUN-10321: default raised from 12 to 20 — Ace no longer supports a manual
+        // RUN-4277/#10321: default raised from 12 to 20 — Ace no longer supports a manual
         // resize handle (upstream removed it), so a taller out-of-the-box default is the
         // supported way to make the inline-script/code editor more usable without configuration.
         int guiAceEditorMinLines = 20;

--- a/rundeckapp/grails-app/views/layouts/base.gsp
+++ b/rundeckapp/grails-app/views/layouts/base.gsp
@@ -134,7 +134,7 @@
             logo:'${g.appLogo()}',
             logocss:'${g.appLogocss()}',
             appRundeckGatewayUrl: '${g.appRundeckGatewayUrl()}',
-            aceEditorMinLines: ${cfg.getInteger(config:'feature.guiAceEditorMinLines', default:12)},
+            aceEditorMinLines: ${cfg.getInteger(config:'feature.guiAceEditorMinLines', default:20)},
             aceEditorMaxLines: ${cfg.getInteger(config:'feature.guiAceEditorMaxLines', default:0)}
         },
         hideVersionUpdateNotification: '${session.filterPref?.hideVersionUpdateNotification}',

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropEdit.vue
@@ -440,7 +440,7 @@ import {
   WorkflowStepType,
 } from "../utils/contextVariableUtils";
 
-// RUN-4277/RUN-10321: default raised from 12 to 20 — Ace no longer supports a manual resize
+// RUN-4277/#10321: default raised from 12 to 20 — Ace no longer supports a manual resize
 // handle (upstream removed it), so a taller out-of-the-box default is the supported way to
 // make the inline-script/code editor more usable without configuration.
 const ACE_EDITOR_DEFAULT_MIN_LINES = 20;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropEdit.vue
@@ -440,7 +440,10 @@ import {
   WorkflowStepType,
 } from "../utils/contextVariableUtils";
 
-const ACE_EDITOR_DEFAULT_MIN_LINES = 12;
+// RUN-4277/RUN-10321: default raised from 12 to 20 — Ace no longer supports a manual resize
+// handle (upstream removed it), so a taller out-of-the-box default is the supported way to
+// make the inline-script/code editor more usable without configuration.
+const ACE_EDITOR_DEFAULT_MIN_LINES = 20;
 const ACE_EDITOR_DEFAULT_MAX_LINES = 0;
 
 interface Prop {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginPropEdit.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginPropEdit.spec.ts
@@ -60,20 +60,20 @@ describe("pluginPropEdit aceEditor computed props", () => {
   });
 
   describe("aceEditorMinLines", () => {
-    it("passes minLines of 12 to AceEditorVue when appMeta has no aceEditorMinLines", async () => {
+    it("passes minLines of 20 to AceEditorVue when appMeta has no aceEditorMinLines", async () => {
       mockGetRundeckContext.mockReturnValueOnce({ appMeta: {} });
       const wrapper = await createCodeWrapper({ prop: codeProp });
 
-      expect(wrapper.findComponent(AceEditorVue).props("minLines")).toBe(12);
+      expect(wrapper.findComponent(AceEditorVue).props("minLines")).toBe(20);
     });
 
     it("passes the configured minLines to AceEditorVue when appMeta provides it", async () => {
       mockGetRundeckContext.mockReturnValueOnce({
-        appMeta: { aceEditorMinLines: 20 },
+        appMeta: { aceEditorMinLines: 30 },
       });
       const wrapper = await createCodeWrapper({ prop: codeProp });
 
-      expect(wrapper.findComponent(AceEditorVue).props("minLines")).toBe(20);
+      expect(wrapper.findComponent(AceEditorVue).props("minLines")).toBe(30);
     });
   });
 

--- a/rundeckapp/src/main/groovy/org/rundeck/app/config/FeatureFlagConfigurable.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/config/FeatureFlagConfigurable.groovy
@@ -25,8 +25,8 @@ class FeatureFlagConfigurable implements SystemConfigurable {
         guiConfig(
             'rundeck.feature.guiAceEditorMinLines',
             'Code Editor - Minimum Lines',
-            'Minimum number of visible lines in the ACE code editor rendered inside plugin configuration forms. Default: 12.',
-            '12',
+            'Minimum number of visible lines in the ACE code editor rendered inside plugin configuration forms. Default: 20.',
+            '20',
             'Integer'
         ),
         guiConfig(


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Follow-up to #10321 ("The text box in the script editor is very small") and [RUN-4277](https://pagerduty.atlassian.net/browse/RUN-4277) (#10137). RUN-4277 made the ACE code editor's minimum line count admin-configurable via System Configuration (`rundeck.feature.guiAceEditorMinLines`), but left the out-of-the-box default at 12 lines — so users who don't know about that setting still see the inline-script/plugin-config editor as tiny, and keep filing this against 6.0.0/6.1.0.

We looked into adding a real manual drag-resize handle instead, but per UI review: Ace no longer supports a proper resize handle upstream (even ace.c9.io's own demo dropped it), and layering `resize` CSS on top of Ace's own auto-grow-to-content sizing produces a jarring "jump" when resizing or typing a new line — it ends up feeling more broken, not less. So a manual resize affordance isn't viable right now.

**Describe the solution you've implemented**

Raised the default from 12 to 20 lines everywhere it's declared:
- `RundeckConfigBase.java` — `guiAceEditorMinLines` field default
- `base.gsp` — fallback default when reading the config value into `appMeta`
- `FeatureFlagConfigurable.groovy` — the System Config UI's label/description/default shown to admins
- `pluginPropEdit.vue` — the JS-side fallback constant used when `appMeta.aceEditorMinLines` is unset

The admin-configurable System Configuration setting still works exactly as before — this only changes the behavior when nobody has explicitly configured it.

**Describe alternatives you've considered**

- Adding a manual drag-resize handle to `AceEditorVue.vue` — investigated and rejected per UI review (see above): Ace's auto-grow (`maxLines`) mode fights with manual CSS resize, producing a broken-feeling jump on every resize/keystroke.

**Additional context**

- Fixes: #10321
- Jira: [RUN-4862](https://pagerduty.atlassian.net/browse/RUN-4862)
- Related: [RUN-4277](https://pagerduty.atlassian.net/browse/RUN-4277) / #10137

## Release Notes

Raised the default minimum visible lines for the ACE code/script editor from 12 to 20. The minimum (and maximum) can still be customized via System Configuration → GUI.


[RUN-4277]: https://pagerduty.atlassian.net/browse/RUN-4277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUN-4277]: https://pagerduty.atlassian.net/browse/RUN-4277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[RUN-4862]: https://pagerduty.atlassian.net/browse/RUN-4862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ