### PR TITLE
[RUN-4555] Harden realm.properties password encoder: drop plaintext fallback, warn on weak formats

### DIFF
--- a/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
@@ -37,6 +37,7 @@ import groovy.sql.Sql
 import org.grails.plugins.metricsweb.CallableGauge
 import org.quartz.Scheduler
 import org.rundeck.app.AppConstants
+import org.rundeck.security.RealmPropertiesWeakFormatScanner
 import rundeck.services.LogFileStorageService
 import rundeck.services.feature.FeatureService
 import rundeckapp.cli.CommandLineSetup
@@ -353,6 +354,27 @@ class BootStrap {
         } else {
             log.info("Using builtin realm authentication")
             authenticationManager.providers.add(grailsApplication.mainContext.getBean("realmAuthProvider"))
+
+            // RUN-4555: warn at startup when realm.properties contains accounts stored in a weak
+            // or unrecognized password format (MD5/CRYPT/plaintext). The password encoder no longer
+            // accepts a plaintext fallback, but weak formats are still accepted for compatibility;
+            // surface them so admins know to migrate those accounts to BCrypt.
+            String realmFilePath = grailsApplication.config.getProperty("rundeck.security.fileUserDataSource", String.class)
+            File realmFile = realmFilePath ? new File(realmFilePath) : null
+            if (realmFile?.exists()) {
+                Properties realmProperties = new Properties()
+                realmFile.withInputStream { realmProperties.load(it) }
+                List<String> weakUsernames = RealmPropertiesWeakFormatScanner.findWeakFormatUsernames(realmProperties)
+                if (weakUsernames) {
+                    log.warn("=" * 80)
+                    log.warn("SECURITY: realm.properties contains accounts using a weak or unrecognized")
+                    log.warn("password format (MD5, CRYPT, or plaintext instead of BCrypt).")
+                    log.warn("Affected accounts: ${weakUsernames.join(', ')}")
+                    log.warn("If this file is disclosed, these credentials are exposed to offline cracking.")
+                    log.warn("Migrate affected accounts to BCRYPT-encoded passwords.")
+                    log.warn("=" * 80)
+                }
+            }
         }
 
         if(grailsApplication.config.getProperty("rundeck.security.authorization.preauthenticated.enabled",Boolean.class, false)

--- a/rundeckapp/src/main/groovy/org/rundeck/security/JettyCompatibleSpringSecurityPasswordEncoder.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/security/JettyCompatibleSpringSecurityPasswordEncoder.groovy
@@ -20,9 +20,6 @@ import org.rundeck.jaas.PasswordCredential
 import org.rundeck.jaas.jetty.BcryptCredentialProvider
 import org.springframework.security.crypto.password.PasswordEncoder
 
-import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
-
 /**
  * Password encoder compatible with Jetty password formats.
  * Updated for JAAS refactoring - uses org.rundeck.jaas.PasswordCredential
@@ -47,8 +44,9 @@ class JettyCompatibleSpringSecurityPasswordEncoder implements PasswordEncoder {
     /**
      * Checks a raw password against an encoded password, dispatching on the encoded
      * password's prefix ({@code MD5:}, {@code CRYPT:}, {@code OBF:}, {@code BCRYPT:}).
-     * Encoded passwords with no recognized prefix are compared as plaintext using a
-     * constant-time comparison.
+     * Encoded passwords with no recognized prefix are rejected: there is no plaintext
+     * fallback, since a plaintext comparison would let any realm.properties entry that
+     * is not explicitly hashed authenticate successfully.
      * @param rawPass the raw password to check
      * @param encPass the stored encoded (or plaintext) password
      * @return true if the raw password matches
@@ -75,10 +73,7 @@ class JettyCompatibleSpringSecurityPasswordEncoder implements PasswordEncoder {
             return new BcryptCredentialProvider().getCredential(encPass).check(rawPass)
         }
 
-        // Plain text comparison - constant-time to avoid leaking length/content via timing
-        return MessageDigest.isEqual(
-            encPass.getBytes(StandardCharsets.UTF_8),
-            rawPass.toString().getBytes(StandardCharsets.UTF_8)
-        )
+        // No recognized prefix: reject. Do not compare as plaintext.
+        return false
     }
 }

--- a/rundeckapp/src/main/groovy/org/rundeck/security/RealmPropertiesWeakFormatScanner.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/security/RealmPropertiesWeakFormatScanner.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.rundeck.security
+
+import groovy.transform.CompileStatic
+
+/**
+ * Scans a {@code realm.properties}-formatted {@link Properties} object for accounts
+ * stored in a weak or unrecognized password format (anything other than {@code BCRYPT:}
+ * or the already-rejected {@code OBF:}), so callers can warn admins to migrate them.
+ */
+@CompileStatic
+class RealmPropertiesWeakFormatScanner {
+
+    /**
+     * Finds usernames whose realm.properties entry is not {@code BCRYPT:}- or
+     * {@code OBF:}-prefixed. Covers {@code MD5:}, {@code CRYPT:}, and bare plaintext
+     * entries (no recognized prefix).
+     * @param realmProperties realm.properties entries, each value in
+     * {@code password[,role1,role2,...]} format
+     * @return usernames with a weak or unrecognized password format, in no particular order
+     */
+    static List<String> findWeakFormatUsernames(Properties realmProperties) {
+        List<String> weakUsernames = []
+        realmProperties?.each { Object username, Object value ->
+            String encodedPassword = value?.toString()?.split(',', 2)?.getAt(0)
+            if (encodedPassword && !isStrongFormat(encodedPassword)) {
+                weakUsernames << username.toString()
+            }
+        }
+        return weakUsernames
+    }
+
+    private static boolean isStrongFormat(String encodedPassword) {
+        encodedPassword.startsWith("BCRYPT:") || encodedPassword.startsWith("OBF:")
+    }
+}

--- a/rundeckapp/src/test/groovy/org/rundeck/security/JettyCompatibleSpringSecurityPasswordEncoderTest.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/security/JettyCompatibleSpringSecurityPasswordEncoderTest.groovy
@@ -27,9 +27,9 @@ class JettyCompatibleSpringSecurityPasswordEncoderTest extends Specification {
         encoder.metaClass.getUsername = { -> return "jsmith" }
     }
 
-    def "Is Password Valid Plaintext"() {
-        expect:
-        encoder.matches("plaintext","plaintext")
+    def "Is Password Valid Plaintext - rejected, no plaintext fallback"() {
+        expect: "unrecognized/no-prefix formats are rejected, even when raw and encoded are byte-identical"
+        !encoder.matches("plaintext","plaintext")
         !encoder.matches("plaintext","plaintxt")
     }
 

--- a/rundeckapp/src/test/groovy/org/rundeck/security/RealmPropertiesWeakFormatScannerSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/security/RealmPropertiesWeakFormatScannerSpec.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.rundeck.security
+
+import spock.lang.Specification
+
+class RealmPropertiesWeakFormatScannerSpec extends Specification {
+
+    def "finds usernames with MD5, CRYPT, or plaintext entries"() {
+        given:
+        Properties realmProperties = new Properties()
+        realmProperties.setProperty("bcryptUser", "BCRYPT:\$2a\$10\$abcdefghijklmnopqrstuv,user")
+        realmProperties.setProperty("md5User", "MD5:5f4dcc3b5aa765d61d8327deb882cf99,user")
+        realmProperties.setProperty("cryptUser", "CRYPT:ab12345678901,user")
+        realmProperties.setProperty("plaintextUser", "hunter2,user")
+
+        when:
+        List<String> weak = RealmPropertiesWeakFormatScanner.findWeakFormatUsernames(realmProperties)
+
+        then:
+        weak.size() == 3
+        weak.containsAll(["md5User", "cryptUser", "plaintextUser"])
+        !weak.contains("bcryptUser")
+    }
+
+    def "returns empty list when all entries are BCRYPT encoded"() {
+        given:
+        Properties realmProperties = new Properties()
+        realmProperties.setProperty("user1", "BCRYPT:\$2a\$10\$abcdefghijklmnopqrstuv,user")
+        realmProperties.setProperty("user2", "BCRYPT:\$2a\$10\$zyxwvutsrqponmlkjihgfe,admin,user")
+
+        expect:
+        RealmPropertiesWeakFormatScanner.findWeakFormatUsernames(realmProperties).isEmpty()
+    }
+
+    def "does not flag OBF entries even though they are already rejected at login"() {
+        given:
+        Properties realmProperties = new Properties()
+        realmProperties.setProperty("obfUser", "OBF:1uve1sho1w8h1vgz1vgv1wui1wtw1vfz1vfv1w991shu1uus,user")
+
+        expect: "OBF handling is unchanged by this ticket - only MD5/CRYPT/plaintext are in scope"
+        RealmPropertiesWeakFormatScanner.findWeakFormatUsernames(realmProperties).isEmpty()
+    }
+
+    def "ignores the role suffix when checking the password prefix"() {
+        given:
+        Properties realmProperties = new Properties()
+        realmProperties.setProperty("user1", "MD5:5f4dcc3b5aa765d61d8327deb882cf99,admin,user,extra")
+
+        expect:
+        RealmPropertiesWeakFormatScanner.findWeakFormatUsernames(realmProperties) == ["user1"]
+    }
+
+    def "returns empty list for empty or null properties"() {
+        expect:
+        RealmPropertiesWeakFormatScanner.findWeakFormatUsernames(new Properties()) == []
+        RealmPropertiesWeakFormatScanner.findWeakFormatUsernames(null) == []
+    }
+}


### PR DESCRIPTION
## Release Notes

Strengthened security for file-based accounts in `realm.properties` when using built-in realm authentication. Passwords without a recognized hash prefix are no longer accepted as plain text, closing a fallback that could allow login with unhashed credentials if the file was exposed. On startup, Rundeck now logs a warning listing accounts still stored in weak formats (MD5, CRYPT, or plain text) so administrators can migrate them to BCrypt.

## PR Details

## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Security hardening fix for [RUN-4555](https://pagerduty.atlassian.net/browse/RUN-4555), sourced from security report PS-1688.

`JettyCompatibleSpringSecurityPasswordEncoder.matches()` accepted MD5 and CRYPT password formats and, for any value with no recognized prefix, fell back to a plaintext comparison — so a realm.properties entry that wasn't explicitly hashed always authenticated successfully. There was also no way for an admin to notice weak-format entries at startup.

Note: the original report also claimed OBF passwords are accepted and "fully reversible." That's a false positive — OBF is already explicitly rejected in this encoder. Only the plaintext-fallback and weak-format-visibility gaps below are addressed here.

**Describe the solution you've implemented**
1. Removed the plaintext-comparison fallback in `JettyCompatibleSpringSecurityPasswordEncoder.matches()`. Any encoded value without a recognized `MD5:`/`CRYPT:`/`BCRYPT:` prefix (OBF: was already rejected) now returns `false` instead of being compared as plaintext.
2. Added `RealmPropertiesWeakFormatScanner`, a small pure utility that scans a `realm.properties`-shaped `Properties` object and returns usernames whose entry is not `BCRYPT:`- or `OBF:`-encoded (i.e. `MD5:`, `CRYPT:`, or bare plaintext).
3. Wired the scanner into `BootStrap.groovy`'s builtin-realm-auth branch: on startup, if any weak-format entries are found in `realm.properties`, a `log.warn` banner lists the affected usernames, matching the existing RUN-4693 security-warning style.
4. Updated/added Spock tests: inverted the existing "plaintext" test to assert rejection, and added a full spec for the new scanner (MD5/CRYPT/plaintext detection, BCRYPT/OBF exclusion, role-suffix handling, empty/null input).

**Describe alternatives you've considered**
Rehashing weak-format credentials to BCrypt automatically on successful login was considered (the ticket allowed either approach). Rejected because `realm.properties` has no existing write-back mechanism — it's a hand-edited, admin-managed file loaded once via `Properties.load()` in both the JAAS and Spring Security paths — so adding one would be a much larger, riskier change than warranted for a P3/Low finding whose threat model is "admin file disclosure," not runtime compromise. The startup warning fully covers the "make weak entries visible to the admin" goal.

The homegrown, non-standard `CRYPT` routine in `PasswordCredential.java` (flagged in the same security report) is tracked as a separate item per the ticket and is intentionally not touched here.

**Additional context**
- Only the non-JAAS (`rundeck.useJaas=false`, "builtin realm authentication") path is affected — the JAAS `PropertyFileLoginModule` path is untouched, since the reported encoder is Spring-Security-specific.
- All 12 tests in the touched Spock specs pass locally (`./gradlew :rundeckapp:test --tests "org.rundeck.security.*"`).

[RUN-4555]: https://pagerduty.atlassian.net/browse/RUN-4555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
