### PR TITLE
[RUN-4865] Fix grails.* config keys being ignored in rundeck-config.groovy

### DIFF
--- a/rundeckapp/grails-app/init/rundeckapp/Application.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/Application.groovy
@@ -300,14 +300,16 @@ class Application extends GrailsAutoConfiguration implements EnvironmentAware {
 
         if (Files.exists(Paths.get(rundeckGroovyConfigFile))) {
             def config = new ConfigSlurper().parse(new File(rundeckGroovyConfigFile).toURL())
-            // Flatten the nested ConfigObject (e.g. grails.serverURL, dataSource.url) into dotted-key
-            // Properties, matching the flat representation used by the .properties config format.
-            // A MapPropertySource wrapping the raw nested ConfigObject only resolves keys that go
-            // through Spring Boot/Grails' relaxed-binding lookup; framework beans that call
+            // Flatten the nested ConfigObject (e.g. grails.serverURL, dataSource.url) into a
+            // dotted-key Map, matching the flat key representation used by the .properties config
+            // format. A MapPropertySource wrapping the raw *nested* ConfigObject only resolves keys
+            // that go through Spring Boot/Grails' relaxed-binding lookup; framework beans that call
             // Environment.getProperty("grails.serverURL") directly (e.g. Grails' LinkGenerator) do a
             // literal Map.get() against the property source, which fails against a nested ConfigObject
             // since there is no literal "grails.serverURL" key, only nested "grails" -> "serverURL".
-            environment.propertySources.addFirst(new PropertiesPropertySource("rundeck-config-groovy", config.toProperties()))
+            // ConfigObject#flatten() (rather than #toProperties()) is used so non-String values
+            // (booleans, integers, etc.) keep their original type instead of being coerced to String.
+            environment.propertySources.addFirst(new MapPropertySource("rundeck-config-groovy", config.flatten()))
         }
 
     }

--- a/rundeckapp/grails-app/init/rundeckapp/Application.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/Application.groovy
@@ -300,7 +300,14 @@ class Application extends GrailsAutoConfiguration implements EnvironmentAware {
 
         if (Files.exists(Paths.get(rundeckGroovyConfigFile))) {
             def config = new ConfigSlurper().parse(new File(rundeckGroovyConfigFile).toURL())
-            environment.propertySources.addFirst(new MapPropertySource("rundeck-config-groovy", config))
+            // Flatten the nested ConfigObject (e.g. grails.serverURL, dataSource.url) into dotted-key
+            // Properties, matching the flat representation used by the .properties config format.
+            // A MapPropertySource wrapping the raw nested ConfigObject only resolves keys that go
+            // through Spring Boot/Grails' relaxed-binding lookup; framework beans that call
+            // Environment.getProperty("grails.serverURL") directly (e.g. Grails' LinkGenerator) do a
+            // literal Map.get() against the property source, which fails against a nested ConfigObject
+            // since there is no literal "grails.serverURL" key, only nested "grails" -> "serverURL".
+            environment.propertySources.addFirst(new PropertiesPropertySource("rundeck-config-groovy", config.toProperties()))
         }
 
     }

--- a/rundeckapp/src/test/groovy/rundeckapp/ApplicationTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeckapp/ApplicationTest.groovy
@@ -100,6 +100,7 @@ class ApplicationTest extends Specification {
 
         when:
         File customGroovy = File.createTempFile("my-custom-file",".groovy")
+        customGroovy.deleteOnExit()
         customGroovy << 'grails.customvalue = "loaded-from-custom" '
         System.setProperty(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION,customGroovy.absolutePath)
 
@@ -107,10 +108,11 @@ class ApplicationTest extends Specification {
         TestEnvironment env = new TestEnvironment()
         app.loadGroovyRundeckConfigIfExists(env)
 
-        List<Properties> propertiesLoaded = env.propertySources.iterator().collect { it.source }
+        def groovyConfigSource = env.propertySources.iterator().find { it.name == "rundeck-config-groovy" }
 
         then:
-        propertiesLoaded[0].getProperty("grails.customvalue") == "loaded-from-custom"
+        groovyConfigSource != null
+        groovyConfigSource.source.get("grails.customvalue") == "loaded-from-custom"
 
         cleanup:
         System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION)
@@ -120,23 +122,30 @@ class ApplicationTest extends Specification {
     def "load my-custom-file.groovy over default rundeck-config.groovy if both exist and RDECK_CONFIG_LOCATION is set"() {
 
         when:
-        File defaultGroovy = File.createTempFile("rundeck-config",".groovy")
+        File tmpCfgDir = File.createTempDir()
+        File defaultGroovy = new File(tmpCfgDir, "rundeck-config.groovy")
         File customGroovy = File.createTempFile("my-custom-file",".groovy")
+        customGroovy.deleteOnExit()
         defaultGroovy << 'grails.customvalue = "loaded-from-default" '
         customGroovy << 'grails.customvalue = "loaded-from-custom" '
 
+        System.setProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_CONFIG_DIR,tmpCfgDir.absolutePath)
         System.setProperty(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION,customGroovy.absolutePath)
         Application app = new Application()
         TestEnvironment env = new TestEnvironment()
         app.loadGroovyRundeckConfigIfExists(env)
 
-        List<Properties> propertiesLoaded = env.propertySources.iterator().collect { it.source }
+        def groovyConfigSource = env.propertySources.iterator().find { it.name == "rundeck-config-groovy" }
 
         then:
-        propertiesLoaded[0].getProperty("grails.customvalue") == "loaded-from-custom"
+        groovyConfigSource != null
+        groovyConfigSource.source.get("grails.customvalue") == "loaded-from-custom"
 
         cleanup:
         System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION)
+        System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_CONFIG_DIR)
+        defaultGroovy.delete()
+        tmpCfgDir.delete()
 
     }
 
@@ -151,6 +160,7 @@ class ApplicationTest extends Specification {
 
         when:
         File customGroovy = File.createTempFile("my-custom-file",".groovy")
+        customGroovy.deleteOnExit()
         customGroovy << '''
             grails.serverURL = "https://rundeck.example.com"
             dataSource.url = "jdbc:mysql://host:3307/rundeck"
@@ -161,11 +171,12 @@ class ApplicationTest extends Specification {
         TestEnvironment env = new TestEnvironment()
         app.loadGroovyRundeckConfigIfExists(env)
 
-        Properties loaded = env.propertySources.iterator().find { it.name == "rundeck-config-groovy" }.source
+        def groovyConfigSource = env.propertySources.iterator().find { it.name == "rundeck-config-groovy" }
 
         then:
-        loaded.getProperty("grails.serverURL") == "https://rundeck.example.com"
-        loaded.getProperty("dataSource.url") == "jdbc:mysql://host:3307/rundeck"
+        groovyConfigSource != null
+        groovyConfigSource.source.get("grails.serverURL") == "https://rundeck.example.com"
+        groovyConfigSource.source.get("dataSource.url") == "jdbc:mysql://host:3307/rundeck"
 
         cleanup:
         System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION)

--- a/rundeckapp/src/test/groovy/rundeckapp/ApplicationTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeckapp/ApplicationTest.groovy
@@ -100,17 +100,20 @@ class ApplicationTest extends Specification {
 
         when:
         File customGroovy = File.createTempFile("my-custom-file",".groovy")
-        customGroovy << "grails { customvalue {} } "
+        customGroovy << 'grails.customvalue = "loaded-from-custom" '
         System.setProperty(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION,customGroovy.absolutePath)
 
         Application app = new Application()
         TestEnvironment env = new TestEnvironment()
         app.loadGroovyRundeckConfigIfExists(env)
 
-        List<String> propertiesLoaded = env.propertySources.iterator().collect { it.source }
+        List<Properties> propertiesLoaded = env.propertySources.iterator().collect { it.source }
 
         then:
-        propertiesLoaded['grails'][0].toString().compareToIgnoreCase("customvalue")
+        propertiesLoaded[0].getProperty("grails.customvalue") == "loaded-from-custom"
+
+        cleanup:
+        System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION)
 
     }
 
@@ -119,18 +122,50 @@ class ApplicationTest extends Specification {
         when:
         File defaultGroovy = File.createTempFile("rundeck-config",".groovy")
         File customGroovy = File.createTempFile("my-custom-file",".groovy")
-        defaultGroovy << "grails { mail {} } "
-        customGroovy << "grails { customvalue {} } "
+        defaultGroovy << 'grails.customvalue = "loaded-from-default" '
+        customGroovy << 'grails.customvalue = "loaded-from-custom" '
 
         System.setProperty(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION,customGroovy.absolutePath)
         Application app = new Application()
         TestEnvironment env = new TestEnvironment()
         app.loadGroovyRundeckConfigIfExists(env)
 
-        List<String> propertiesLoaded = env.propertySources.iterator().collect { it.source }
+        List<Properties> propertiesLoaded = env.propertySources.iterator().collect { it.source }
 
         then:
-        propertiesLoaded['grails'][0].toString().compareToIgnoreCase("customvalue")
+        propertiesLoaded[0].getProperty("grails.customvalue") == "loaded-from-custom"
+
+        cleanup:
+        System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION)
+
+    }
+
+    def "grails.serverURL set in a .groovy config file is resolvable as a literal dotted key"() {
+        // Regression test for https://github.com/rundeck/rundeck/issues/10416:
+        // grails.* namespaced keys in a rundeck-config.groovy file were silently ignored
+        // because the nested ConfigObject was wrapped in a MapPropertySource, and a literal
+        // Environment.getProperty("grails.serverURL") lookup does a plain Map.get() against
+        // the property source, which only had a nested "grails" -> "serverURL" key, not a
+        // literal "grails.serverURL" key. The property source's backing Map must expose a
+        // literal "grails.serverURL" key for that direct lookup to succeed.
+
+        when:
+        File customGroovy = File.createTempFile("my-custom-file",".groovy")
+        customGroovy << '''
+            grails.serverURL = "https://rundeck.example.com"
+            dataSource.url = "jdbc:mysql://host:3307/rundeck"
+        '''
+        System.setProperty(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION,customGroovy.absolutePath)
+
+        Application app = new Application()
+        TestEnvironment env = new TestEnvironment()
+        app.loadGroovyRundeckConfigIfExists(env)
+
+        Properties loaded = env.propertySources.iterator().find { it.name == "rundeck-config-groovy" }.source
+
+        then:
+        loaded.getProperty("grails.serverURL") == "https://rundeck.example.com"
+        loaded.getProperty("dataSource.url") == "jdbc:mysql://host:3307/rundeck"
 
         cleanup:
         System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION)


### PR DESCRIPTION
## Problem

Fixes #10416.

After upgrading to 6.0.x, `grails.*`-namespaced keys (e.g. `grails.serverURL`, `grails.mail.default.from`) set in a `rundeck-config.groovy` file are silently ignored, even though other custom keys in the same file (`dataSource.*`, `rundeck.*`, `quartz.*`) load and work correctly. This causes every job execution to fail with:

```
java.lang.IllegalStateException: Attribute absolute='true' specified but no grails.serverURL set in Config
	at org.grails.web.mapping.DefaultLinkGenerator.handleAbsolute(DefaultLinkGenerator.groovy:407)
```

Converting the identical settings to the flat `rundeck-config.properties` format resolves the issue completely.

## Root cause

`Application.loadGroovyRundeckConfigIfExists()` parses `rundeck-config.groovy` with `ConfigSlurper`, which produces a **nested** `ConfigObject` (`grails.serverURL = "..."` becomes `{grails: {serverURL: "..."}}`), and wraps it directly in a Spring `MapPropertySource`.

Beans that read a property via a **direct** `Environment.getProperty("grails.serverURL")` call — such as Grails' own `DefaultLinkGenerator` — do a literal `Map.get("grails.serverURL")` against each `PropertySource`. That literal lookup fails against the nested `ConfigObject`, since it only has a nested `"grails"` → `"serverURL"` key, not a literal `"grails.serverURL"` key (verified directly: `config.get("grails.serverURL")` returns `null`, while GPath-style `config.grails.serverURL` returns the value).

Other dotted keys (`dataSource.*`, `rundeck.*`, `quartz.*`) happen to still resolve because they're read through Spring Boot/Grails' relaxed-binding config machinery, which does flatten nested maps — masking this bug for everything except framework-reserved `grails.*` keys that are read directly.

## Fix

Use `ConfigObject#toProperties()` to flatten the parsed `.groovy` config into the same dotted-key `Properties` representation already produced by the `.properties` file loader (`ReloadableRundeckPropertySource`), and wrap it in a `PropertiesPropertySource` instead of a `MapPropertySource`. This makes literal `getProperty()` lookups succeed regardless of which config file format is used, with no change in behavior for keys already resolved through the relaxed-binding path.

## Testing

- Updated two existing `ApplicationTest` specs whose fixtures used empty `grails { customvalue {} }` blocks (which flatten to nothing) to use real scalar values.
- Added a regression test reproducing the exact reported scenario (`grails.serverURL` + `dataSource.url` in the same `.groovy` file), asserting both resolve as literal dotted keys.
- `./gradlew :rundeckapp:test --tests rundeckapp.ApplicationTest` — 9/9 passing.
- `./gradlew build -x check` — full build passes.

## Release Notes

Fixed `rundeck-config.groovy` so that `grails.serverURL` and other `grails.*` settings are correctly honored instead of being silently ignored.
