### PR TITLE
[RUN-4728] Restore runner key storage selector in job step config

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/EditStepCard.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/EditStepCard.vue
@@ -83,6 +83,8 @@
           description-css="ml-5"
           data-testid="plugin-info"
           :service-name="serviceName"
+          :use-runner-selector="true"
+          :event-bus="eventBus"
           :extra-autocomplete-vars="extraAutocompleteVars"
         />
       </div>
@@ -193,6 +195,7 @@ export default defineComponent({
       loading: false,
       pluginConfigMode: "edit",
       validationErrors: resetValidation(),
+      eventBus: rundeckContext.eventBus,
       jobRefDefaults: {
         description: "",
         jobref: createJobRefDefinition(rundeckContext.projectName),

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/EditPluginModal.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/EditPluginModal.vue
@@ -28,6 +28,8 @@
         description-css="ml-5"
         data-testid="plugin-info"
         :service-name="serviceName"
+        :use-runner-selector="true"
+        :event-bus="eventBus"
         :extra-autocomplete-vars="extraAutocompleteVars"
       ></plugin-config>
       <slot name="extra"></slot>
@@ -54,6 +56,7 @@ import pluginInfo from "./PluginInfo.vue";
 import { PluginConfig } from "../../../library/interfaces/PluginConfig";
 import { getServiceProviderDescription } from "../../../library/modules/pluginService";
 import { ContextVariable } from "../../../library/stores/contextVariables";
+import { getRundeckContext } from "../../../library";
 import { cloneDeep } from "lodash";
 import { defineComponent, type PropType } from "vue";
 
@@ -98,6 +101,7 @@ export default defineComponent({
       provider: null,
       loading: false,
       pluginConfigMode: "edit",
+      eventBus: getRundeckContext()?.eventBus,
     };
   },
   computed: {


### PR DESCRIPTION
## Jira Ticket

[RUN-4728](https://pagerduty.atlassian.net/browse/RUN-4728) — *Secrets into Key Storage used through Runners are not accessible nor visible across all project-level features*

## Summary

Secrets held by a runner-backed storage plugin (e.g. HashiCorp Vault configured via `RUNNER_RUNDECK_STORAGE_*`) can be browsed in **Edit Nodes**, but not when configuring a **job step**. This is a regression, not a missing feature.

The legacy GSP plugin config form rendered the `plugin-runner-key-selector` ui-socket for *every* `STORAGE_PATH` property:

https://github.com/rundeck/rundeck/blob/main/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp#L343-L346

That socket was added in the same commit as the feature itself (`b0b554843a`, RUN-1808), so runner key browsing covered job steps from day one. The Vue step editor never passed `use-runner-selector`, so `pluginPropEdit` falls back to the plain `KeyStorageSelector`, which only lists the **server** storage tree — and the server has no runner-backed Vault provider.

The gap became the default when the workflow tab was promoted out of `nextUi` in `9eee2274cc` (#9994, 2026-02-26). Before that, the default step editor was the GSP one, which had the picker.

## Root cause

`EditPluginModal` is the component that actually edits steps (`WorkflowSteps` mounts it when `modalComponent === "edit-plugin-modal"`), and it is also used by `LogFilterControls`. Neither passed the prop. `EditStepCard` had the same omission.

Only **discovery** was broken. Runtime resolution already works — `RunnerVaultSpec` proves a step with `password = runner/simple.secret` executes successfully against a Vault that exists only on the runner.

## Changes

- `EditPluginModal.vue` — pass `use-runner-selector` and the event bus (fixes job step editing **and** log filters, both of which came from GSP forms that had the socket)
- `EditStepCard.vue` — same

`getRundeckContext()` is read with optional chaining because `window._rundeck` is absent under Jest.

## Scope

This restores parity for job steps and log filters only. **Job Options** and **SCM** are *not* regressions and are unchanged:

- Job Options never had the picker, even in GSP (`_optEdit.gsp` uses the raw `obs-select-storage-path` modal with `storageRoot = "keys"`), and secure options resolve server-side before dispatch.
- SCM setup is still GSP and still shows the picker, but `ScmService` resolves against the server tree.

Those need a product decision, tracked separately.

## Test plan

- [x] `EditPluginModal.spec.ts`, `EditStepCard.spec.ts`, `WorkflowSteps.spec.ts`, `LogFilterControls.spec.ts` — 65 tests pass
- [x] No lint errors
- [ ] Manual: configure a runner with a Vault storage plugin, edit a job step whose plugin has a Key Storage property, confirm the runner key selector appears and lists keys under `runner/`
- [ ] Manual: same job with `?legacyUi=true` for the before/after contrast
- [ ] Manual: confirm log filter editing still behaves correctly

## Notes

Draft until manual verification on a runner-backed Vault environment is complete.

Paired rundeckpro PR (conditional workflow step editor) to follow.

Made with [Cursor](https://cursor.com)

[RUN-4728]: https://pagerduty.atlassian.net/browse/RUN-4728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ