### PR TITLE
[RUN-4861] Support bare JSON array bodies in JsonUtil for MenuController#listExport

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3737,7 +3737,7 @@ if executed in cluster mode.
             // The request body here is a bare JSON array of job ids (not an object), sent by the
             // legacy (non-NextUI) job list page — see RUN-10468.
             def data = com.dtolabs.rundeck.util.JsonUtil.parseRequestBodyAsList(request)
-            def nextScheduled = data?.join(",")?.replaceAll(/"/, '')
+            def nextScheduled = data?.join(",")
             def query = new ScheduledExecutionQuery()
             query.idlist = nextScheduled
             query.projFilter = params.project

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3734,7 +3734,9 @@ if executed in cluster mode.
         def results=[:]
         if(request.format=='json' ) {
             // Grails 7: Parse body using Jackson instead of request.JSON
-            def data = com.dtolabs.rundeck.util.JsonUtil.parseRequestBody(request)
+            // The request body here is a bare JSON array of job ids (not an object), sent by the
+            // legacy (non-NextUI) job list page — see RUN-10468.
+            def data = com.dtolabs.rundeck.util.JsonUtil.parseRequestBodyAsList(request)
             def nextScheduled = data?.join(",")?.replaceAll(/"/, '')
             def query = new ScheduledExecutionQuery()
             query.idlist = nextScheduled

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/util/JsonUtil.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/util/JsonUtil.groovy
@@ -34,12 +34,61 @@ class JsonUtil {
     /**
      * Grails 7: Parse JSON from HttpServletRequest body using Jackson ObjectMapper.
      * This replaces the broken request.JSON property in Grails 7/Spring Boot 3.
-     * 
+     *
      * @param request HttpServletRequest with JSON body
-     * @return Parsed JSON as Map, or null if request body is empty or already consumed
+     * @return Parsed JSON as Map, or null if request body is empty, already consumed, or not a JSON object
      * @throws IOException if JSON parsing fails (but not if body is unavailable)
      */
     static Map parseRequestBody(HttpServletRequest request) throws IOException {
+        def content = readRequestBodyContent(request, 'parseRequestBody')
+        if (!content) {
+            return null
+        }
+
+        try {
+            return objectMapper.readValue(content, Map.class)
+        } catch (JsonProcessingException parseEx) {
+            // Body readable but not a JSON object (array, primitive, malformed) — return null
+            log.error("parseRequestBody: JSON parsing failed [${parseEx.class.simpleName}: ${parseEx.originalMessage}] — body was readable but not a JSON object")
+            return null
+        }
+    }
+
+    /**
+     * Grails 7: Parse a JSON array from HttpServletRequest body using Jackson ObjectMapper.
+     * Some endpoints (e.g. the legacy-UI job list export status request) send a bare JSON
+     * array as the request body rather than a JSON object; {@link #parseRequestBody} always
+     * expects an object and would fail to parse those requests (RUN-10468).
+     *
+     * @param request HttpServletRequest with a JSON array body
+     * @return Parsed JSON as a List, or null if request body is empty, already consumed, or not a JSON array
+     * @throws IOException if JSON parsing fails (but not if body is unavailable)
+     */
+    static List parseRequestBodyAsList(HttpServletRequest request) throws IOException {
+        def content = readRequestBodyContent(request, 'parseRequestBodyAsList')
+        if (!content) {
+            return null
+        }
+
+        try {
+            return objectMapper.readValue(content, List.class)
+        } catch (JsonProcessingException parseEx) {
+            // Body readable but not a JSON array (object, primitive, malformed) — return null
+            log.error("parseRequestBodyAsList: JSON parsing failed [${parseEx.class.simpleName}: ${parseEx.originalMessage}] — body was readable but not a JSON array")
+            return null
+        }
+    }
+
+    /**
+     * Reads the raw text content of a request body intended to contain JSON, or null if the
+     * content-type is not JSON or the body is empty/unavailable. Shared by
+     * {@link #parseRequestBody} and {@link #parseRequestBodyAsList}.
+     *
+     * @param request HttpServletRequest with JSON body
+     * @param logPrefix label used in log messages to identify the calling method
+     * @return the raw body content, or null
+     */
+    private static String readRequestBodyContent(HttpServletRequest request, String logPrefix) {
         def contentType = request.contentType
         if (contentType && !contentType.toLowerCase().contains('json')) {
             return null
@@ -57,7 +106,7 @@ class JsonUtil {
             // call, etc.) — fall back to reading raw bytes without the available() check.
             // Do NOT use available(): it returns only buffered bytes and silently truncates
             // data not yet in the local buffer on proxied/slow connections.
-            log.error("parseRequestBody: getReader() failed [${readerEx.class.simpleName}: ${readerEx.message}], falling back to getInputStream()")
+            log.error("${logPrefix}: getReader() failed [${readerEx.class.simpleName}: ${readerEx.message}], falling back to getInputStream()")
             try {
                 def bytes = request.getInputStream()?.readAllBytes()
                 if (bytes?.length > 0) {
@@ -65,21 +114,11 @@ class JsonUtil {
                 }
             } catch (Exception streamEx) {
                 // Both reader and stream unavailable — body cannot be read
-                log.error("parseRequestBody: getInputStream() also failed [${streamEx.class.simpleName}: ${streamEx.message}] — body is unreadable")
+                log.error("${logPrefix}: getInputStream() also failed [${streamEx.class.simpleName}: ${streamEx.message}] — body is unreadable")
             }
         }
 
-        if (!content?.trim()) {
-            return null
-        }
-
-        try {
-            return objectMapper.readValue(content, Map.class)
-        } catch (JsonProcessingException parseEx) {
-            // Body readable but not a JSON object (array, primitive, malformed) — return null
-            log.error("parseRequestBody: JSON parsing failed [${parseEx.class.simpleName}: ${parseEx.originalMessage}] — body was readable but not a JSON object")
-            return null
-        }
+        content?.trim() ? content : null
     }
 
     /**

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/util/JsonUtil.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/util/JsonUtil.groovy
@@ -37,9 +37,8 @@ class JsonUtil {
      *
      * @param request HttpServletRequest with JSON body
      * @return Parsed JSON as Map, or null if request body is empty, already consumed, or not a JSON object
-     * @throws IOException if JSON parsing fails (but not if body is unavailable)
      */
-    static Map parseRequestBody(HttpServletRequest request) throws IOException {
+    static Map parseRequestBody(HttpServletRequest request) {
         def content = readRequestBodyContent(request, 'parseRequestBody')
         if (!content) {
             return null
@@ -62,9 +61,8 @@ class JsonUtil {
      *
      * @param request HttpServletRequest with a JSON array body
      * @return Parsed JSON as a List, or null if request body is empty, already consumed, or not a JSON array
-     * @throws IOException if JSON parsing fails (but not if body is unavailable)
      */
-    static List parseRequestBodyAsList(HttpServletRequest request) throws IOException {
+    static List parseRequestBodyAsList(HttpServletRequest request) {
         def content = readRequestBodyContent(request, 'parseRequestBodyAsList')
         if (!content) {
             return null

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/util/JsonUtilSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/util/JsonUtilSpec.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dtolabs.rundeck.util
+
+import jakarta.servlet.http.HttpServletRequest
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class JsonUtilSpec extends Specification {
+
+    HttpServletRequest mockRequest(String contentType, String body) {
+        Mock(HttpServletRequest) {
+            getContentType() >> contentType
+            getReader() >> new BufferedReader(new StringReader(body ?: ''))
+        }
+    }
+
+    def "parseRequestBody parses a JSON object body"() {
+        given:
+        def request = mockRequest('application/json', '{"a":"b"}')
+
+        expect:
+        JsonUtil.parseRequestBody(request) == [a: 'b']
+    }
+
+    @Unroll
+    def "parseRequestBody returns null for #reason"() {
+        given:
+        def request = mockRequest(contentType, body)
+
+        expect:
+        JsonUtil.parseRequestBody(request) == null
+
+        where:
+        reason                  | contentType        | body
+        'a JSON array body'     | 'application/json' | '["a","b"]'
+        'a non-json contentType'| 'text/plain'       | '{"a":"b"}'
+        'an empty body'         | 'application/json' | ''
+    }
+
+    def "parseRequestBodyAsList parses a JSON array body"() {
+        // Reproduces the legacy job list page's POST /menu/listExport request body (RUN-10468),
+        // a bare array of job ids rather than a JSON object.
+        given:
+        def request = mockRequest('application/json', '["7add463a-93c1-4936-9ac0-01a25321554f","3b66b5b7-c066-46f9-9c4d-b448cb7cb990"]')
+
+        expect:
+        JsonUtil.parseRequestBodyAsList(request) == [
+            '7add463a-93c1-4936-9ac0-01a25321554f',
+            '3b66b5b7-c066-46f9-9c4d-b448cb7cb990'
+        ]
+    }
+
+    @Unroll
+    def "parseRequestBodyAsList returns null for #reason"() {
+        given:
+        def request = mockRequest(contentType, body)
+
+        expect:
+        JsonUtil.parseRequestBodyAsList(request) == null
+
+        where:
+        reason                   | contentType        | body
+        'a JSON object body'     | 'application/json' | '{"a":"b"}'
+        'a non-json contentType' | 'text/plain'       | '["a"]'
+        'an empty body'          | 'application/json' | ''
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1640,6 +1640,45 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
         !response.json.scmImportEnabled
     }
 
+    def "list Export parses bare JSON array body sent by legacy job list page"() {
+        // RUN-10468: the legacy (non-NextUI) job list page POSTs a bare JSON array of job ids
+        // as the request body, not a JSON object. Ensure it is parsed into query.idlist correctly
+        // instead of silently failing to parse (which previously left idlist null).
+        given:
+        controller.frameworkService = Mock(FrameworkService)
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor)
+        controller.aclFileManagerService = Mock(AclFileManagerService)
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService)
+        controller.scmService = Mock(ScmService)
+        def project = 'test'
+        def jobIds = ['7add463a-93c1-4936-9ac0-01a25321554f', '3b66b5b7-c066-46f9-9c4d-b448cb7cb990']
+
+        when:
+        request.method = 'POST'
+        request.JSON = jobIds
+        request.format = 'json'
+        params.project = project
+        controller.listExport()
+
+        then:
+        1 * controller.scheduledExecutionService.listWorkflows(
+            { ScheduledExecutionQuery query -> query.idlist == jobIds.join(",") },
+            _
+        ) >> [schedlist: []]
+        1 * controller.scheduledExecutionService.finishquery(_, _, _) >> [max: 20,
+                                                                           offset: 0,
+                                                                           paginateParams: [:],
+                                                                           displayParams: [:]]
+        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN,
+                                                                                            AuthConstants.ACTION_EXPORT,
+                                                                                            AuthConstants.ACTION_SCM_EXPORT]) >> false
+        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN,
+                                                                                            AuthConstants.ACTION_IMPORT,
+                                                                                            AuthConstants.ACTION_SCM_IMPORT]) >> false
+
+        response.status == 200
+    }
+
     @Unroll
     def "list export calls exportStatusForJobs when export is enabled"() {
         given:


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. Fixes #10468. The legacy (non-NextUI) job list page POSTs the visible job ids as a bare JSON array body to `POST /menu/listExport`, e.g. `["7add463a-...","3b66b5b7-..."]`, rather than a JSON object. `JsonUtil.parseRequestBody` (added as part of the Grails 7 migration, replacing the old `request.JSON` binding) always deserializes into `Map.class`, so this array body fails to parse (`MismatchedInputException: Cannot deserialize value of type LinkedHashMap from Array value`). This is logged as an ERROR on every legacy job list page view, and `listExport()` silently falls back to `idlist=null` instead of the intended comma-joined id list, since the parse failure is swallowed by safe navigation (`data?.join(...)`).

**Describe the solution you've implemented**

Added `JsonUtil.parseRequestBodyAsList(request)`, sharing the existing reader/fallback logic (extracted into `readRequestBodyContent`) but deserializing into `List.class`, and switched `MenuController#listExport` to use it instead of `parseRequestBody`. The other call sites of `parseRequestBody` are untouched since they all expect JSON objects.

**Describe alternatives you've considered**

Considered making `parseRequestBody` accept a target class/type parameter instead of adding a second method, but that would change the signature (and behavior) for the 9 other existing call sites that all expect a JSON object — a much larger blast radius for a fix that only needs to affect this one array-bodied endpoint.

**Additional context**

Added unit tests for `JsonUtil.parseRequestBody`/`parseRequestBodyAsList`, and extended `MenuControllerSpec` with a "list Export" case using a non-empty array body, asserting `idlist` is populated correctly (the existing test only used an empty array and didn't assert on `idlist`, so it didn't catch this regression). `JsonUtilSpec`: 8/8 passing. `MenuControllerSpec`: 157/158 passing (1 pre-existing unrelated skip).

This recreates the fix from #10535, which was closed after its branch was accidentally built on top of an unrelated commit from a different PR — this branch is cut cleanly from `main` with a single commit containing only this fix.

## Release Notes

Fixed the legacy (non-NextUI) job list page so that job ids are correctly parsed from the `POST /menu/listExport` request body, instead of silently failing to parse and logging an error on every page view.