### PR TITLE
[RUN-4866] Don't persist STATIC_TEXT plugin properties into saved job config

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginConfig.vue
@@ -457,7 +457,12 @@ export default defineComponent({
         if (config[prop.name]) {
           this.inputValues[prop.name] = config[prop.name];
         }
-        if (modeCreate && !this.inputValues[prop.name] && prop.defaultValue) {
+        if (
+          modeCreate &&
+          !this.isStaticTextProp(prop) &&
+          !this.inputValues[prop.name] &&
+          prop.defaultValue
+        ) {
           this.inputValues[prop.name] = prop.defaultValue;
         }
         if (
@@ -506,6 +511,12 @@ export default defineComponent({
       const values: { [index: string]: any } = {};
       //convert true boolean to 'true'
       this.props.forEach((prop: any) => {
+        if (this.isStaticTextProp(prop)) {
+          // STATIC_TEXT properties are display-only help text (e.g. workflow strategy
+          // "info" panels) and must never be persisted as real config data.
+          // See https://github.com/rundeck/rundeck/issues/10420
+          return;
+        }
         if (prop.type === "Boolean") {
           if (
             this.inputValues[prop.name] === true ||
@@ -604,6 +615,14 @@ export default defineComponent({
     },
     isPropHidden(testProp: any): boolean {
       return testProp.options && testProp.options["displayType"] === "HIDDEN";
+    },
+    isStaticTextProp(testProp: any): boolean {
+      // STATIC_TEXT properties (e.g. the WorkflowStrategy "info" help table) are
+      // rendered from prop.staticTextDefaultValue and are never user-editable, so
+      // they must not be seeded with a default value or exported as config data.
+      return (
+        testProp.options && testProp.options["displayType"] === "STATIC_TEXT"
+      );
     },
     isPropInScope(testProp: any): boolean {
       // determine if property is visible in scope

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginConfig.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginConfig.spec.ts
@@ -397,6 +397,86 @@ describe("PluginConfig", () => {
     });
   });
 
+  describe("STATIC_TEXT props", () => {
+    // Regression tests for https://github.com/rundeck/rundeck/issues/10420:
+    // WorkflowStrategy's "info" property is a STATIC_TEXT/display-only help table
+    // (rendered from prop.staticTextDefaultValue, never user-editable). It was
+    // being seeded from prop.defaultValue in create mode and then persisted into
+    // the saved job config as literal HTML, polluting exported YAML and causing
+    // spurious SCM diffs.
+    it("does not seed a STATIC_TEXT prop with its default value in create mode", async () => {
+      const wrapper = await createWrapper({
+        props: {
+          mode: "create",
+          modelValue: { type: "test", config: {} },
+          pluginConfig: {
+            props: [
+              {
+                name: "info",
+                type: "String",
+                defaultValue: "<table><tr><td>1.</td></tr></table>",
+                options: { displayType: "STATIC_TEXT" },
+              },
+            ],
+          },
+        },
+      });
+
+      expect(wrapper.findComponent(PluginPropEdit).props("modelValue")).toBeFalsy();
+    });
+
+    it("never includes a STATIC_TEXT prop in the exported config payload", async () => {
+      const wrapper = await createWrapper({
+        props: {
+          mode: "create",
+          modelValue: { type: "test", config: {} },
+          pluginConfig: {
+            props: [
+              {
+                name: "info",
+                type: "String",
+                defaultValue: "<table><tr><td>1.</td></tr></table>",
+                options: { displayType: "STATIC_TEXT" },
+              },
+            ],
+          },
+        },
+      });
+
+      const emitted = wrapper.emitted("update:modelValue");
+      if (emitted) {
+        for (const call of emitted) {
+          expect((call[0] as any).config).not.toHaveProperty("info");
+        }
+      }
+    });
+
+    it("strips an already-persisted STATIC_TEXT value out of the exported config (self-heals legacy data)", async () => {
+      const wrapper = await createWrapper({
+        props: {
+          mode: "edit",
+          modelValue: {
+            type: "test",
+            config: { info: "<table><tr><td>1.</td></tr></table>" },
+          },
+          pluginConfig: {
+            props: [
+              { name: "info", type: "String", options: { displayType: "STATIC_TEXT" } },
+              { name: "host", type: "String", options: {} },
+            ],
+          },
+        },
+      });
+
+      // trigger the exportInputs/update:modelValue path via an edit to an unrelated field
+      await wrapper.findAllComponents(PluginPropEdit)[1].vm.$emit("update:modelValue", "localhost");
+      await wrapper.vm.$nextTick();
+
+      const emitted = wrapper.emitted("update:modelValue")!;
+      expect((emitted[emitted.length - 1][0] as any).config).not.toHaveProperty("info");
+    });
+  });
+
   describe("boolean export", () => {
     it("emits the string 'true' in the config payload when a Boolean field is set to true", async () => {
       const wrapper = await createWrapper({


### PR DESCRIPTION
## Problem

Fixes #10420.

`WorkflowStrategy`'s `node-first` provider has an `info` property that's a `STATIC_TEXT` display-only help table (a hardcoded HTML `<table>`, rendered from `prop.staticTextDefaultValue`, never user-editable — see [`NodeFirstWorkflowStrategy.java`](https://github.com/rundeck/rundeck/blob/main/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/NodeFirstWorkflowStrategy.java#L43)).

Editing and saving a job through the UI (including creating a new job, or duplicating an existing one) persists that raw HTML into `sequence.pluginConfig.WorkflowStrategy.node-first.info` in the job's config. This:
- Shows up as literal `<table>...` markup in the read-only "show"/Definition view.
- Gets written into exported YAML, causing spurious diffs for anyone using Git SCM export/import — jobs imported from YAML and never edited in the UI don't have it; the moment they're opened and saved in the UI, it appears.

## Root cause

`pluginConfig.vue`'s `prepareInputs()`/`exportInputs()` treat every plugin property the same way: `prepareInputs()` seeds any property's `defaultValue` into the form's `inputValues` in create mode, and `exportInputs()` unconditionally writes every property back into the saved config. Neither has an exemption for `STATIC_TEXT` properties, which are purely descriptive and were never meant to be treated as real config data.

Separately, [`WorkflowStrategy.vue`](https://github.com/rundeck/rundeck/blob/main/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/WorkflowStrategy.vue)'s `model` watcher flips `mode` to `"create"` whenever it sees `newVal.type !== oldVal.type` — but `model` starts as `{}` in `data()` and only gets its real `type` assigned in `mounted()`, which the deep watcher sees as a "type change" from `undefined` on *every single mount*. So opening the job editor at all (not just genuinely creating a new job) transiently exercises the create-mode defaulting path for this sub-form.

## Fix

Rather than touch the `mode`-detection quirk (which affects more than just this one field and carries more risk), this excludes `STATIC_TEXT` properties from both `prepareInputs()`'s default-seeding and `exportInputs()`'s export, via a new `isStaticTextProp()` helper mirroring the existing `isPropHidden()` pattern. This:
- Stops new pollution going forward, regardless of the `mode`-detection quirk.
- **Self-heals** already-affected jobs — saving them again now strips the bogus `info` key out of `config` instead of carrying it forward.
- Makes the raw-HTML display in the "show" view moot too, since there's no persisted value left to render.

## Testing

Added 3 regression tests to `pluginConfig.spec.ts`:
- STATIC_TEXT props are never seeded with a default value in create mode.
- STATIC_TEXT props are never included in the exported config payload.
- An already-persisted STATIC_TEXT value is stripped out of the exported config on the next save (self-heals legacy data).

`npx jest pluginConfig.spec.ts` — 33/33 passing. `npx eslint` on both changed files — 0 errors, no new warnings.

## Release Notes

Fixed the Workflow Strategy configuration so its descriptive help text is no longer saved into the job definition and exported YAML as raw HTML.  This will not fix existing jobs, but opening and resaving the job manually will fix the issue.
