### PR TITLE
[RUN-4790] Fix rd system acls create JsonParseException regression

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/acl/SystemAclCreateSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/acl/SystemAclCreateSpec.groovy
@@ -1,0 +1,53 @@
+package org.rundeck.tests.functional.api.acl
+
+import okhttp3.Headers
+import org.rundeck.util.annotations.APITest
+import org.rundeck.util.container.BaseContainer
+
+/**
+ * Regression coverage for RUN-4790: creating a system ACL with a YAML request body while
+ * asking for a JSON response (as the CLI's API client does) must return a JSON-wrapped body,
+ * not raw YAML.
+ */
+@APITest
+class SystemAclCreateSpec extends BaseContainer {
+
+    def "create system acl with yaml body and json accept returns json"() {
+        given:
+        def aclPath = "run4790-${UUID.randomUUID()}.aclpolicy"
+        def yamlBody = '''by:
+  group: Run4790Group
+description: Allow [read] for project_acl
+for:
+  project_acl:
+  - allow:
+    - read
+context:
+  application: rundeck
+'''
+
+        when:
+        int code
+        String contentType
+        Map json
+        try (def resp = client.doPost(
+                "/system/acl/${aclPath}",
+                yamlBody,
+                'application/yaml',
+                Headers.of('Accept', 'application/json')
+        )) {
+            code = resp.code()
+            contentType = resp.header('Content-Type')
+            json = client.jsonValue(resp.body(), Map)
+        }
+
+        then:
+        code == 201
+        contentType != null
+        contentType.contains('application/json')
+        json.contents.contains('Run4790Group')
+
+        cleanup:
+        deleteSystemAcl(aclPath)
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/acl/SystemAclCreateSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/acl/SystemAclCreateSpec.groovy
@@ -27,7 +27,7 @@ context:
 '''
 
         when:
-        int code
+        Integer code
         String contentType
         Map json
         try (def resp = client.doPost(

--- a/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
@@ -987,12 +987,10 @@ class ApiService implements WebUtilService{
 
     @Override
     String extractResponseFormat(HttpServletRequest request, HttpServletResponse response, List<String> allowed, String defformat) {
-        def requestFormat = request.format
-        if (allowed && requestFormat && allowed.contains(requestFormat)) {
-            return requestFormat
-        }
-        
-        // Grails 7: request.format might not be set from Accept header, check it explicitly.
+        // Accept header takes precedence: content negotiation should honor what the client asked
+        // to receive, independent of the format of the request body it sent. Checking request.format
+        // first (RUN-4790) meant a YAML-bodied request with Accept: application/json was answered
+        // with raw YAML, since 'yaml' matched request.format before the Accept header was consulted.
         // HTTP media types are case-insensitive (RFC 7231), so normalize before matching.
         String acceptHeader = request.getHeader('Accept')?.toLowerCase()
         if (acceptHeader && allowed) {
@@ -1010,7 +1008,12 @@ class ApiService implements WebUtilService{
                 return 'text'
             }
         }
-        
+
+        def requestFormat = request.format
+        if (allowed && requestFormat && allowed.contains(requestFormat)) {
+            return requestFormat
+        }
+
         if (defformat) {
             return defformat
         }

--- a/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
@@ -112,6 +112,13 @@ class ApiServiceSpec extends Specification implements ServiceUnitTest<ApiService
         'application/xml'            | 'all'     | 'xml'
         'text/plain'                 | 'all'     | 'text'
         'yaml'                       | 'yaml'    | 'yaml'
+        'application/json'           | 'yaml'    | 'json'
+        'application/json'           | 'xml'     | 'json'
+        // RUN-4790 non-regression: when Accept doesn't resolve to an allowed format,
+        // request.format (the body's own content type) must still decide the response format.
+        '*/*'                        | 'yaml'    | 'yaml'
+        null                         | 'yaml'    | 'yaml'
+        'text/html'                  | 'yaml'    | 'yaml'
     }
 
     def "jsonRenderDirlist"(){

--- a/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
@@ -121,6 +121,29 @@ class ApiServiceSpec extends Specification implements ServiceUnitTest<ApiService
         'text/html'                  | 'yaml'    | 'yaml'
     }
 
+    @Unroll
+    def "extractResponseFormat with a fixed defformat distinct from request.format ('#reqFormat' vs defformat '#defformat')"(){
+        // PR #10537 review follow-up: some callers (e.g. ProjectController#apiProjectConfigGet) pass a
+        // fixed literal defformat rather than request.format itself. This pins down that the
+        // requestFormat-vs-allowed check still matters for that caller shape: when Accept doesn't
+        // resolve, request.format 'xml' (in allowed) must win over the fixed defformat 'json', while a
+        // request.format outside allowed correctly falls through to the fixed defformat.
+        given:
+        def request = GroovyMock(HttpServletRequest)
+        request.format >> reqFormat
+        request.getHeader('Accept') >> null
+        def response = Mock(HttpServletResponse)
+        def allowed = ['json', 'text', 'xml']
+
+        expect:
+        service.extractResponseFormat(request, response, allowed, defformat) == expected
+
+        where:
+        reqFormat | defformat | expected
+        'xml'     | 'json'    | 'xml'
+        'bogus'   | 'json'    | 'json'
+    }
+
     def "jsonRenderDirlist"(){
         when:
         // Grails 7: Service returns Map directly, no need for JSONBuilder


### PR DESCRIPTION
## Release Notes

Fixed a regression where creating system ACL policies via the API or `rd` CLI with a YAML request body and a JSON Accept header could fail with a parse error even though the ACL was created successfully. The server now returns JSON when requested via the Accept header instead of defaulting to the request body's content type.

## PR Details

## Jira Ticket
[RUN-4790](https://pagerduty.atlassian.net/browse/RUN-4790)

## Summary
`rd system acls create` uploads a YAML `aclpolicy` body and requests a JSON response
(`Accept: application/json`). `ApiService.extractResponseFormat()` checked the
request's own `Content-Type`-derived format (`request.format`) *before* checking the
`Accept` header, so the server answered with raw YAML instead of the expected
`{"contents": "..."}` JSON body. The CLI then threw
`JsonParseException: Unrecognized token 'by'` trying to parse that YAML as JSON —
even though the ACL was created successfully server-side.

- Reordered `extractResponseFormat` so the `Accept` header is resolved first, falling
  back to `request.format`/`defformat` only when `Accept` doesn't map to an allowed
  format.
- Added unit test coverage in `ApiServiceSpec.groovy` for the conflicting-format case
  (YAML body + JSON Accept) plus non-regression rows confirming the fallback still
  works when `Accept` is absent or unrecognized.
- Added a functional test (`SystemAclCreateSpec`) exercising the system ACL create
  endpoint with a YAML body and `Accept: application/json`, asserting a JSON response.

This is a server-only fix; no `rd-cli-tool`/`rd-api-client` changes are needed since the
client's existing JSON parsing is correct once the server response is fixed.

## Testing
- `./gradlew test --tests "rundeck.services.ApiServiceSpec"` — pass
- `./gradlew test --tests "rundeck.controllers.FrameworkControllerSpec" --tests "rundeck.controllers.ProjectControllerSpec" --tests "rundeck.controllers.ProjectController2Spec"` — pass (these mock `extractResponseFormat`, confirming no regression)
- New functional spec compiles; requires a running rundeck instance to execute end-to-end

[RUN-4790]: https://pagerduty.atlassian.net/browse/RUN-4790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
