### PR TITLE
[RUN-4764] Fix dynamic form and select value handling

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
@@ -62,6 +62,12 @@ const messages = {
   message_description: "Description",
   message_fieldLabel: "Field Label",
   message_fieldKey: "Field Key",
+  // Descriptions generated for a custom field. The wording differs between
+  // these three on purpose: it reproduces the text these fields have always
+  // shown, so existing configurations read the same as before.
+  message_fieldKeyDescription: "Field key: {0}",
+  message_fieldKeyOnlyDescription: "Field key {0}",
+  message_fieldKeyAppendedDescription: "{0} (Field key: {1})",
   message_fieldFilter: "Type to filter a field",
   message_empty: "Can be empty",
   message_cancel: "Cancel",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/DynamicFormPluginProp.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/DynamicFormPluginProp.vue
@@ -257,6 +257,9 @@ export default defineComponent({
   methods: {
     syncFieldsFromProp(fields: string) {
       if (fields == null || fields === "") {
+        // Clearing the prop must clear the list too, otherwise the previous
+        // fields stay on screen after the parent resets the value.
+        this.customFields = [];
         return;
       }
       const customFieldsObject = JSON.parse(fields);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/DynamicFormPluginProp.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/DynamicFormPluginProp.vue
@@ -1,5 +1,6 @@
 <template>
   <div id="fieldcustomeditor" class="col-sm-12">
+    <input ref="hiddenFieldInput" type="hidden" :name="name" />
     <hr />
 
     <div v-if="customFields != null">
@@ -74,15 +75,21 @@
             <div :class="['form-data']">
               <label class="col-md-4">{{ $t("message_select") }}</label>
               <div class="col-md-8">
-                <vue-multiselect
+                <!--
+                  append-to="self" keeps the dropdown overlay inside this
+                  modal's stacking context. The default ("body") renders it at
+                  z-index 1001, below the surrounding modal (1070), which makes
+                  the options render but stay unclickable.
+                -->
+                <pt-select
                   v-model="selectedField"
                   :options="customOptions"
-                  track-by="label"
-                  label="label"
+                  option-label="label"
+                  :filter="true"
                   :placeholder="$t('message_select')"
+                  append-to="self"
                   data-testid="multiselect"
-                >
-                </vue-multiselect>
+                />
               </div>
             </div>
 
@@ -108,6 +115,7 @@
                   v-model="newLabelField"
                   type="text"
                   :class="['form-control']"
+                  data-testid="field-label-input"
                 />
               </div>
             </div>
@@ -165,9 +173,9 @@
 </template>
 
 <script lang="ts">
-import VueMultiselect from "vue-multiselect";
 import { defineComponent } from "vue";
 import { Btn, Alert, Modal } from "uiv";
+import PtSelect from "../primeVue/PtSelect/PtSelect.vue";
 
 interface CustomField {
   key?: string;
@@ -179,7 +187,7 @@ interface CustomField {
 export default defineComponent({
   name: "DynamicFormPluginProp",
   components: {
-    VueMultiselect,
+    PtSelect,
     Btn,
     Alert,
     Modal,
@@ -192,10 +200,6 @@ export default defineComponent({
     options: {
       type: String,
       required: false,
-    },
-    element: {
-      type: String,
-      required: true,
     },
     hasOptions: {
       type: String,
@@ -220,23 +224,23 @@ export default defineComponent({
       selectedField: { value: "", label: "" },
     };
   },
+  watch: {
+    fields(newFields: string) {
+      // Keep local state in sync if the prop changes after mount (e.g. the
+      // parent round-trips the value through its own v-model chain). Skip
+      // when the incoming value already matches what we just emitted
+      // ourselves, to avoid fighting with in-flight edits.
+      if (newFields === JSON.stringify(this.customFields)) {
+        return;
+      }
+      this.syncFieldsFromProp(newFields);
+    },
+  },
   mounted() {
     if (this.hasOptions === "true") {
       this.useOptions = true;
     }
-    if (this.fields != null && this.fields !== "") {
-      const customFieldsObject = JSON.parse(this.fields);
-      if (customFieldsObject != null) {
-        const fields = Object.keys(customFieldsObject).map((key: any) => {
-          const value = customFieldsObject[key];
-          if (value.desc == null) {
-            value.desc = "Field key: " + value.key;
-          }
-          return value;
-        });
-        this.customFields = fields;
-      }
-    }
+    this.syncFieldsFromProp(this.fields);
 
     if (this.useOptions && this.options !== null && this.options !== undefined && this.options !== "") {
       const optionsObject = JSON.parse(this.options!);
@@ -251,6 +255,22 @@ export default defineComponent({
     this.customFields = null as any;
   },
   methods: {
+    syncFieldsFromProp(fields: string) {
+      if (fields == null || fields === "") {
+        return;
+      }
+      const customFieldsObject = JSON.parse(fields);
+      if (customFieldsObject != null) {
+        const parsedFields = Object.keys(customFieldsObject).map((key: any) => {
+          const value = customFieldsObject[key];
+          if (value.desc == null) {
+            value.desc = "Field key: " + value.key;
+          }
+          return value;
+        });
+        this.customFields = parsedFields;
+      }
+    },
     openNewField() {
       this.modalAddField = true;
     },
@@ -323,15 +343,15 @@ export default defineComponent({
     },
     refreshPlugin() {
       const fieldsJson = JSON.stringify(this.customFields);
-      const cFields = document.getElementById(this.element) as HTMLInputElement;
-      cFields.value = fieldsJson;
+      const hiddenFieldInput = this.$refs.hiddenFieldInput as HTMLInputElement;
+      if (hiddenFieldInput) {
+        hiddenFieldInput.value = fieldsJson;
+      }
       this.$emit("update:modelValue", fieldsJson);
     },
   },
 });
 </script>
-<style scoped src="vue-multiselect/dist/vue-multiselect.min.css"></style>
-
 <style scoped>
 .form-data {
   padding-bottom: 30px;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/DynamicFormPluginProp.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/DynamicFormPluginProp.vue
@@ -267,7 +267,7 @@ export default defineComponent({
         const parsedFields = Object.keys(customFieldsObject).map((key: any) => {
           const value = customFieldsObject[key];
           if (value.desc == null) {
-            value.desc = "Field key: " + value.key;
+            value.desc = this.$t("message_fieldKeyDescription", [value.key]);
           }
           return value;
         });
@@ -287,9 +287,14 @@ export default defineComponent({
 
           let description = this.newFieldDescription;
           if (description == "") {
-            description = "Field key " + newField.value;
+            description = this.$t("message_fieldKeyOnlyDescription", [
+              newField.value,
+            ]);
           } else {
-            description = description + " (Field key: " + newField.value + ")";
+            description = this.$t("message_fieldKeyAppendedDescription", [
+              description,
+              newField.value,
+            ]);
           }
 
           field = {
@@ -301,9 +306,14 @@ export default defineComponent({
       } else {
         let description = this.newFieldDescription;
         if (description == "") {
-          description = "Field key " + this.newField;
+          description = this.$t("message_fieldKeyOnlyDescription", [
+            this.newField,
+          ]);
         } else {
-          description = description + " (Field key: " + this.newField + ")";
+          description = this.$t("message_fieldKeyAppendedDescription", [
+            description,
+            this.newField,
+          ]);
         }
 
         field = {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginConfig.vue
@@ -545,7 +545,23 @@ export default defineComponent({
 
       this.props.forEach((prop: any) => {
         if (data.dynamicProps && data.dynamicProps[prop.name]) {
-          prop.allowed = data.dynamicProps[prop.name];
+          const dynamic = data.dynamicProps[prop.name];
+          if (
+            dynamic &&
+            typeof dynamic === "object" &&
+            !Array.isArray(dynamic)
+          ) {
+            // Dynamic values can arrive as a { value: label } map, e.g.
+            // ServiceNow urgency { "1": "1 - High" }. Keep the map as
+            // selectLabels (what pluginPropVal renders) and expose only the
+            // keys as allowed values, otherwise iterating the object yields
+            // the labels and the submitted value becomes "1 - High" instead
+            // of "1".
+            prop.selectLabels = dynamic;
+            prop.allowed = Object.keys(dynamic);
+          } else {
+            prop.allowed = dynamic;
+          }
         }
         if (data.dynamicDefaults && data.dynamicDefaults[prop.name]) {
           prop.defaultValue = data.dynamicDefaults[prop.name];

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginConfig.vue
@@ -546,22 +546,26 @@ export default defineComponent({
       this.props.forEach((prop: any) => {
         if (data.dynamicProps && data.dynamicProps[prop.name]) {
           const dynamic = data.dynamicProps[prop.name];
-          if (
-            dynamic &&
-            typeof dynamic === "object" &&
-            !Array.isArray(dynamic)
-          ) {
-            // Dynamic values can arrive as a { value: label } map, e.g.
-            // ServiceNow urgency { "1": "1 - High" }. Keep the map as
-            // selectLabels (what pluginPropVal renders) and expose only the
-            // keys as allowed values, otherwise iterating the object yields
-            // the labels and the submitted value becomes "1 - High" instead
-            // of "1".
-            prop.selectLabels = dynamic;
-            prop.allowed = Object.keys(dynamic);
-          } else {
-            prop.allowed = dynamic;
+          const isValueLabelMap =
+            typeof dynamic === "object" && !Array.isArray(dynamic);
+
+          // Remember the labels the descriptor itself supplied. loadPluginData
+          // can run more than once over the same prop object, so labels
+          // derived from an earlier map must not survive into a later
+          // list-shaped load, and the descriptor's own labels must not be lost.
+          if (prop.descriptorSelectLabels === undefined) {
+            prop.descriptorSelectLabels = prop.selectLabels || null;
           }
+
+          // A map arrives as { value: label }, e.g. ServiceNow urgency
+          // { "1": "1 - High" }. Iterating an object with v-for yields the
+          // labels, so the rendered option value would become "1 - High"
+          // instead of "1"; keep the map as the labels pluginPropVal renders
+          // and expose only the keys as the allowed values.
+          prop.selectLabels = isValueLabelMap
+            ? dynamic
+            : prop.descriptorSelectLabels || undefined;
+          prop.allowed = isValueLabelMap ? Object.keys(dynamic) : dynamic;
         }
         if (data.dynamicDefaults && data.dynamicDefaults[prop.name]) {
           prop.defaultValue = data.dynamicDefaults[prop.name];

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropEdit.vue
@@ -63,15 +63,11 @@
     <template
       v-else-if="prop.options && prop.options['displayType'] === 'DYNAMIC_FORM'"
     >
-      <input :id="rkey" type="hidden" :name="prop.name" />
-
       <dynamic-form-plugin-prop
-        :id="rkey"
         v-model="currentValue"
         :fields="modelValue"
         :has-options="hasAllowedValues()"
         :options="parseAllowedValues()"
-        :element="rkey"
         :name="prop.name"
       ></dynamic-form-plugin-prop>
     </template>
@@ -450,6 +446,10 @@ interface Prop {
   required: boolean;
   options: any;
   allowed: string;
+  // Optional { value: label } map supplied when a plugin provides dynamic
+  // values as a map; pluginConfig keeps it here while `allowed` holds the
+  // keys. Rendered by pluginPropVal.
+  selectLabels?: Record<string, string>;
   name: string;
   desc: string;
   staticTextDefaultValue: string;
@@ -679,6 +679,12 @@ export default defineComponent({
       }
     },
     parseAllowedValues() {
+      // DYNAMIC_FORM consumers expect the original { value: label } map,
+      // which pluginConfig keeps in selectLabels when the plugin supplies
+      // dynamic values as a map rather than a plain list.
+      if (this.prop.selectLabels) {
+        return JSON.stringify(this.prop.selectLabels);
+      }
       return JSON.stringify(this.prop.allowed);
     },
     handleUpdate(val: any) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropView.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropView.vue
@@ -212,6 +212,11 @@ export default defineComponent({
       innerValue: this.value as string,
     };
   },
+  watch: {
+    value(newValue: string) {
+      this.innerValue = newValue;
+    },
+  },
   methods: {
     getCustomValues(): any[] {
       if (this.innerValue !== "") {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropView.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropView.vue
@@ -213,8 +213,10 @@ export default defineComponent({
     };
   },
   watch: {
-    value(newValue: string) {
-      this.innerValue = newValue;
+    value(newValue: boolean | string) {
+      // Mirrors the cast in data(): the prop accepts a boolean, but every
+      // consumer of innerValue treats it as a string.
+      this.innerValue = newValue as string;
     },
   },
   methods: {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/DynamicFormPluginProp.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/DynamicFormPluginProp.spec.ts
@@ -1,11 +1,7 @@
 import { mount, flushPromises, VueWrapper } from "@vue/test-utils";
 import DynamicFormPluginProp from "../DynamicFormPluginProp.vue";
 import { Btn, Modal, Alert } from "uiv";
-import VueMultiselect from "vue-multiselect";
-
-const mockElement = document.createElement("input");
-mockElement.id = "test-element";
-document.body.appendChild(mockElement);
+import PtSelect from "../../primeVue/PtSelect/PtSelect.vue";
 
 const createWrapper = (props = {}) => {
   return mount(DynamicFormPluginProp, {
@@ -19,7 +15,6 @@ const createWrapper = (props = {}) => {
         },
       }),
       options: JSON.stringify({ field1: ["option1", "option2"] }),
-      element: "test-element",
       hasOptions: "true",
       name: "test-name",
       ...props,
@@ -30,7 +25,7 @@ const createWrapper = (props = {}) => {
       };
     },
     global: {
-      components: { Btn, Modal, Alert, VueMultiselect },
+      components: { Btn, Modal, Alert, PtSelect },
       stubs: {
         Modal: {
           template: `<div data-testid="modal-title"><slot></slot><slot name="footer"></slot>Add Field</div>`,
@@ -39,9 +34,9 @@ const createWrapper = (props = {}) => {
         Alert: {
           template: `<div ref="duplicateWarningRef">Duplicate warning text</div>`,
         },
-        VueMultiselect: {
-          template: `<div data-testid="multiselect">Multiselect Stub</div>`,
-        },
+        // PtSelect is deliberately NOT stubbed: the previous vue-multiselect
+        // stub is what hid RUN-4764 (a render crash in the real select
+        // component) from this suite.
       },
     },
     attachTo: document.body,
@@ -63,7 +58,7 @@ describe("DynamicFormPluginProp.vue", () => {
     const wrapper = createWrapper();
     await wrapper.find('[data-testid="add-field-button"]').trigger("click");
     await flushPromises();
-    const multiselect = wrapper.findComponent(VueMultiselect);
+    const multiselect = wrapper.findComponent(PtSelect);
     await (multiselect as VueWrapper<any>).vm.$emit("update:modelValue", {
       value: "Option1",
       label: "Field 1",
@@ -104,7 +99,7 @@ describe("DynamicFormPluginProp.vue", () => {
     const addField = await wrapper.find('[data-testid="add-field-button"]');
     await addField.trigger("click");
     await wrapper.vm.$nextTick();
-    const multiselect = wrapper.findComponent(VueMultiselect);
+    const multiselect = wrapper.findComponent(PtSelect);
     await multiselect.vm.$emit("update:modelValue", {
       value: "field1",
       label: "Field 1",
@@ -128,5 +123,61 @@ describe("DynamicFormPluginProp.vue", () => {
     await flushPromises();
     const updatedFieldValue = (wrapper.vm as any).customFields[0].value;
     expect(updatedFieldValue).toBe("Updated Value");
+  });
+
+  describe("regression for RUN-4764", () => {
+    it("adds a field via the free-text Field Label/Field Key path without throwing", async () => {
+      // hasOptions "false" is the free-text path, used whenever the plugin
+      // supplies no allowed values. The tests above only covered the
+      // select path, so this branch was previously untested.
+      const wrapper = createWrapper({
+        hasOptions: "false",
+      });
+      await wrapper.find('[data-testid="add-field-button"]').trigger("click");
+      await flushPromises();
+
+      await wrapper
+        .find('[data-testid="field-label-input"]')
+        .setValue("Root Cause");
+      await wrapper
+        .find('[data-testid="field-key-input"]')
+        .setValue("u_root_cause");
+      await wrapper
+        .find('[data-testid="confirm-add-field-button"]')
+        .trigger("click");
+      await flushPromises();
+
+      const fields = wrapper.findAll('[data-testid="field-item"]');
+      expect(fields.length).toBe(2);
+      expect(fields.at(1)?.find("label")?.text()).toBe("Root Cause");
+    });
+
+    it("syncs the fields prop reactively when it changes after mount", async () => {
+      const wrapper = createWrapper();
+      await flushPromises();
+      expect(wrapper.findAll('[data-testid="field-item"]').length).toBe(1);
+
+      await wrapper.setProps({
+        fields: JSON.stringify({
+          field1: {
+            key: "field1",
+            label: "Option1",
+            value: "field1",
+            desc: "Description1",
+          },
+          field2: {
+            key: "field2",
+            label: "Option2",
+            value: "field2",
+            desc: "Description2",
+          },
+        }),
+      });
+      await flushPromises();
+
+      const fields = wrapper.findAll('[data-testid="field-item"]');
+      expect(fields.length).toBe(2);
+      expect(fields.at(1)?.find("label")?.text()).toBe("Option2");
+    });
   });
 });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/DynamicFormPluginProp.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/DynamicFormPluginProp.spec.ts
@@ -3,6 +3,20 @@ import DynamicFormPluginProp from "../DynamicFormPluginProp.vue";
 import { Btn, Modal, Alert } from "uiv";
 import PtSelect from "../../primeVue/PtSelect/PtSelect.vue";
 
+// The global $t mock returns the key and drops the arguments, which would
+// make the generated descriptions unverifiable. Interpolate the real en_US
+// templates instead so the assertions below still check the composed text.
+const messages: Record<string, string> = {
+  message_fieldKeyDescription: "Field key: {0}",
+  message_fieldKeyOnlyDescription: "Field key {0}",
+  message_fieldKeyAppendedDescription: "{0} (Field key: {1})",
+};
+const translate = (key: string, params: string[] = []) =>
+  (messages[key] ?? key).replace(
+    /\{(\d+)\}/g,
+    (_match, index) => params[Number(index)],
+  );
+
 const createWrapper = (props = {}) => {
   return mount(DynamicFormPluginProp, {
     props: {
@@ -25,6 +39,7 @@ const createWrapper = (props = {}) => {
       };
     },
     global: {
+      mocks: { $t: translate },
       components: { Btn, Modal, Alert, PtSelect },
       stubs: {
         Modal: {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/DynamicFormPluginProp.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/DynamicFormPluginProp.spec.ts
@@ -152,6 +152,17 @@ describe("DynamicFormPluginProp.vue", () => {
       expect(fields.at(1)?.find("label")?.text()).toBe("Root Cause");
     });
 
+    it("clears the list when the fields prop is emptied after mount", async () => {
+      const wrapper = createWrapper();
+      await flushPromises();
+      expect(wrapper.findAll('[data-testid="field-item"]').length).toBe(1);
+
+      await wrapper.setProps({ fields: "" });
+      await flushPromises();
+
+      expect(wrapper.findAll('[data-testid="field-item"]').length).toBe(0);
+    });
+
     it("syncs the fields prop reactively when it changes after mount", async () => {
       const wrapper = createWrapper();
       await flushPromises();

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginConfig.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginConfig.spec.ts
@@ -533,6 +533,50 @@ describe("PluginConfig", () => {
       expect(prop.selectLabels).toEqual({ "1": "1 - High", "3": "3 - Low" });
     });
 
+    it("drops map-derived labels when the same prop is reloaded with a list", async () => {
+      const wrapper = await createWrapper();
+      const props = [{ name: "urgency", type: "FreeSelect", options: {} }];
+
+      (wrapper.vm as any).loadPluginData({
+        props,
+        dynamicProps: { urgency: { "1": "1 - High" } },
+      });
+      await wrapper.vm.$nextTick();
+      expect(props[0]).toHaveProperty("selectLabels", { "1": "1 - High" });
+
+      // loadPluginData runs again over the very same prop objects when it is
+      // called with the pluginConfig prop.
+      (wrapper.vm as any).loadPluginData({
+        props,
+        dynamicProps: { urgency: ["High", "Low"] },
+      });
+      await wrapper.vm.$nextTick();
+
+      expect((props[0] as any).allowed).toEqual(["High", "Low"]);
+      expect((props[0] as any).selectLabels).toBeUndefined();
+    });
+
+    it("keeps labels the descriptor supplied when dynamic values are a list", async () => {
+      const wrapper = await createWrapper();
+      const descriptorLabels = { High: "Very high" };
+      const props = [
+        {
+          name: "urgency",
+          type: "FreeSelect",
+          options: {},
+          selectLabels: descriptorLabels,
+        },
+      ];
+
+      (wrapper.vm as any).loadPluginData({
+        props,
+        dynamicProps: { urgency: ["High", "Low"] },
+      });
+      await wrapper.vm.$nextTick();
+
+      expect((props[0] as any).selectLabels).toEqual(descriptorLabels);
+    });
+
     it("leaves list-style dynamic values untouched", async () => {
       const wrapper = await createWrapper();
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginConfig.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginConfig.spec.ts
@@ -515,4 +515,38 @@ describe("PluginConfig", () => {
       expect(wrapper.find('[data-testid="prop-field-host"]').classes()).not.toContain("has-error");
     });
   });
+
+  describe("dynamic select values — regression for RUN-4764", () => {
+    it("exposes map keys as allowed values so the submitted value is the code, not the label", async () => {
+      const wrapper = await createWrapper();
+
+      (wrapper.vm as any).loadPluginData({
+        props: [{ name: "urgency", type: "FreeSelect", options: {} }],
+        dynamicProps: { urgency: { "1": "1 - High", "3": "3 - Low" } },
+      });
+      await wrapper.vm.$nextTick();
+
+      const prop = (wrapper.vm as any).props.find(
+        (p: any) => p.name === "urgency",
+      );
+      expect(prop.allowed).toEqual(["1", "3"]);
+      expect(prop.selectLabels).toEqual({ "1": "1 - High", "3": "3 - Low" });
+    });
+
+    it("leaves list-style dynamic values untouched", async () => {
+      const wrapper = await createWrapper();
+
+      (wrapper.vm as any).loadPluginData({
+        props: [{ name: "assignmentGroup", type: "FreeSelect", options: {} }],
+        dynamicProps: { assignmentGroup: ["App Support", "Network Ops"] },
+      });
+      await wrapper.vm.$nextTick();
+
+      const prop = (wrapper.vm as any).props.find(
+        (p: any) => p.name === "assignmentGroup",
+      );
+      expect(prop.allowed).toEqual(["App Support", "Network Ops"]);
+      expect(prop.selectLabels).toBeUndefined();
+    });
+  });
 });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginPropView.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginPropView.spec.ts
@@ -462,6 +462,31 @@ describe("PluginPropView", () => {
 
       expect(wrapper.findAll('[data-testid="configpair"]')).toHaveLength(0);
     });
+
+    it("reflects a value prop change after mount — regression for RUN-4764", async () => {
+      const wrapper = await createWrapper({
+        props: {
+          prop: {
+            type: "String",
+            title: "Config",
+            desc: "Dynamic form",
+            options: { displayType: "DYNAMIC_FORM" },
+          },
+          value: "",
+        },
+      });
+      expect(wrapper.findAll('[data-testid="configpair"]')).toHaveLength(0);
+
+      await wrapper.setProps({
+        value: JSON.stringify([{ label: "Host", value: "localhost" }]),
+      });
+      await wrapper.vm.$nextTick();
+
+      const pairs = wrapper.findAll('[data-testid="configpair"]');
+      expect(pairs).toHaveLength(1);
+      expect(pairs[0].text()).toContain("Host:");
+      expect(pairs[0].text()).toContain("localhost");
+    });
   });
 
   describe("prop.desc undefined — regression for RUN-4521", () => {


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. Three defects in the shared plugin-config components made the ServiceNow "Create Incident" configuration unusable as soon as the instance returned dynamic values. They also affect every other plugin using a `DYNAMIC_FORM` property (RoiMetrics, Jira, PagerDuty) or dynamic select values.

**1. "Add Custom Field" crashed the editor**

`DynamicFormPluginProp` rendered `vue-multiselect`, a Vue 2 component whose precompiled bundle calls the Vue 2 `_self._c` render helper. Under Vue 3 that is `undefined`, so the modal threw `TypeError: Cannot read properties of undefined (reading '_c')` while mounting and never opened.

**2. Selecting a dynamic value submitted its label instead of its value**

Plugins can supply dynamic values as a `{ value: label }` map, e.g. `{ "1": "1 - High" }`. `pluginConfig` assigned that map straight to `prop.allowed`, and iterating an object with `v-for` yields the *values*, so the rendered `<option>` carried the label as its value. Urgency, Impact and Priority were stored and sent to ServiceNow as `"1 - High"` instead of `"1"`; ServiceNow does not recognise that as a choice value and falls back to its own defaults.

**3. Non-reactive props**

`DynamicFormPluginProp` (`fields`) and `pluginPropView` (`value`) both read their prop into local state once and never watched it, so later changes were ignored.

**Describe the solution you've implemented**

1. Replaced `vue-multiselect` with the `PtSelect` PrimeVue wrapper already present in the library layer. The overlay is rendered with `append-to="self"` so it shares the modal's stacking context — with the default (`body`) it renders at `z-index: 1001`, below the surrounding modal at `1070`, so options appeared but could not be clicked.
2. The dynamic map is now kept in `prop.selectLabels`, which `pluginPropVal` already uses for display, while `prop.allowed` holds the keys. `parseAllowedValues()` prefers `selectLabels` so `DYNAMIC_FORM` consumers still receive the original map. List-style dynamic values are untouched.
3. Added the missing watchers.

Also replaced a `document.getElementById` lookup in `refreshPlugin()` with a template ref — the id it resolved (`rkey`) was shared with a sibling hidden input rendered by the parent, so two DOM nodes competed for it.

**Describe alternatives you've considered**

- Normalising the option loops in `pluginPropEdit` instead of using `selectLabels`. Rejected: `selectLabels` is the mechanism already implemented in `pluginPropVal`, and it avoids touching five `v-for` blocks shared by every plugin.
- Upgrading `vue-multiselect` to a Vue 3 compatible release. Rejected: the library layer already exposes a maintained PrimeVue wrapper, and project convention is to prefer it over importing a third party directly.

**Additional context**

The existing suite stubbed `vue-multiselect` with a plain `<div>`, which is precisely why the crash was never caught. The replacement is now mounted for real in tests.

Verified end to end against a mock ServiceNow instance: the incident payload now carries `"urgency":"1"`, `"impact":"2"`, `"priority":"3"` plus the configured custom fields, where it previously carried the labels.

Tests: 93 passing across the affected suites, including new regression coverage for the free-text add-field path, dynamic map handling, and post-mount prop changes.

## Release Notes

Fixes the ServiceNow plugin configuration editor: custom fields can be added again, and Urgency/Impact/Priority now submit the selected code rather than its display label.