### PR TITLE
[RUN-4757] Hide incomplete nodes from execution results and logs

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -722,6 +722,31 @@ RDNode.computeNodeDurationMs = function (durationMs, steps, execDurationMs) {
     return ms != null ? ms : -1;
 };
 
+/**
+ * Whether a node's only unrun steps were skipped, and everything that did run succeeded.
+ *
+ * A NOT_STARTED step is not proof of a skipped conditional: a step is also NOT_STARTED when it
+ * was never reached because an earlier step aborted. Identifying hide-able incomplete nodes
+ * therefore requires the step counts, not just the summary state. Server summaries from a node
+ * whose steps have not been loaded omit these counts on older releases, in which case the node
+ * is left visible.
+ * @param counts object with total, SUCCEEDED, NOT_STARTED and optional pending counts
+ * @returns {boolean}
+ */
+RDNode.isSkippedOnlySuccess = function (counts) {
+    if (!counts) {
+        return false;
+    }
+    var total = counts.total, succeeded = counts.SUCCEEDED, notStarted = counts.NOT_STARTED;
+    if (typeof total !== 'number' || typeof succeeded !== 'number' || typeof notStarted !== 'number') {
+        return false;
+    }
+    if (counts.pending > 0 || notStarted < 1 || total < 1) {
+        return false;
+    }
+    return total - notStarted === succeeded;
+};
+
 function RDNode(name, steps,flow){
     var self=this;
     self.flow= flow;
@@ -825,6 +850,30 @@ function RDNode(name, steps,flow){
         }
         return null;
     };
+    self.skipCounts = ko.observable(null);
+    /**
+     * Store the counts used to decide whether this node is incomplete only because of skipped steps.
+     * @param counts object with total, SUCCEEDED, NOT_STARTED and optional pending
+     */
+    self.captureSkipCounts=function(counts){
+        if(!counts){
+            self.skipCounts(null);
+            return;
+        }
+        self.skipCounts({
+            total: counts.total,
+            SUCCEEDED: counts.SUCCEEDED,
+            NOT_STARTED: counts.NOT_STARTED,
+            pending: counts.pending != null ? counts.pending : self.flow.pendingStepsForNode(self.name)
+        });
+    };
+    /**
+     * Whether this node should be hidden when the hide-incomplete toggle is on.
+     * @returns {boolean}
+     */
+    self.isIncompleteSkipOnly=function(){
+        return RDNode.isSkippedOnlySuccess(self.skipCounts());
+    };
     /**
      * Determine summary data for the node, sets the summaryState and summary and currentStep
      */
@@ -863,6 +912,7 @@ function RDNode(name, steps,flow){
                 currentStep = step;
             }
         });
+        self.captureSkipCounts(summarydata);
         self.currentStep(currentStep);
 
         //based on step states set the summary for this node
@@ -911,10 +961,13 @@ function RDNode(name, steps,flow){
     };
     self.updateSummary=function(nodesummary){
         if(nodesummary.lastUpdated && self.lastUpdated()==nodesummary.lastUpdated
-            && nodesummary.summaryState==self.summaryState()){
+            && self._serverSummary && nodesummary.summaryState==self._serverSummary.summaryState){
+            self.captureSkipCounts(nodesummary);
             return;
         }
         self.lastUpdated(nodesummary.lastUpdated);
+        self._serverSummary=nodesummary;
+        self.captureSkipCounts(nodesummary);
         self.summaryState(nodesummary.summaryState);
         self.summary(self.summaryDescriptionForState(nodesummary));
 
@@ -990,6 +1043,14 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
     self.endTime=ko.observable();
     self.executionId = ko.observable(data.executionId);
     self.outputScrollOffset=0;
+    self.hideIncompleteNodes = ko.observable(false);
+    /**
+     * Skipped conditionals can only be told apart from steps that were never reached once the
+     * execution has finished successfully, so the toggle has no effect on any other execution.
+     */
+    self.hideIncompleteNodesApplies = ko.pureComputed(function () {
+        return !!self.completed() && self.executionState() === 'SUCCEEDED';
+    });
     self.activeView = ko.observable("nodes");
     /**
      * synonym with activeView, to maintain compatibility
@@ -1033,6 +1094,35 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
     self.activeNodes=ko.pureComputed(function(){
         return ko.utils.arrayFilter(self.nodes(), function (n) {
             return n.summaryState() !== 'NONE';
+        });
+    });
+    /**
+     * Names of nodes that are incomplete only because skipped conditionals did not run.
+     */
+    self.incompleteSkipNodeNames=ko.pureComputed(function(){
+        var names=[];
+        ko.utils.arrayForEach(self.nodes(), function (n) {
+            if (n.isIncompleteSkipOnly && n.isIncompleteSkipOnly()) {
+                names.push(n.name);
+            }
+        });
+        return names;
+    });
+    /**
+     * Nodes shown in the Nodes tab. When the hide-incomplete toggle is on, skip-only
+     * incomplete nodes are omitted from the list (completion counts are unchanged).
+     */
+    self.visibleNodes=ko.pureComputed(function(){
+        var nodes=self.activeNodes();
+        if (!self.hideIncompleteNodes() || !self.hideIncompleteNodesApplies()) {
+            return nodes;
+        }
+        var hide={};
+        ko.utils.arrayForEach(self.incompleteSkipNodeNames(), function (name) {
+            hide[name]=true;
+        });
+        return ko.utils.arrayFilter(nodes, function (n) {
+            return !hide[n.name];
         });
     });
     self.displayStatusString = ko.computed(function () {
@@ -1200,6 +1290,41 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
     self.percentageFixed = function(a,b){
         return (b==0)?0:(100*(a/b)).toFixed(0);
     };
+
+    self.publishHideIncompleteState = function () {
+        var bus = window._rundeck && window._rundeck.eventBus;
+        if (!bus || typeof bus.emit !== 'function') {
+            return;
+        }
+        var hide = !!(self.hideIncompleteNodes() && self.hideIncompleteNodesApplies());
+        bus.emit('execution-hide-incomplete-nodes-state', {
+            hide: hide,
+            applies: self.hideIncompleteNodesApplies(),
+            nodeNames: hide ? self.incompleteSkipNodeNames() : []
+        });
+    };
+    self.hideIncompleteNodes.subscribe(function () {
+        self.publishHideIncompleteState();
+    });
+    self.hideIncompleteNodesApplies.subscribe(function () {
+        self.publishHideIncompleteState();
+    });
+    self.incompleteSkipNodeNames.subscribe(function () {
+        self.publishHideIncompleteState();
+    });
+    (function bindHideIncompleteEventBus() {
+        var bus = window._rundeck && window._rundeck.eventBus;
+        if (!bus || typeof bus.on !== 'function') {
+            return;
+        }
+        bus.on('execution-hide-incomplete-nodes-toggle', function (hide) {
+            self.hideIncompleteNodes(!!hide);
+        });
+        bus.on('execution-hide-incomplete-nodes-request', function () {
+            self.publishHideIncompleteState();
+        });
+        self.publishHideIncompleteState();
+    })();
 
     self.stopShowingOutput= function () {
         if(self.followingControl){

--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.test.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.test.js
@@ -130,6 +130,31 @@ jQuery(function () {
             // Actual execution duration: 457ms
             var ms = RDNode.computeNodeDurationMs(-1, steps, 457);
             this.assert('clamps to execDurationMs', ms === 457);
+        },
+        isSkippedOnlySuccessAcceptsAllStepsSkippedTest: function () {
+            this.assert('every step was skipped',
+                RDNode.isSkippedOnlySuccess({total: 3, SUCCEEDED: 0, NOT_STARTED: 3}) === true);
+        },
+        isSkippedOnlySuccessAcceptsMixOfSkippedAndSucceededTest: function () {
+            this.assert('every step that ran succeeded',
+                RDNode.isSkippedOnlySuccess({total: 3, SUCCEEDED: 2, NOT_STARTED: 1}) === true);
+        },
+        isSkippedOnlySuccessRejectsStepThatRanWithoutSucceedingTest: function () {
+            this.assert('aborted step',
+                RDNode.isSkippedOnlySuccess({total: 3, SUCCEEDED: 1, NOT_STARTED: 1, other: 1}) === false);
+        },
+        isSkippedOnlySuccessRejectsPendingWorkTest: function () {
+            this.assert('node still has pending steps',
+                RDNode.isSkippedOnlySuccess({total: 3, SUCCEEDED: 2, NOT_STARTED: 1, pending: 1}) === false);
+        },
+        isSkippedOnlySuccessRejectsNodeWithoutSkippedStepsTest: function () {
+            this.assert('nothing was skipped',
+                RDNode.isSkippedOnlySuccess({total: 2, SUCCEEDED: 2, NOT_STARTED: 0}) === false);
+        },
+        isSkippedOnlySuccessRejectsSummaryWithoutCountsTest: function () {
+            this.assert('summary from a server that does not report counts',
+                RDNode.isSkippedOnlySuccess({summaryState: 'PARTIAL_NOT_STARTED'}) === false);
+            this.assert('no summary at all', RDNode.isSkippedOnlySuccess(null) === false);
         }
     });
 });

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1893,6 +1893,8 @@ execution.show.mode.column.node=Node
 execution.show.mode.column.step=Step
 execution.show.mode.inset.label=Inset
 execution.show.mode.inset.node=Node
+execution.show.nodes.hideIncompleteNodes.label=Hide incomplete nodes
+execution.show.nodes.hideIncompleteNodes.description=Hide nodes whose only unfinished steps were skipped by a conditional. Successful executions only.
 
 gui.admin.GetPlugins=Get Plugins
 gui.admin.InstallPlugin=Install Plugin

--- a/rundeckapp/grails-app/services/rundeck/services/workflow/StateMapping.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/workflow/StateMapping.groovy
@@ -143,9 +143,17 @@ class StateMapping {
                 summary.WAITING=summarydata.WAITING;
                 summary.summaryState=("WAITING");
             } else if (summarydata.NOT_STARTED == summarydata.total && summarydata.pending < 1) {
+                summary.total=summarydata.total;
+                summary.SUCCEEDED=summarydata.SUCCEEDED;
+                summary.NOT_STARTED=summarydata.NOT_STARTED;
                 summary.summaryState=("NOT_STARTED");
             } else if (summarydata.NOT_STARTED > 0) {
                 summary.PARTIAL_NOT_STARTED=summarydata.NOT_STARTED;
+                //the summary state alone cannot tell a skipped conditional apart from a step that was
+                //never reached, so expose the counts the UI needs to make that distinction
+                summary.total=summarydata.total;
+                summary.SUCCEEDED=summarydata.SUCCEEDED;
+                summary.NOT_STARTED=summarydata.NOT_STARTED;
                 summary.summaryState=("PARTIAL_NOT_STARTED");
             }else if(summarydata.pending > 0 ){
                 summary.summaryState=("WAITING");

--- a/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
@@ -68,7 +68,7 @@
       </div>
     </div>
   </div>
-  <div data-bind="foreach: activeNodes()">
+  <div data-bind="foreach: visibleNodes()">
     <div class="wfnodestate" data-bind="css: { open: expanded() }, attr: { 'data-node': name } ">
       <div class="row wfnodeoverall action" data-bind="click: toggleExpand">
           <div class="col-sm-6  nodectx"

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -622,6 +622,19 @@ search
                           </a>
                           <!-- /ko -->
 
+                          <div data-bind="visible: activeTab()==='nodes'" class="pull-right" style="margin-left: 10px;">
+                              <div class="checkbox-inline">
+                                  <input type="checkbox"
+                                         data-bind="checked: hideIncompleteNodes, enable: hideIncompleteNodesApplies"
+                                         id="hide-incomplete-nodes"
+                                         data-testid="hide-incomplete-nodes"
+                                         title="${g.message(code: 'execution.show.nodes.hideIncompleteNodes.description',
+                                                 default: 'Hide nodes whose only unfinished steps were skipped by a conditional. Successful executions only.')}"/>
+                                  <label for="hide-incomplete-nodes">
+                                      <g:message code="execution.show.nodes.hideIncompleteNodes.label" default="Hide incomplete nodes"/>
+                                  </label>
+                              </div>
+                          </div>
 
                           <span data-bind="visible: activeTab().startsWith('output')">
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
@@ -1439,7 +1439,10 @@ const messages = {
   commonNodeSteps: "Common Node Steps",
   commonWorkflowSteps: "Common Workflow Steps",
   learnMore: "Learn more",
-  plugins: "plugins"
+  plugins: "plugins",
+  hideIncompleteNodes: "Hide incomplete nodes",
+  hideIncompleteNodesDescription:
+    "Hide nodes whose only unfinished steps were skipped by a conditional. Successful executions only.",
 };
 
 export default messages;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
@@ -84,6 +84,20 @@
           <input id="logview_stats" v-model="settings.stats" type="checkbox" data-testid="log-viewer-stats-checkbox" />
           <label for="logview_stats">Display Stats</label>
         </div>
+        <div class="checkbox">
+          <input
+            id="logview_hideIncomplete"
+            type="checkbox"
+            data-testid="log-viewer-hide-incomplete-checkbox"
+            :checked="hideIncompleteNodes"
+            :disabled="!hideIncompleteApplies"
+            :title="$t('hideIncompleteNodesDescription')"
+            @change="onHideIncompleteCheckboxChange"
+          />
+          <label for="logview_hideIncomplete">{{
+            $t("hideIncompleteNodes")
+          }}</label>
+        </div>
         <ui-socket
           section="execution-log-viewer"
           location="settings"
@@ -349,6 +363,16 @@ export default defineComponent({
       viewerEntriesByNodeCtx: null,
       viewerFilteredEntries: [] as any[],
       autorunDisposer: null as IReactionDisposer | null,
+      hideIncompleteNodes: false,
+      hideIncompleteApplies: false,
+      incompleteNodeNames: [] as string[],
+      hideIncompleteStateListener: null as
+        | ((payload: {
+            hide?: boolean;
+            applies?: boolean;
+            nodeNames?: string[];
+          }) => void)
+        | null,
     };
   },
   computed: {
@@ -391,10 +415,18 @@ export default defineComponent({
       if (this.viewer == null) {
         return [];
       }
-      if (this.node) {
-        return this.viewerFilteredEntries;
+      const entries = this.node
+        ? this.viewerFilteredEntries
+        : this.entriesFromViewer;
+      if (
+        !this.hideIncompleteNodes ||
+        !this.incompleteNodeNames ||
+        this.incompleteNodeNames.length < 1
+      ) {
+        return entries;
       }
-      return this.entriesFromViewer;
+      const hidden = new Set(this.incompleteNodeNames);
+      return (entries || []).filter((entry) => !hidden.has(entry.node));
     },
   },
   watch: {
@@ -449,6 +481,13 @@ export default defineComponent({
       this.autorunDisposer();
       this.autorunDisposer = null;
     }
+    if (this.eventBus && this.hideIncompleteStateListener) {
+      this.eventBus.off(
+        "execution-hide-incomplete-nodes-state",
+        this.hideIncompleteStateListener,
+      );
+      this.hideIncompleteStateListener = null;
+    }
   },
   async mounted() {
     await this.viewer.init();
@@ -467,6 +506,7 @@ export default defineComponent({
 
     this.execCompleted = this.viewer.execCompleted;
     this.mfollow = !this.viewer.execCompleted;
+    this.bindHideIncompleteNodes();
 
     if (this.viewer.execCompleted && this.viewer.size > this.maxLogSize) {
       this.logSize = this.viewer.size;
@@ -478,6 +518,38 @@ export default defineComponent({
     this.populateLogsProm = await this.populateLogs();
   },
   methods: {
+    bindHideIncompleteNodes() {
+      if (!this.eventBus) {
+        return;
+      }
+      this.hideIncompleteStateListener = (payload) => {
+        this.onHideIncompleteState(payload);
+      };
+      this.eventBus.on(
+        "execution-hide-incomplete-nodes-state",
+        this.hideIncompleteStateListener,
+      );
+      this.eventBus.emit("execution-hide-incomplete-nodes-request");
+    },
+    onHideIncompleteState(payload: {
+      hide?: boolean;
+      applies?: boolean;
+      nodeNames?: string[];
+    }) {
+      this.hideIncompleteNodes = !!payload && !!payload.hide;
+      this.hideIncompleteApplies = !!payload && !!payload.applies;
+      this.incompleteNodeNames =
+        payload && payload.nodeNames ? payload.nodeNames : [];
+    },
+    onHideIncompleteCheckboxChange(event: Event) {
+      const target = event.target as HTMLInputElement;
+      if (this.eventBus) {
+        this.eventBus.emit(
+          "execution-hide-incomplete-nodes-toggle",
+          !!target.checked,
+        );
+      }
+    },
     loadConfig() {
       if (this.useUserSettings) {
         const _settings = localStorage.getItem(CONFIG_STORAGE_KEY);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/test/logViewer.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/test/logViewer.spec.ts
@@ -34,6 +34,14 @@ const findByTestId = (wrapper: VueWrapper<any>, testId: string) => {
   return wrapper.find(`[data-testid="${testId}"]`);
 };
 
+const findEventHandler = (
+  eventBus: { on: jest.Mock },
+  eventName: string,
+) => {
+  const call = eventBus.on.mock.calls.find((args) => args[0] === eventName);
+  return call ? call[1] : undefined;
+};
+
 // Setup function to mount the component with given props
 const createWrapper = (props = {}, options = {}): VueWrapper<any> => {
   return shallowMount(LogViewer, {
@@ -48,6 +56,9 @@ const createWrapper = (props = {}, options = {}): VueWrapper<any> => {
       ...props,
     },
     global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
       stubs: {
         RdDrawer: {
           template: "<div><slot></slot></div>",
@@ -56,6 +67,22 @@ const createWrapper = (props = {}, options = {}): VueWrapper<any> => {
         ProgressBar: true,
         Btn: false,
         BtnGroup: false,
+        LogNodeChunk: {
+          name: "LogNodeChunk",
+          props: ["entries"],
+          emits: ["line-select", "jumped", "follow-change"],
+          template: `
+            <div data-testid="log-node-chunk">
+              <div
+                v-for="(entry, idx) in entries || []"
+                :key="idx"
+                :data-testid="'log-entry-' + entry.node"
+              >
+                {{ entry.log }}
+              </div>
+            </div>
+          `,
+        },
       },
       ...options,
     },
@@ -351,6 +378,70 @@ describe("LogViewer", () => {
         expect(wrapper.emitted("line-deselect")).toBeTruthy();
         expect(wrapper.emitted("line-deselect")?.[0]).toEqual([42]);
       });
+    });
+  });
+
+  describe("Hide incomplete nodes", () => {
+    it("renders hide incomplete checkbox in settings and keeps it disabled until it applies", async () => {
+      const wrapper = createWrapper({ showSettings: true });
+      await flushPromises();
+
+      const checkbox = findByTestId(
+        wrapper,
+        "log-viewer-hide-incomplete-checkbox",
+      );
+      expect(checkbox.exists()).toBe(true);
+      expect(checkbox.attributes("disabled")).toBeDefined();
+    });
+
+    it("hides log lines for incomplete nodes when hide state is published", async () => {
+      mockViewer.entries = [
+        { node: "runner", log: "skipped" },
+        { node: "localhost", log: "ok" },
+      ];
+      const wrapper = createWrapper({ showSettings: true });
+      await flushPromises();
+
+      const stateHandler = findEventHandler(
+        mockEventBus as unknown as { on: jest.Mock },
+        "execution-hide-incomplete-nodes-state",
+      );
+      expect(stateHandler).toBeDefined();
+      stateHandler({
+        hide: true,
+        applies: true,
+        nodeNames: ["runner"],
+      });
+      await nextTick();
+
+      expect(findByTestId(wrapper, "log-entry-runner").exists()).toBe(false);
+      expect(findByTestId(wrapper, "log-entry-localhost").exists()).toBe(true);
+      expect(findByTestId(wrapper, "log-entry-localhost").text()).toContain(
+        "ok",
+      );
+    });
+
+    it("emits toggle when user checks hide incomplete nodes", async () => {
+      const wrapper = createWrapper({ showSettings: true });
+      await flushPromises();
+
+      const stateHandler = findEventHandler(
+        mockEventBus as unknown as { on: jest.Mock },
+        "execution-hide-incomplete-nodes-state",
+      );
+      stateHandler({ hide: false, applies: true, nodeNames: ["runner"] });
+      await nextTick();
+
+      await findByTestId(
+        wrapper,
+        "log-viewer-hide-incomplete-checkbox",
+      ).setValue(true);
+      await nextTick();
+
+      expect(mockEventBus.emit).toHaveBeenCalledWith(
+        "execution-hide-incomplete-nodes-toggle",
+        true,
+      );
     });
   });
 });


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Enhancement. Fixes [RUN-4757](https://pagerduty.atlassian.net/browse/RUN-4757).

Conditionals that don't run on a node make the node show as incomplete in the execution results. This is confusing when the job actually succeeded. The request is to add a toggle that hides these incomplete nodes from the Nodes tab and filters their log lines.

Supersedes #10496 — that PR remapped node summaries to `SUCCEEDED`; this PR hides the nodes instead, matching the updated ticket AC.

**Describe the solution you've implemented**

1. **Backend (`StateMapping.groovy`):** Emit `total`, `SUCCEEDED`, and `NOT_STARTED` step counts in the node summary so the UI can distinguish skipped conditionals from truly unreached steps.

2. **Predicate (`executionStateKO.js`):** Pure static `RDNode.isSkippedOnlySuccess(counts)` — returns true only when every step that ran succeeded and the only unrun steps were skipped (no aborted/other/pending). Each node captures its counts in a `skipCounts` observable.

3. **Nodes tab (`show.gsp` + `_wfstateNodeModelDisplay.gsp`):** "Hide incomplete nodes" checkbox (disabled unless execution is `SUCCEEDED`). When checked, `visibleNodes` computed filters out skip-only incomplete nodes. Completion counts (`completedNodes`, `partialNodes`) are **unchanged** — the node is hidden, not reclassified.

4. **Log viewer (`logViewer.vue`):** Same checkbox in the Settings drawer. State is shared via the global `EventBus` (`execution-hide-incomplete-nodes-state/toggle/request`). `viewerEntries` computed filters out log lines whose `entry.node` is in the hidden set.

5. **Tests:**
   - `executionStateKO.test.js`: 7 cases for `isSkippedOnlySuccess` (all-skipped, mixed, aborted, pending, no-skip, legacy, null).
   - `logViewer.spec.ts`: checkbox renders disabled, log filtering hides correct entries, toggle emits correct event.

6. **i18n:** `messages.properties` + `en_US.js`.

**Describe alternatives you've considered**
- Remap node summaries to `SUCCEEDED` (PR #10496) — misrepresents the actual state and inflates completion counts on collapsed nodes with aborted steps.
- Persistent job setting — could be a follow-up enhancement.

**Additional context**
- Checkbox only active on `SUCCEEDED` executions (disabled otherwise).
- Default is OFF (original behavior preserved).
- Node summary/state is left unchanged; only visibility is affected.
- Related PR: #10496 (will be superseded by this one).

## Release Notes

Added "Hide incomplete nodes" toggle to the execution results page. When enabled on a successful execution, nodes whose only unfinished steps were skipped by a conditional are hidden from the Nodes list and their log lines are filtered from the Log Output view.

Made with [Cursor](https://cursor.com)

[RUN-4757]: https://pagerduty.atlassian.net/browse/RUN-4757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ