### PR TITLE
[RUN-4886] Gate node/npm engine Renovate group behind Dependency Dashboard approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -121,10 +121,11 @@
       "enabled": true
     },
     {
-      "description": "Group Node.js version (.nvmrc) with the npm engine pin so they update together",
+      "description": "Group Node.js version (.nvmrc) with the npm engine pin so they update together. Gated behind Dependency Dashboard approval: node/npm must move in lockstep across the rundeck and rundeckpro repos (Renovate cannot open a single cross-repo PR), so auto-created PRs can never merge unilaterally and only burn CI. Approve the checkbox on BOTH repos' dashboards in the same session, merge rundeck first, then rundeckpro.",
       "matchManagers": ["nvm", "npm"],
       "matchDepNames": ["node", "npm"],
-      "groupName": "node and npm engine versions"
+      "groupName": "node and npm engine versions",
+      "dependencyDashboardApproval": true
     },
     {
       "description": "Default registry for the vast majority of Gradle dependencies (Spring, Netty, Jackson, JUnit, etc.) instead of checking every globally-declared repo (m2proxy, PackageCloud, Sonatype, Grails, Gradle Plugin Portal, ...) for every dependency. Only ~9% of our gradle deps are actually Grails/Groovy-namespaced, so grails.org is scoped separately below rather than checked for everything.",


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Maintenance / CI cost reduction for Renovate configuration.

Renovate runs independently on `rundeck` and `rundeckpro`, and node/npm versions (`.nvmrc` + `engines.npm`) must move in lockstep across both repos. Renovate cannot open a single cross-repo PR, so the auto-created "node and npm engine versions" PRs (branch `renovate/node-and-npm-engine-versions`) can never be merged unilaterally — they only consume CircleCI credits on every rebase.

**Describe the solution you've implemented**

Added `"dependencyDashboardApproval": true` to the existing `"node and npm engine versions"` package rule in `renovate.json`, and extended the rule's description to document the cross-repo lockstep rationale. Renovate now lists the update under "Pending Approval" on the Dependency Dashboard instead of creating a branch/PR. When a coordinated bump is due, approve the checkbox on both repos' dashboards in the same session, merge the rundeck PR first, then the rundeckpro one.

A mirror PR applies the identical change to `rundeckpro` (the two `renovate.json` files are intentionally kept in sync).

**Describe alternatives you've considered**

- A `schedule` on the group: reduces noise but still auto-creates unmergeable PRs.
- A single cross-repo PR: not supported by Renovate (per-repository operation; submodule contents are not scanned).

**Additional context**

Validated with `npx --package renovate -- renovate-config-validator renovate.json` (passes). No change needed for the per-project `.npmrc` files — they are already identical across the npm projects and Renovate honors them.

## Release Notes

N/A — CI/dependency-bot configuration only, no product change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)