### PR TITLE
[RUN-4826] Fix jsch-scp failing on remote paths containing a colon (Windows drive letters)

### DIFF
--- a/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/ExtScp.java
+++ b/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/ExtScp.java
@@ -20,17 +20,28 @@ import com.dtolabs.rundeck.core.utils.SSHAgent;
 import com.dtolabs.rundeck.plugins.PluginLogger;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.DirectoryScanner;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.taskdefs.optional.ssh.Directory;
 import org.apache.tools.ant.taskdefs.optional.ssh.SSHUserInfo;
 import org.apache.tools.ant.taskdefs.optional.ssh.Scp;
+import org.apache.tools.ant.taskdefs.optional.ssh.ScpToMessage;
 import org.apache.tools.ant.types.FileSet;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
- * ExtScp is ...
+ * ExtScp extends Ant's {@link Scp} task for Rundeck. Host, port and credentials are configured directly on the task
+ * by {@code SSHTaskBuilder}; the remote destination is supplied verbatim through {@link #setRemotePath(String)} and
+ * uploaded by {@link #execute()} without going through Ant's {@code user@host:path} URI parsing, which splits on the
+ * last colon and therefore breaks Windows drive-letter paths such as {@code C:\WINDOWS\TEMP}.
  *
  * @author greg
  * @since 2014-03-20
@@ -47,6 +58,8 @@ public class ExtScp extends Scp implements SSHTaskBuilder.SCPInterface {
     private String toDir;
     private List<FileSet> fileSets;
     private String bindAddress;
+    private String remotePath;
+    private String localFile;
 
     @Override
     public void setTodir(final String aToUri) {
@@ -61,6 +74,126 @@ public class ExtScp extends Scp implements SSHTaskBuilder.SCPInterface {
         }
         fileSets.add(set);
         super.addFileset(set);
+    }
+
+    @Override
+    public void setLocalFile(final String aFromUri) {
+        this.localFile = aFromUri;
+        super.setLocalFile(aFromUri);
+    }
+
+    /**
+     * Set the remote destination path used verbatim by {@link #execute()}, bypassing Ant's URI parsing.
+     *
+     * @param remotePath remote file or directory path, may contain colons (e.g. Windows drive letters)
+     */
+    @Override
+    public void setRemotePath(final String remotePath) {
+        this.remotePath = remotePath;
+    }
+
+    /**
+     * @return the remote path set via {@link #setRemotePath(String)}, or null
+     */
+    public String getIfaceRemotePath() {
+        return remotePath;
+    }
+
+    /**
+     * Upload the local file or nested filesets to {@link #setRemotePath(String) remotePath} using the host and
+     * credentials already configured on this task. Falls back to Ant's {@link Scp#execute()} when no remote path
+     * was set. Mirrors Ant's error contract: failures are raised as {@link BuildException} with the task location
+     * when {@code failonerror} is true, otherwise logged.
+     *
+     * @throws BuildException on failure when failonerror is true
+     */
+    @Override
+    public void execute() throws BuildException {
+        if (remotePath == null) {
+            super.execute();
+            return;
+        }
+        try {
+            if (localFile == null && (fileSets == null || fileSets.isEmpty())) {
+                throw new BuildException("Either 'localFile' or one or more nested filesets are required.");
+            }
+            Session session = null;
+            try {
+                session = openSession();
+                if (localFile != null) {
+                    sendMessage(new ScpToMessage(getVerbose(), session, getProject().resolveFile(localFile), remotePath));
+                } else {
+                    final List<Directory> list = new ArrayList<>(fileSets.size());
+                    for (FileSet set : fileSets) {
+                        final Directory d = createDirectory(set);
+                        if (d != null) {
+                            list.add(d);
+                        }
+                    }
+                    if (!list.isEmpty()) {
+                        sendMessage(new ScpToMessage(getVerbose(), session, list, remotePath));
+                    }
+                }
+            } finally {
+                if (session != null) {
+                    session.disconnect();
+                }
+            }
+        } catch (final Exception e) {
+            if (getFailonerror()) {
+                if (e instanceof BuildException) {
+                    final BuildException be = (BuildException) e;
+                    if (be.getLocation() == null) {
+                        be.setLocation(getLocation());
+                    }
+                    throw be;
+                }
+                throw new BuildException(e);
+            }
+            log("Caught exception: " + e.getMessage(), Project.MSG_ERR);
+        }
+    }
+
+    /**
+     * Perform the transfer for a prepared message. Extracted so tests can intercept the message.
+     *
+     * @param message prepared upload message
+     * @throws IOException   on i/o error
+     * @throws JSchException on scp error
+     */
+    protected void sendMessage(final ScpToMessage message) throws IOException, JSchException {
+        message.setLogListener(this);
+        message.execute();
+    }
+
+    /**
+     * Build the {@link Directory} tree for a fileset, equivalent to Ant's private {@code Scp.createDirectory}.
+     *
+     * @param set fileset to scan
+     * @return directory tree, or null if the fileset matched no files
+     */
+    private Directory createDirectory(final FileSet set) {
+        final DirectoryScanner scanner = set.getDirectoryScanner(getProject());
+        final String[] files = scanner.getIncludedFiles();
+        if (files.length == 0) {
+            return null;
+        }
+        final Directory root = new Directory(scanner.getBasedir());
+        Stream.of(files).map(Directory::getPath).forEach(path -> {
+            Directory current = root;
+            File currentParent = scanner.getBasedir();
+            for (String element : path) {
+                final File file = new File(currentParent, element);
+                if (file.isDirectory()) {
+                    current.addDirectory(new Directory(file));
+                    current = current.getChild(file);
+                    currentParent = current.getDirectory();
+                } else if (file.isFile()) {
+                    current.addFile(file);
+                }
+            }
+        });
+        return root;
     }
 
     @Override

--- a/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/ExtScp.java
+++ b/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/ExtScp.java
@@ -22,6 +22,7 @@ import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
+import org.apache.tools.ant.Location;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.optional.ssh.Directory;
 import org.apache.tools.ant.taskdefs.optional.ssh.SSHUserInfo;
@@ -141,14 +142,11 @@ public class ExtScp extends Scp implements SSHTaskBuilder.SCPInterface {
             }
         } catch (final Exception e) {
             if (getFailonerror()) {
-                if (e instanceof BuildException) {
-                    final BuildException be = (BuildException) e;
-                    if (be.getLocation() == null) {
-                        be.setLocation(getLocation());
-                    }
-                    throw be;
+                final BuildException be = e instanceof BuildException ? (BuildException) e : new BuildException(e);
+                if (be.getLocation() == null || Location.UNKNOWN_LOCATION.equals(be.getLocation())) {
+                    be.setLocation(getLocation());
                 }
-                throw new BuildException(e);
+                throw be;
             }
             log("Caught exception: " + e.getMessage(), Project.MSG_ERR);
         }

--- a/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/ExtScp.java
+++ b/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/ExtScp.java
@@ -118,22 +118,25 @@ public class ExtScp extends Scp implements SSHTaskBuilder.SCPInterface {
             if (localFile == null && (fileSets == null || fileSets.isEmpty())) {
                 throw new BuildException("Either 'localFile' or one or more nested filesets are required.");
             }
+            final List<Directory> list = new ArrayList<>();
+            if (localFile == null) {
+                for (FileSet set : fileSets) {
+                    final Directory d = createDirectory(set);
+                    if (d != null) {
+                        list.add(d);
+                    }
+                }
+                if (list.isEmpty()) {
+                    return;
+                }
+            }
             Session session = null;
             try {
                 session = openSession();
                 if (localFile != null) {
                     sendMessage(new ScpToMessage(getVerbose(), session, getProject().resolveFile(localFile), remotePath));
                 } else {
-                    final List<Directory> list = new ArrayList<>(fileSets.size());
-                    for (FileSet set : fileSets) {
-                        final Directory d = createDirectory(set);
-                        if (d != null) {
-                            list.add(d);
-                        }
-                    }
-                    if (!list.isEmpty()) {
-                        sendMessage(new ScpToMessage(getVerbose(), session, list, remotePath));
-                    }
+                    sendMessage(new ScpToMessage(getVerbose(), session, list, remotePath));
                 }
             } finally {
                 if (session != null) {

--- a/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/SSHTaskBuilder.java
+++ b/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/SSHTaskBuilder.java
@@ -816,11 +816,6 @@ public class SSHTaskBuilder {
         if (null == remotepath) {
             throw new BuilderException("remotePath was not set");
         }
-        final String username = sshConnectionInfo.getUsername();
-        if (null == username) {
-            throw new BuilderException("username was not set");
-        }
-
 
         configureSSHBase(nodeentry, project, sshConnectionInfo, scp, loglevel, logger);
 
@@ -847,11 +842,6 @@ public class SSHTaskBuilder {
         if (null == remotePath) {
             throw new BuilderException("remotePath was not set");
         }
-        final String username = sshConnectionInfo.getUsername();
-        if (null == username) {
-            throw new BuilderException("username was not set");
-        }
-
         configureSSHBase(nodeentry, project, sshConnectionInfo, scp, loglevel, logger);
 
         scp.setTimeout(sshConnectionInfo.getTimeout());
@@ -891,11 +881,6 @@ public class SSHTaskBuilder {
         if (null == remotePath) {
             throw new BuilderException("remotePath was not set");
         }
-        final String username = sshConnectionInfo.getUsername();
-        if (null == username) {
-            throw new BuilderException("username was not set");
-        }
-
         configureSSHBase(nodeentry, project, sshConnectionInfo, scp, loglevel, logger);
 
         scp.setTimeout(sshConnectionInfo.getTimeout());

--- a/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/SSHTaskBuilder.java
+++ b/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/SSHTaskBuilder.java
@@ -844,6 +844,9 @@ public class SSHTaskBuilder {
         if (null == sourceFolder) {
             throw new BuilderException("sourceFolder was not set");
         }
+        if (null == remotePath) {
+            throw new BuilderException("remotePath was not set");
+        }
         final String username = sshConnectionInfo.getUsername();
         if (null == username) {
             throw new BuilderException("username was not set");
@@ -884,6 +887,9 @@ public class SSHTaskBuilder {
 
         if (null == files || files.size()==0) {
             throw new BuilderException("files was not set");
+        }
+        if (null == remotePath) {
+            throw new BuilderException("remotePath was not set");
         }
         final String username = sshConnectionInfo.getUsername();
         if (null == username) {

--- a/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/SSHTaskBuilder.java
+++ b/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/SSHTaskBuilder.java
@@ -321,6 +321,13 @@ public class SSHTaskBuilder {
         void addFileset(FileSet set);
 
         void setTodir(String aToUri);
+
+        /**
+         * Set the remote destination path verbatim (no {@code user@host:} prefix).
+         *
+         * @param remotePath remote path
+         */
+        void setRemotePath(String remotePath);
     }
 
     private static abstract class SSHBaseImpl implements SSHBaseInterface {
@@ -547,6 +554,10 @@ public class SSHTaskBuilder {
         public void addFileset(FileSet set) { instance.addFileset(set);}
 
         public void setTodir(String uri){instance.setTodir(uri);}
+
+        public void setRemotePath(String remotePath) {
+            instance.setRemotePath(remotePath);
+        }
 
     }
 
@@ -821,8 +832,7 @@ public class SSHTaskBuilder {
         //Set the local and remote file paths
 
         scp.setLocalFile(sourceFile.getAbsolutePath());
-        final String sshUriPrefix = username + "@" + nodeentry.extractHostname() + ":";
-        scp.setRemoteTofile(sshUriPrefix + remotepath);
+        scp.setRemotePath(remotepath);
     }
 
 
@@ -854,8 +864,7 @@ public class SSHTaskBuilder {
             scp.addFileset(set);
 
 
-        final String sshUriPrefix = username + "@" + nodeentry.extractHostname() + ":";
-        scp.setTodir(sshUriPrefix + remotePath);
+        scp.setRemotePath(remotePath);
 
     }
 
@@ -918,8 +927,7 @@ public class SSHTaskBuilder {
             top.setIncludes(dirpath);
         }
 
-        final String sshUriPrefix = username + "@" + nodeentry.extractHostname() + ":";
-        scp.setTodir(sshUriPrefix + remotePath);
+        scp.setRemotePath(remotePath);
     }
 
     public static class BuilderException extends Exception {

--- a/plugins/jsch-plugin/src/test/groovy/org/rundeck/plugins/jsch/net/SSHTaskBuilderSpec.groovy
+++ b/plugins/jsch-plugin/src/test/groovy/org/rundeck/plugins/jsch/net/SSHTaskBuilderSpec.groovy
@@ -17,13 +17,48 @@
 package org.rundeck.plugins.jsch.net
 
 import com.dtolabs.rundeck.core.common.INodeEntry
+import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import com.dtolabs.rundeck.core.execution.ExecutionListener
 import com.dtolabs.rundeck.core.utils.FileUtils
+import com.jcraft.jsch.JSchException
+import com.jcraft.jsch.Session
+import org.apache.tools.ant.BuildException
 import org.apache.tools.ant.Project
+import org.apache.tools.ant.taskdefs.optional.ssh.ScpToMessage
 import spock.lang.Specification
 
 import java.nio.file.Files
 import java.nio.file.Path
+
+/**
+ * ExtScp test double that records the host the task would connect to and aborts before any network I/O.
+ */
+class HostCapturingScp extends ExtScp {
+    String capturedHost
+
+    @Override
+    protected Session openSession() throws JSchException {
+        capturedHost = getHost()
+        throw new JSchException('test-abort: no real connection')
+    }
+}
+
+/**
+ * ExtScp test double that captures the prepared upload message instead of transferring anything.
+ */
+class MessageCapturingScp extends ExtScp {
+    ScpToMessage captured
+
+    @Override
+    protected Session openSession() throws JSchException {
+        return null
+    }
+
+    @Override
+    protected void sendMessage(final ScpToMessage message) {
+        captured = message
+    }
+}
 
 /**
  * @author greg
@@ -106,7 +141,7 @@ class SSHTaskBuilderSpec extends Specification {
         result != null
         result instanceof ExtScp
         ExtScp built = (ExtScp) result
-        built.getIfaceToDir() == 'bob@ahostname:monkey/test'
+        built.getIfaceRemotePath() == 'monkey/test'
         built.getIfaceFileSets() != null
         built.getIfaceFileSets().size() == 1
         built.getIfaceFileSets()[0].getDir() == basedir
@@ -164,7 +199,7 @@ class SSHTaskBuilderSpec extends Specification {
         result != null
         result instanceof ExtScp
         ExtScp built = (ExtScp) result
-        built.getIfaceToDir() == 'bob@ahostname:monkey/test'
+        built.getIfaceRemotePath() == 'monkey/test'
         built.getIfaceFileSets() != null
         built.getIfaceFileSets().size() == 1
         built.getIfaceFileSets()[0].getDir() == basedir
@@ -224,7 +259,7 @@ class SSHTaskBuilderSpec extends Specification {
         result != null
         result instanceof ExtScp
         ExtScp built = (ExtScp) result
-        built.getIfaceToDir() == 'bob@ahostname:monkey/test'
+        built.getIfaceRemotePath() == 'monkey/test'
         built.getIfaceFileSets() != null
         built.getIfaceFileSets().size() == 1
         built.getIfaceFileSets()[0].getDir() == basedir
@@ -381,5 +416,278 @@ class SSHTaskBuilderSpec extends Specification {
 
         built.getBindAddress() == "192.168.0.120"
 
+    }
+
+    def "windows remote path with colon does not corrupt scp host"() {
+        given:
+        def scp = new HostCapturingScp()
+        def keyfile = Files.createTempFile(testDir, 'key', 'file').toFile()
+        def sourceFile = Files.createTempFile(testDir, 'src', 'file').toFile()
+        def node = Mock(INodeEntry) {
+            extractHostname() >> 'ahostname'
+        }
+        def nodeAuthentication = Mock(SSHTaskBuilder.SSHConnectionInfo) {
+            getUsername() >> 'bob'
+            getAuthenticationType() >> SSHTaskBuilder.AuthenticationType.privateKey
+            getPrivateKeyfilePath() >> keyfile.absolutePath
+        }
+        SSHTaskBuilder.buildScp(
+                scp,
+                node,
+                new Project(),
+                'C:\\WINDOWS\\TEMP\\test.bat',
+                sourceFile,
+                nodeAuthentication,
+                0,
+                Mock(ExecutionListener)
+        )
+
+        when:
+        scp.execute()
+
+        then:
+        thrown(BuildException)
+        scp.capturedHost == 'ahostname'
+    }
+
+    SSHTaskBuilder.SSHConnectionInfo storageKeyAuth(String username = 'bob') {
+        Mock(SSHTaskBuilder.SSHConnectionInfo) {
+            getUsername() >> username
+            getAuthenticationType() >> SSHTaskBuilder.AuthenticationType.privateKey
+            getPrivateKeyStoragePath() >> 'keys/fake/path'
+            getPrivateKeyStorageData() >> {
+                new ByteArrayInputStream('data'.bytes)
+            }
+        }
+    }
+
+    def "single file remote path reaches scp transfer verbatim"() {
+        given:
+        def scp = new MessageCapturingScp()
+        def sourceFile = Files.createTempFile(testDir, 'src', 'file').toFile()
+        def node = Mock(INodeEntry) {
+            extractHostname() >> 'ahostname'
+        }
+        SSHTaskBuilder.buildScp(scp, node, new Project(), remotePath, sourceFile, storageKeyAuth(), 0, Mock(ExecutionListener))
+
+        when:
+        scp.execute()
+
+        then:
+        scp.captured != null
+        scp.captured.remotePath == remotePath
+        scp.captured.localFile == sourceFile
+        scp.host == 'ahostname'
+
+        where:
+        remotePath                    | _
+        'C:\\WINDOWS\\TEMP\\test.bat' | _
+        '/tmp/rundeck/test.sh'        | _
+        '/tmp/with:colon/test.sh'     | _
+        'monkey/test'                 | _
+    }
+
+    def "multi scp remote path reaches scp transfer verbatim"() {
+        given:
+        def scp = new MessageCapturingScp()
+        def basedir = copyDir.toFile()
+        def files = makeDirFiles(copyDir, ['test1.txt', 'sub1/test3.xml']).values().toList()
+        def node = Mock(INodeEntry) {
+            extractHostname() >> 'ahostname'
+        }
+        SSHTaskBuilder.buildMultiScp(scp, node, new Project(), basedir, files, 'C:\\WINDOWS\\TEMP', storageKeyAuth(), 0, Mock(ExecutionListener))
+
+        when:
+        scp.execute()
+
+        then:
+        scp.captured != null
+        scp.captured.remotePath == 'C:\\WINDOWS\\TEMP'
+        scp.captured.localFile == null
+        scp.host == 'ahostname'
+    }
+
+    def "recursive scp remote path reaches scp transfer verbatim"() {
+        given:
+        def scp = new MessageCapturingScp()
+        makeDirFiles(copyDir, ['test1.txt', 'sub1/test3.xml'])
+        def node = Mock(INodeEntry) {
+            extractHostname() >> 'ahostname'
+        }
+        SSHTaskBuilder.buildRecursiveScp(scp, node, new Project(), 'C:\\WINDOWS\\TEMP', copyDir.toFile(), storageKeyAuth(), 0, Mock(ExecutionListener))
+
+        when:
+        scp.execute()
+
+        then:
+        scp.captured != null
+        scp.captured.remotePath == 'C:\\WINDOWS\\TEMP'
+        scp.captured.localFile == null
+        scp.host == 'ahostname'
+    }
+
+    def "execute falls back to ant behavior when remotePath unset"() {
+        given:
+        def scp = new HostCapturingScp()
+        def keyfile = Files.createTempFile(testDir, 'key', 'file').toFile()
+        def sourceFile = Files.createTempFile(testDir, 'src', 'file').toFile()
+        scp.setProject(new Project())
+        scp.setFailonerror(true)
+        scp.setKeyfile(keyfile.absolutePath)
+        scp.setLocalFile(sourceFile.absolutePath)
+        scp.setRemoteTofile('bob@ahostname:/some/path')
+
+        when:
+        scp.execute()
+
+        then:
+        thrown(BuildException)
+        scp.capturedHost == 'ahostname'
+    }
+
+    def "execute failure honours failonerror and sets location"() {
+        given:
+        def scp = new HostCapturingScp()
+        def sourceFile = Files.createTempFile(testDir, 'src', 'file').toFile()
+        def node = Mock(INodeEntry) {
+            extractHostname() >> 'ahostname'
+        }
+        SSHTaskBuilder.buildScp(scp, node, new Project(), '/tmp/test.sh', sourceFile, storageKeyAuth(), 0, Mock(ExecutionListener))
+
+        when:
+        scp.execute()
+
+        then:
+        def e = thrown(BuildException)
+        e.location != null
+        e.cause instanceof JSchException
+    }
+
+    def "execute failure is logged when failonerror is false"() {
+        given:
+        def scp = new HostCapturingScp()
+        def sourceFile = Files.createTempFile(testDir, 'src', 'file').toFile()
+        def node = Mock(INodeEntry) {
+            extractHostname() >> 'ahostname'
+        }
+        SSHTaskBuilder.buildScp(scp, node, new Project(), '/tmp/test.sh', sourceFile, storageKeyAuth(), 0, Mock(ExecutionListener))
+        scp.setFailonerror(false)
+
+        when:
+        scp.execute()
+
+        then:
+        notThrown(BuildException)
+        scp.capturedHost == 'ahostname'
+    }
+
+    def "execute with remotePath and no localFile or filesets fails"() {
+        given:
+        def scp = new MessageCapturingScp()
+        scp.setProject(new Project())
+        scp.setFailonerror(true)
+        scp.setRemotePath('/tmp/test.sh')
+
+        when:
+        scp.execute()
+
+        then:
+        def e = thrown(BuildException)
+        e.message.contains('localFile')
+        scp.captured == null
+    }
+
+    def "buildScp with private key sets connection params and raw remote path"() {
+        given:
+        def built = new ExtScp()
+        def keyfile = Files.createTempFile(testDir, 'key', 'file').toFile()
+        def sourceFile = Files.createTempFile(testDir, 'src', 'file').toFile()
+        def project = new Project()
+        def nodeAuthentication = Mock(SSHTaskBuilder.SSHConnectionInfo) {
+            getUsername() >> 'testusername'
+            getAuthenticationType() >> SSHTaskBuilder.AuthenticationType.privateKey
+            getPrivateKeyfilePath() >> keyfile.absolutePath
+        }
+
+        when:
+        SSHTaskBuilder.buildScp(built, new NodeEntryImpl('hostname', 'nodename'), project, '/test/path', sourceFile, nodeAuthentication, 0, Mock(ExecutionListener))
+
+        then:
+        built.ifaceRemotePath == '/test/path'
+        built.host == 'hostname'
+        built.port == 22
+        built.keyfile == keyfile.absolutePath
+        built.userInfo.passphrase == ''
+        built.userInfo.password == null
+        built.userInfo.name == 'testusername'
+        !built.verbose
+        built.failonerror
+        built.userInfo.trust
+        built.knownhosts == null
+        built.project == project
+    }
+
+    def "buildScp with password auth"() {
+        given:
+        def built = new ExtScp()
+        def sourceFile = Files.createTempFile(testDir, 'src', 'file').toFile()
+        def nodeAuthentication = Mock(SSHTaskBuilder.SSHConnectionInfo) {
+            getUsername() >> 'testusername'
+            getAuthenticationType() >> SSHTaskBuilder.AuthenticationType.password
+            getPassword() >> 'passwordValue'
+        }
+
+        when:
+        SSHTaskBuilder.buildScp(built, new NodeEntryImpl('hostname', 'nodename'), new Project(), '/test/path', sourceFile, nodeAuthentication, 0, Mock(ExecutionListener))
+
+        then:
+        built.ifaceRemotePath == '/test/path'
+        built.host == 'hostname'
+        built.keyfile == null
+        built.userInfo.password == 'passwordValue'
+        built.userInfo.name == 'testusername'
+        built.failonerror
+        built.userInfo.trust
+    }
+
+    def "buildScp fails when username not set"() {
+        given:
+        def sourceFile = Files.createTempFile(testDir, 'src', 'file').toFile()
+        def nodeAuthentication = Mock(SSHTaskBuilder.SSHConnectionInfo) {
+            getUsername() >> null
+            getAuthenticationType() >> authType
+            getPassword() >> 'passwordValue'
+        }
+
+        when:
+        SSHTaskBuilder.buildScp(new ExtScp(), new NodeEntryImpl('hostname', 'nodename'), new Project(), '/test/path', sourceFile, nodeAuthentication, 0, Mock(ExecutionListener))
+
+        then:
+        def e = thrown(SSHTaskBuilder.BuilderException)
+        e.message == 'username was not set'
+
+        where:
+        authType << [SSHTaskBuilder.AuthenticationType.privateKey, SSHTaskBuilder.AuthenticationType.password]
+    }
+
+    def "buildScp fails when sourceFile not set"() {
+        when:
+        SSHTaskBuilder.buildScp(new ExtScp(), new NodeEntryImpl('hostname', 'nodename'), new Project(), '/test/path', null, storageKeyAuth('testusername'), 0, Mock(ExecutionListener))
+
+        then:
+        def e = thrown(SSHTaskBuilder.BuilderException)
+        e.message == 'sourceFile was not set'
+    }
+
+    def "buildScp fails when remotePath not set"() {
+        given:
+        def sourceFile = Files.createTempFile(testDir, 'src', 'file').toFile()
+
+        when:
+        SSHTaskBuilder.buildScp(new ExtScp(), new NodeEntryImpl('hostname', 'nodename'), new Project(), null, sourceFile, storageKeyAuth('testusername'), 0, Mock(ExecutionListener))
+
+        then:
+        def e = thrown(SSHTaskBuilder.BuilderException)
+        e.message == 'remotePath was not set'
     }
 }

--- a/plugins/jsch-plugin/src/test/groovy/org/rundeck/plugins/jsch/net/SSHTaskBuilderSpec.groovy
+++ b/plugins/jsch-plugin/src/test/groovy/org/rundeck/plugins/jsch/net/SSHTaskBuilderSpec.groovy
@@ -49,9 +49,11 @@ class HostCapturingScp extends ExtScp {
  */
 class MessageCapturingScp extends ExtScp {
     ScpToMessage captured
+    boolean sessionOpened
 
     @Override
     protected Session openSession() throws JSchException {
+        sessionOpened = true
         return null
     }
 
@@ -713,5 +715,22 @@ class SSHTaskBuilderSpec extends Specification {
         then:
         def e = thrown(SSHTaskBuilder.BuilderException)
         e.message == 'remotePath was not set'
+    }
+
+    def "execute does not open a session when filesets match no files"() {
+        given:
+        def scp = new MessageCapturingScp()
+        def node = Mock(INodeEntry) {
+            extractHostname() >> 'ahostname'
+        }
+        SSHTaskBuilder.buildRecursiveScp(scp, node, new Project(), '/tmp/dest', copyDir.toFile(), storageKeyAuth(), 0, Mock(ExecutionListener))
+
+        when:
+        scp.execute()
+
+        then:
+        notThrown(BuildException)
+        !scp.sessionOpened
+        scp.captured == null
     }
 }

--- a/plugins/jsch-plugin/src/test/groovy/org/rundeck/plugins/jsch/net/SSHTaskBuilderSpec.groovy
+++ b/plugins/jsch-plugin/src/test/groovy/org/rundeck/plugins/jsch/net/SSHTaskBuilderSpec.groovy
@@ -23,6 +23,7 @@ import com.dtolabs.rundeck.core.utils.FileUtils
 import com.jcraft.jsch.JSchException
 import com.jcraft.jsch.Session
 import org.apache.tools.ant.BuildException
+import org.apache.tools.ant.Location
 import org.apache.tools.ant.Project
 import org.apache.tools.ant.taskdefs.optional.ssh.ScpToMessage
 import spock.lang.Specification
@@ -553,13 +554,15 @@ class SSHTaskBuilderSpec extends Specification {
             extractHostname() >> 'ahostname'
         }
         SSHTaskBuilder.buildScp(scp, node, new Project(), '/tmp/test.sh', sourceFile, storageKeyAuth(), 0, Mock(ExecutionListener))
+        def location = new Location('jsch-scp-test', 7, 1)
+        scp.setLocation(location)
 
         when:
         scp.execute()
 
         then:
         def e = thrown(BuildException)
-        e.location != null
+        e.location == location
         e.cause instanceof JSchException
     }
 
@@ -685,6 +688,27 @@ class SSHTaskBuilderSpec extends Specification {
 
         when:
         SSHTaskBuilder.buildScp(new ExtScp(), new NodeEntryImpl('hostname', 'nodename'), new Project(), null, sourceFile, storageKeyAuth('testusername'), 0, Mock(ExecutionListener))
+
+        then:
+        def e = thrown(SSHTaskBuilder.BuilderException)
+        e.message == 'remotePath was not set'
+    }
+
+    def "buildRecursiveScp fails when remotePath not set"() {
+        when:
+        SSHTaskBuilder.buildRecursiveScp(new ExtScp(), new NodeEntryImpl('hostname', 'nodename'), new Project(), null, copyDir.toFile(), storageKeyAuth('testusername'), 0, Mock(ExecutionListener))
+
+        then:
+        def e = thrown(SSHTaskBuilder.BuilderException)
+        e.message == 'remotePath was not set'
+    }
+
+    def "buildMultiScp fails when remotePath not set"() {
+        given:
+        def files = makeDirFiles(copyDir, ['test1.txt']).values().toList()
+
+        when:
+        SSHTaskBuilder.buildMultiScp(new ExtScp(), new NodeEntryImpl('hostname', 'nodename'), new Project(), copyDir.toFile(), files, null, storageKeyAuth('testusername'), 0, Mock(ExecutionListener))
 
         then:
         def e = thrown(SSHTaskBuilder.BuilderException)

--- a/plugins/jsch-plugin/src/test/java/org/rundeck/plugins/jsch/net/TestSSHTaskBuilder.java
+++ b/plugins/jsch-plugin/src/test/java/org/rundeck/plugins/jsch/net/TestSSHTaskBuilder.java
@@ -33,7 +33,6 @@ import junit.framework.TestCase;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.optional.ssh.SSHUserInfo;
 import org.apache.tools.ant.types.Environment;
-import org.apache.tools.ant.types.FileSet;
 import org.rundeck.storage.api.PathUtil;
 import org.rundeck.storage.api.StorageException;
 
@@ -236,29 +235,6 @@ public class TestSSHTaskBuilder extends TestCase {
         @Override
         public void setCommandTimeout(long commandTimeout) {
             this.commandTimeout = commandTimeout;
-        }
-    }
-
-    static class testSCPInterface extends testSSHBaseInterface implements SSHTaskBuilder.SCPInterface {
-        String localFile;
-        String remoteTofile;
-        String dir;
-        FileSet fileSet;
-
-        public void setLocalFile(String localFile) {
-            this.localFile = localFile;
-        }
-
-        public void setRemoteTofile(String remoteTofile) {
-            this.remoteTofile = remoteTofile;
-        }
-
-        public void addFileset(FileSet set) {
-            this.fileSet = set;
-        }
-
-        public void setTodir(String aToUri) {
-            this.dir = aToUri;
         }
     }
 
@@ -481,11 +457,6 @@ public class TestSSHTaskBuilder extends TestCase {
             state.sshConnectionInfo, state.loglevel, pluginLogger);
     }
 
-    private void runBuildSCP(final testState state, final testSCPInterface test, PluginLogger pluginLogger) throws
-        SSHTaskBuilder.BuilderException {
-        SSHTaskBuilder.buildScp(test, state.node, state.project, state.remotePath,
-            state.sourceFile, state.sshConnectionInfo, state.loglevel, pluginLogger);
-    }
     PluginLogger testLogger = new PluginLogger() {
         @Override
         public void log(int level, String message) {
@@ -798,130 +769,5 @@ public class TestSSHTaskBuilder extends TestCase {
         } catch (SSHTaskBuilder.BuilderException e) {
             assertNotNull(e);
         }
-    }
-
-    public void testBuildSCPDefault() throws Exception {
-
-        final testState state = new testState();
-        final testSCPInterface test = new testSCPInterface();
-
-        state.sourceFile = testSourcefile;
-        state.remotePath = "/test/path";
-
-        runBuildSCP(state, test, testLogger);
-
-        assertEquals(testSourcefile.getAbsolutePath(), test.localFile);
-        assertEquals("testusername@hostname:/test/path", test.remoteTofile);
-
-        assertEquals("hostname", test.getHost());
-        assertEquals(0, test.getPort());
-        assertEquals(testKeyfile.getAbsolutePath(), test.getKeyfile());
-        assertEquals("", test.passphrase);
-        assertEquals(null, test.password);
-        assertEquals("testusername", test.username);
-        assertEquals(false, test.getVerbose());
-        assertInvariableBase(state, test);
-    }
-
-    public void testBuildSCPPassword() throws Exception {
-
-        final testState state = new testState();
-        final testSCPInterface test = new testSCPInterface();
-
-        state.sshConnectionInfo.authenticationType = SSHTaskBuilder.AuthenticationType.password;
-        state.sshConnectionInfo.password = "passwordValue";
-        state.sourceFile = testSourcefile;
-        state.remotePath = "/test/path";
-
-        runBuildSCP(state, test, testLogger);
-
-        assertEquals(testSourcefile.getAbsolutePath(), test.localFile);
-        assertEquals("testusername@hostname:/test/path", test.remoteTofile);
-
-        assertEquals("hostname", test.getHost());
-        assertEquals(0, test.getPort());
-        assertEquals(null, test.getKeyfile());
-        assertEquals(null, test.passphrase);
-        assertEquals("passwordValue", test.password);
-        assertEquals("testusername", test.username);
-        assertEquals(false, test.getVerbose());
-        assertInvariableBase(state, test);
-    }
-
-    public void testBuildSCPKeyNoUsername() throws Exception {
-
-        final testState state = new testState();
-        final testSCPInterface test = new testSCPInterface();
-
-        state.sourceFile = testSourcefile;
-        state.remotePath = "/test/path";
-
-        state.sshConnectionInfo.username = null;
-
-        //null username
-        try {
-            runBuildSCP(state, test, testLogger);
-            fail("Shouldn't succeed");
-        } catch (SSHTaskBuilder.BuilderException e) {
-            assertEquals("username was not set", e.getMessage());
-        }
-    }
-
-    public void testBuildSCPKeyPasswordUsername() throws Exception {
-
-        final testState state = new testState();
-        final testSCPInterface test = new testSCPInterface();
-
-
-        state.sshConnectionInfo.authenticationType = SSHTaskBuilder.AuthenticationType.password;
-        state.sshConnectionInfo.password = "passwordValue";
-        state.sourceFile = testSourcefile;
-        state.remotePath = "/test/path";
-
-        state.sshConnectionInfo.username = null;
-
-        //null username
-        try {
-            runBuildSCP(state, test, testLogger);
-            fail("Shouldn't succeed");
-        } catch (SSHTaskBuilder.BuilderException e) {
-            assertEquals("username was not set", e.getMessage());
-        }
-    }
-
-    public void testBuildSCPNoSourcefile() throws Exception {
-
-        final testState state = new testState();
-        final testSCPInterface test = new testSCPInterface();
-
-        state.sourceFile = null;
-        state.remotePath = "/test/path";
-
-        //null sourceFile
-        try {
-            runBuildSCP(state, test, testLogger);
-            fail("Shouldn't succeed");
-        } catch (SSHTaskBuilder.BuilderException e) {
-            assertEquals("sourceFile was not set", e.getMessage());
-        }
-
-    }
-
-    public void testBuildSCPNoRemotePath() throws Exception {
-
-        final testState state = new testState();
-        final testSCPInterface test = new testSCPInterface();
-
-        state.sourceFile = testSourcefile;
-        state.remotePath = null;
-
-        //null remotePath
-        try {
-            runBuildSCP(state, test, testLogger);
-            fail("Shouldn't succeed");
-        } catch (SSHTaskBuilder.BuilderException e) {
-            assertEquals("remotePath was not set", e.getMessage());
-        }
-
     }
 }


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. Since Rundeck 6.1.0 (ant-jsch 1.10.15 → 1.10.17) the `jsch-scp` file copier fails on every Windows node, and on any destination containing a colon:

```
Failed: HostNotFound: [jsch-scp] Failed copying the file: 192.168.1.50:C
```

Ant 1.10.16 changed the private `Scp.parseUri` to split host and path at the *last* colon (IPv6 fix, Ant BUG-ID 59160). Rundeck encoded the destination as `user@host:C:\WINDOWS\TEMP\<file>.bat`, which is now parsed as host `host:C`. Node executor (commands) and Unix destinations without a colon are unaffected. Last known good release is 6.0.1.

**Describe the solution you've implemented**

Stop round-tripping the destination through Ant's URI parsing. `SSHTaskBuilder.configureSSHBase()` already sets host, port, username and credentials directly on the task, so the `user@host:` prefix was only ever built for `parseUri` to tear apart again.

- `ExtScp` gains `setRemotePath(String)` and an `execute()` override that uploads with `ScpToMessage` using the remote path verbatim. When no remote path is set it falls back to Ant's `Scp.execute()`. The error contract is preserved: failures surface as `BuildException` with the task location and `failonerror` is honoured, so `JschScpFileCopier.handleBuildException` keeps mapping them to `FileCopierException` unchanged.
- `SSHTaskBuilder.buildScp` / `buildRecursiveScp` / `buildMultiScp` pass the raw remote path via `setRemotePath`; `SCPInterface` and `SCPImpl` expose the new method.
- `ant-jsch` stays at `${antVersion}` (1.10.17); no downgrade.

Tests: a regression test that captures the host at `openSession()` time (fails on `main` with `ahostname:C`), Spock coverage for Windows / Unix / colon-bearing destinations across the single-file, multi-file and recursive builders, the fallback path and the `failonerror` contract. The SCP cases of the JUnit 3 `TestSSHTaskBuilder` were migrated to `SSHTaskBuilderSpec` and removed from the JUnit class.

**Describe alternatives you've considered**

- Pinning `ant-jsch` back to 1.10.15: reintroduces the IPv6 bug, leaves colon-bearing paths broken by design, and silently re-breaks on the next dependency bump.
- Reimplementing a corrected `parseUri` in `ExtScp`: `parseUri`, `upload`, `download` and the URI fields are all private in Ant, so it would mean the same amount of code while keeping the unnecessary round-trip. Overriding `execute()` is the only available seam.
- The `sshj-scp` copier already passes the raw path with no `user@host:` prefix; this change follows that precedent.

**Additional context**

Verified end to end with a standalone build: a file node source with `osFamily="windows" file-copier="jsch-scp"` pointing at an unreachable host now logs `copying file: ... to: 'winnode:C:\WINDOWS\TEMP\1-2-winnode-dispatch-script.tmp.bat'`, then `Connecting to 192.168.1.50:22` and fails with a plain `ConnectionFailure: No route to host` instead of the mangled-host `HostNotFound`. A Unix node through `jsch-scp` behaves the same. `./gradlew :plugins:jsch-plugin:test`: 171 tests, 0 failures.

Backport to 6.1.x to be decided separately; the diff is kept contained to `plugins/jsch-plugin` for that purpose.

## Release Notes

Fixed the `jsch-scp` file copier failing with `HostNotFound: ... <host>:C` on Windows nodes (and on any destination path containing a colon) since 6.1.0. The remote path is now passed to the SCP transfer verbatim instead of being parsed from a `user@host:path` URI.