### PR TITLE
[RUN-4890] Make ACE editor manually resizable when minLines is unset

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -510,10 +510,10 @@ public class RundeckConfigBase {
         Enabled activityDefaultTimeFilter = new Enabled();
         Enabled vueKeyStorage = new Enabled(true);
         Enabled pluginGroups = new Enabled(true);
-        // RUN-4277/#10321: default raised from 12 to 20 — Ace no longer supports a manual
-        // resize handle (upstream removed it), so a taller out-of-the-box default is the
-        // supported way to make the inline-script/code editor more usable without configuration.
-        int guiAceEditorMinLines = 20;
+        // RUN-4862: minimum number of visible lines in the ACE code editor. A value of 0
+        // (the default) makes the editor manually resizable via drag handle instead of
+        // auto-sizing to a fixed number of lines.
+        int guiAceEditorMinLines = 0;
         int guiAceEditorMaxLines = 0;
 
         @Data

--- a/rundeckapp/grails-app/views/layouts/base.gsp
+++ b/rundeckapp/grails-app/views/layouts/base.gsp
@@ -134,7 +134,7 @@
             logo:'${g.appLogo()}',
             logocss:'${g.appLogocss()}',
             appRundeckGatewayUrl: '${g.appRundeckGatewayUrl()}',
-            aceEditorMinLines: ${cfg.getInteger(config:'feature.guiAceEditorMinLines', default:20)},
+            aceEditorMinLines: ${cfg.getInteger(config:'feature.guiAceEditorMinLines', default:0)},
             aceEditorMaxLines: ${cfg.getInteger(config:'feature.guiAceEditorMaxLines', default:0)}
         },
         hideVersionUpdateNotification: '${session.filterPref?.hideVersionUpdateNotification}',

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropEdit.vue
@@ -221,11 +221,9 @@
                 prop.options['codeSyntaxSelectable'] === 'true' &&
                 !renderReadOnly
               "
-              height="200"
-              width="100%"
               :read-only="renderReadOnly"
               :context-variable-suggestions="scriptTypeContextVariables"
-              :min-lines="aceEditorMinLines"
+              :min-lines="aceEditorMinLines > 0 ? aceEditorMinLines : undefined"
               :max-lines="aceEditorMaxLines"
             />
           </ui-socket>
@@ -440,10 +438,7 @@ import {
   WorkflowStepType,
 } from "../utils/contextVariableUtils";
 
-// RUN-4277/#10321: default raised from 12 to 20 — Ace no longer supports a manual resize
-// handle (upstream removed it), so a taller out-of-the-box default is the supported way to
-// make the inline-script/code editor more usable without configuration.
-const ACE_EDITOR_DEFAULT_MIN_LINES = 20;
+const ACE_EDITOR_DEFAULT_MIN_LINES = 0;
 const ACE_EDITOR_DEFAULT_MAX_LINES = 0;
 
 interface Prop {
@@ -602,7 +597,8 @@ export default defineComponent({
       return this.appMeta.aceEditorMinLines ?? ACE_EDITOR_DEFAULT_MIN_LINES;
     },
     aceEditorMaxLines(): number {
-      const raw = this.appMeta.aceEditorMaxLines ?? ACE_EDITOR_DEFAULT_MAX_LINES;
+      const raw =
+        this.appMeta.aceEditorMaxLines ?? ACE_EDITOR_DEFAULT_MAX_LINES;
       return raw === 0 ? Infinity : raw;
     },
   },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginPropEdit.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginPropEdit.spec.ts
@@ -60,11 +60,11 @@ describe("pluginPropEdit aceEditor computed props", () => {
   });
 
   describe("aceEditorMinLines", () => {
-    it("passes minLines of 20 to AceEditorVue when appMeta has no aceEditorMinLines", async () => {
+    it("passes minLines of 0 to AceEditorVue when appMeta has no aceEditorMinLines", async () => {
       mockGetRundeckContext.mockReturnValueOnce({ appMeta: {} });
       const wrapper = await createCodeWrapper({ prop: codeProp });
 
-      expect(wrapper.findComponent(AceEditorVue).props("minLines")).toBe(20);
+      expect(wrapper.findComponent(AceEditorVue).props("minLines")).toBe(0);
     });
 
     it("passes the configured minLines to AceEditorVue when appMeta provides it", async () => {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/AceEditorVue.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/AceEditorVue.vue
@@ -1,5 +1,7 @@
 <template>
-  <div :id="identifier" ref="root"></div>
+  <div :class="{ resizable: minLines === 0 }">
+    <div :id="identifier" ref="root"></div>
+  </div>
 </template>
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
@@ -31,7 +33,7 @@ export default defineComponent({
     },
     minLines: {
       type: Number,
-      default: 12,
+      default: 0,
     },
     maxLines: {
       type: Number,
@@ -63,14 +65,26 @@ export default defineComponent({
     editor: Ace.Editor | null;
     contentBackup: string;
     observer: MutationObserver | null;
+    resizeObserver: ResizeObserver | null;
     jsonSpaces: number;
   } {
     return {
       editor: null,
       contentBackup: "",
       observer: null,
+      resizeObserver: null,
       jsonSpaces: 2,
     };
+  },
+  computed: {
+    /**
+     * When minLines is 0, the editor is manually resizable via CSS instead of
+     * auto-growing/shrinking to fit its content, so minLines/maxLines must not
+     * be handed to ace or its own auto-sizing will fight the manual resize.
+     */
+    isResizable(): boolean {
+      return this.minLines === 0;
+    },
   },
   watch: {
     modelValue: function (val: string): void {
@@ -92,10 +106,14 @@ export default defineComponent({
       this.editor!.setOptions(newOption);
     },
     minLines: function (val: number): void {
-      this.editor!.setOptions({ minLines: val });
+      if (val && !this.isResizable) {
+        this.editor!.setOptions({ minLines: val });
+      }
     },
     maxLines: function (val: number): void {
-      this.editor!.setOptions({ maxLines: val });
+      if (!this.isResizable) {
+        this.editor!.setOptions({ maxLines: val });
+      }
     },
     height: function (): void {
       this.$nextTick(function () {
@@ -114,7 +132,7 @@ export default defineComponent({
 
     require("ace-builds/src-noconflict/ext-emmet");
 
-    const editor = (this.editor = ace.edit(this.$el));
+    const editor = (this.editor = ace.edit(this.$refs.root as HTMLElement));
 
     this.$emit("init", editor);
     editor.getSession().setUseWorker(false);
@@ -125,10 +143,13 @@ export default defineComponent({
       this.contextVariableSuggestions &&
       this.contextVariableSuggestions.length > 0;
     const autoCompleteDelay = shouldEnableAutoCompletion ? 150 : undefined;
+    // When resizable, ace must not auto-manage the container height via
+    // minLines/maxLines, since that fights with manually resizing it.
     editor.setOptions({
       ...(this.options || {}),
-      minLines: this.minLines,
-      maxLines: this.maxLines,
+      ...(this.isResizable
+        ? {}
+        : { minLines: this.minLines, maxLines: this.maxLines }),
       enableLiveAutocompletion: shouldEnableAutoCompletion,
       liveAutocompletionDelay: autoCompleteDelay,
     });
@@ -140,13 +161,25 @@ export default defineComponent({
     this.addContextVariableSuggestions();
     this.observeDarkMode();
     this.attachChangeEventToEditor();
+
+    if (this.isResizable) this.observeResize();
   },
   beforeUnmount: function () {
     this.editor!.destroy();
     this.editor!.container.remove();
     this.observer?.disconnect();
+    this.resizeObserver?.disconnect();
   },
   methods: {
+    /**
+     * Keep the ace renderer in sync when the container is manually resized
+     */
+    observeResize() {
+      this.resizeObserver = new ResizeObserver(() => {
+        this.editor!.resize();
+      });
+      this.resizeObserver.observe(this.$refs.root as HTMLElement);
+    },
     /**
      * Observe the dark mode and update the theme for the editor
      */

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/tests/AceEditorVue.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/tests/AceEditorVue.spec.ts
@@ -53,6 +53,11 @@ global.MutationObserver = jest.fn().mockImplementation(() => ({
   disconnect: jest.fn(),
 })) as unknown as typeof MutationObserver;
 
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  disconnect: jest.fn(),
+})) as unknown as typeof ResizeObserver;
+
 const createWrapper = async (options: { props?: Record<string, any> } = {}) => {
   const wrapper = shallowMount(AceEditorVue, {
     props: {
@@ -70,11 +75,14 @@ describe("AceEditorVue", () => {
   });
 
   describe("minLines prop", () => {
-    it("passes default minLines of 12 to editor setOptions on mount", async () => {
+    it("omits minLines/maxLines from editor setOptions on mount when minLines is 0 (resizable, default)", async () => {
       await createWrapper();
 
       expect(mockSetOptions).toHaveBeenCalledWith(
-        expect.objectContaining({ minLines: 12 }),
+        expect.not.objectContaining({ minLines: expect.anything() }),
+      );
+      expect(mockSetOptions).toHaveBeenCalledWith(
+        expect.not.objectContaining({ maxLines: expect.anything() }),
       );
     });
 
@@ -86,8 +94,8 @@ describe("AceEditorVue", () => {
       );
     });
 
-    it("calls setOptions when minLines prop changes", async () => {
-      const wrapper = await createWrapper();
+    it("calls setOptions when minLines prop changes away from 0", async () => {
+      const wrapper = await createWrapper({ props: { minLines: 5 } });
       jest.clearAllMocks();
 
       await wrapper.setProps({ minLines: 20 });
@@ -95,33 +103,85 @@ describe("AceEditorVue", () => {
 
       expect(mockSetOptions).toHaveBeenCalledWith({ minLines: 20 });
     });
+
+    it("does not call setOptions for minLines when staying resizable (minLines 0)", async () => {
+      const wrapper = await createWrapper();
+      jest.clearAllMocks();
+
+      await wrapper.setProps({ minLines: 0 });
+      await wrapper.vm.$nextTick();
+
+      expect(mockSetOptions).not.toHaveBeenCalled();
+    });
   });
 
   describe("maxLines prop", () => {
-    it("passes default maxLines of Infinity to editor setOptions on mount", async () => {
-      await createWrapper();
-
-      expect(mockSetOptions).toHaveBeenCalledWith(
-        expect.objectContaining({ maxLines: Infinity }),
-      );
-    });
-
-    it("passes custom maxLines to editor setOptions when prop is provided", async () => {
-      await createWrapper({ props: { maxLines: 30 } });
+    it("passes custom maxLines to editor setOptions when prop is provided alongside a non-zero minLines", async () => {
+      await createWrapper({ props: { minLines: 5, maxLines: 30 } });
 
       expect(mockSetOptions).toHaveBeenCalledWith(
         expect.objectContaining({ maxLines: 30 }),
       );
     });
 
-    it("calls setOptions when maxLines prop changes", async () => {
-      const wrapper = await createWrapper();
+    it("calls setOptions when maxLines prop changes and the editor is not resizable", async () => {
+      const wrapper = await createWrapper({ props: { minLines: 5 } });
       jest.clearAllMocks();
 
       await wrapper.setProps({ maxLines: 50 });
       await wrapper.vm.$nextTick();
 
       expect(mockSetOptions).toHaveBeenCalledWith({ maxLines: 50 });
+    });
+
+    it("does not call setOptions when maxLines prop changes while resizable (minLines 0)", async () => {
+      const wrapper = await createWrapper();
+      jest.clearAllMocks();
+
+      await wrapper.setProps({ maxLines: 50 });
+      await wrapper.vm.$nextTick();
+
+      expect(mockSetOptions).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("resizable class", () => {
+    it("applies the resizable class to the wrapper when minLines is 0 (default)", async () => {
+      const wrapper = await createWrapper();
+
+      expect(wrapper.classes()).toContain("resizable");
+    });
+
+    it("does not apply the resizable class to the wrapper when minLines is greater than 0", async () => {
+      const wrapper = await createWrapper({ props: { minLines: 5 } });
+
+      expect(wrapper.classes()).not.toContain("resizable");
+    });
+
+    it("toggles the resizable class reactively when minLines prop changes", async () => {
+      const wrapper = await createWrapper({ props: { minLines: 5 } });
+      expect(wrapper.classes()).not.toContain("resizable");
+
+      await wrapper.setProps({ minLines: 0 });
+
+      expect(wrapper.classes()).toContain("resizable");
+    });
+  });
+
+  describe("resize observer", () => {
+    it("observes the editor container for resize when resizable (minLines 0, default)", async () => {
+      await createWrapper();
+
+      expect(global.ResizeObserver).toHaveBeenCalled();
+      const instance = (global.ResizeObserver as jest.Mock).mock.results[0]
+        .value as { observe: jest.Mock };
+      expect(instance.observe).toHaveBeenCalled();
+    });
+
+    it("does not observe for resize when not resizable", async () => {
+      await createWrapper({ props: { minLines: 5 } });
+
+      expect(global.ResizeObserver).not.toHaveBeenCalled();
     });
   });
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/custom/ace-editor.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/custom/ace-editor.scss
@@ -3,3 +3,15 @@
     z-index: 0;
   }
 }
+
+.resizable {
+  width: 100%;
+  position: relative;
+}
+
+.resizable .ace_editor {
+  width: 100%;
+  height: 200px;
+  resize: vertical;
+  overflow: auto;
+}

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/custom/ace-editor.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/custom/ace-editor.scss
@@ -11,7 +11,7 @@
 
 .resizable .ace_editor {
   width: 100%;
-  height: 200px;
+  height: 320px;
   resize: vertical;
   overflow: auto;
 }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/config/FeatureFlagConfigurable.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/config/FeatureFlagConfigurable.groovy
@@ -25,8 +25,8 @@ class FeatureFlagConfigurable implements SystemConfigurable {
         guiConfig(
             'rundeck.feature.guiAceEditorMinLines',
             'Code Editor - Minimum Lines',
-            'Minimum number of visible lines in the ACE code editor rendered inside plugin configuration forms. Default: 20.',
-            '20',
+            'Minimum number of visible lines in the ACE code editor rendered inside plugin configuration forms. Set to 0 (default) to make the editor manually resizable via drag handle instead of auto-sizing to a fixed number of lines.',
+            '0',
             'Integer'
         ),
         guiConfig(


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

The original GSP-based script/plugin-config editor supported manual drag-to-resize. When it was converted to `AceEditorVue.vue`, the resize behavior became wonky — CSS `resize` fights with Ace's own auto-grow-to-content sizing, producing a jarring "jump" on resize or on typing a new line.

As a workaround, #10137 ([RUN-4277](https://pagerduty.atlassian.net/browse/RUN-4277)) introduced admin-configurable `minLines`/`maxLines` props on `AceEditorVue.vue`, letting Ace auto-size the editor instead of relying on manual resize. #10536 ([RUN-4862](https://pagerduty.atlassian.net/browse/RUN-4862)) later just raised the out-of-the-box default `minLines` from 12 to 20, since most users weren't aware the setting existed and kept seeing a tiny editor.

This PR re-introduces working manual resize by making it mutually exclusive with Ace's `minLines`/`maxLines` auto-sizing, instead of only supporting one or the other project-wide, and makes resizable the new out-of-the-box default.

**Describe the solution you've implemented**
- `AceEditorVue.vue` now wraps its root element in a `<div>` that gets a `resizable` class when `minLines === 0`.
- When resizable, `minLines`/`maxLines` are no longer passed to Ace's `setOptions` at all, so Ace's own auto-sizing doesn't fight the manual CSS resize. A `ResizeObserver` keeps Ace's internal renderer in sync when the container is dragged to a new size.
- When `minLines` is set to a non-zero value, behavior is unchanged from #10137/#10536: Ace manages height via `minLines`/`maxLines` auto-sizing, and manual resize is disabled.
- Added `.resizable .ace_editor { resize: vertical; overflow: auto; height: 320px; }` to `ace-editor.scss`, scoped to the new wrapper class. Height lives on `.ace_editor` itself (not the wrapper), so the wrapper grows to contain a manually-resized editor instead of the enlarged editor overlapping subsequent form fields.
- Changed the out-of-the-box default `minLines` from 20 back to **0** (manually resizable) in `RundeckConfigBase.java`, `base.gsp`, and the System Configuration description in `FeatureFlagConfigurable.groovy` — the config description now explains that 0 means the editor is manually resizable rather than auto-sized to a fixed line count. Admins can still opt back into the fixed-height auto-sizing behavior by configuring a non-zero `guiAceEditorMinLines`.
- Updated `AceEditorVue.spec.ts` to cover both the resizable (`minLines === 0`) and non-resizable (`minLines > 0`) code paths, the `resizable` class toggling, and the `ResizeObserver` wiring. Fixed a stale assertion in `pluginPropEdit.spec.ts` that still expected the old default of 20.

**Describe alternatives you've considered**
Considered fully removing Ace's `minLines`/`maxLines` auto-sizing (from #10137) in favor of manual resize only, but that would break existing consumers/admins relying on the configured auto-fit sizing. Making the two modes mutually exclusive (gated on whether `minLines` is set) keeps both available without them conflicting, per Ace's own limitation that it doesn't handle auto-sizing and manual resize at the same time.

**Additional context**
Verified manually via the job creation Script step editor: with `minLines` unset (default), the editor is resizable and dragging it larger correctly pushes subsequent form fields down without overlap or jumping. With `minLines` set to a non-zero value (e.g. 20), the editor auto-fits its content with no resize handle, matching #10137/#10536 behavior for that mode.

- Related: [RUN-4277](https://pagerduty.atlassian.net/browse/RUN-4277) (#10137), [RUN-4862](https://pagerduty.atlassian.net/browse/RUN-4862) (#10536), #10321

## Release Notes

The ACE code editor is now manually resizable via drag handle by default (0 minimum lines). Admins can restore the previous auto-fit behavior by configuring a non-zero minimum line count under System Configuration → GUI.

[RUN-4277]: https://pagerduty.atlassian.net/browse/RUN-4277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUN-4862]: https://pagerduty.atlassian.net/browse/RUN-4862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUN-4277]: https://pagerduty.atlassian.net/browse/RUN-4277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ