### PR TITLE
Restore default-enabled ACL evaluation cache

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -399,7 +399,7 @@ beans={
     }
 
     authContextEvaluatorCacheManager(AuthContextEvaluatorCacheManager){
-        enabled = grailsApplication.config.getProperty("rundeck.auth.evaluation.cache.enabled", Boolean.class, false)
+        enabled = grailsApplication.config.getProperty("rundeck.auth.evaluation.cache.enabled", Boolean.class, true)
         expirationTime = grailsApplication.config.getProperty("rundeck.auth.evaluation.cache.expire", Long.class, 120)
         metricService = ref('metricService')
     }


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. `authContextEvaluatorCacheManager`'s `enabled` property (in `rundeckapp/grails-app/conf/spring/resources.groovy`) is supposed to default to enabled, but currently defaults to `false`.

The original bean definition (added in #6331, "ACL evaluation cache system") was:

    enabled = !(config.rundeck?.auth?.evaluation?.cache?.enabled in ["false", false])

which defaults to `true` (enabled unless explicitly set to `false`).

During the Grails 6→7 config API migration (commit `3ccae5e6e4`), this was mechanically rewritten to use the typed config API:

    enabled = config.getProperty("rundeck.auth.evaluation.cache.enabled", Boolean.class, false)

The negated condition doesn't map 1:1 onto `getProperty(key, type, default)`, so the default silently flipped to `false` in that conversion.

**Describe the solution you've implemented**

Restore the default to `true`, matching the originally intended behavior:

    enabled = config.getProperty("rundeck.auth.evaluation.cache.enabled", Boolean.class, true)

The cache is invalidated via the `acl.modified` event whenever an ACL policy file is written or deleted (`AuthorizationService#pathWasModified`) — the same invalidation path already used by `sourceCache` and `storedPolicyPathsCache` in the same class.

This cache is also more broadly used than it might look at first glance: it backs `BaseAuthContextEvaluator`'s `authorizeProjectResource(s)` / `authorizeApplicationResource*` methods, which `rundeckAuthContextProcessor` (`@Delegate`d into `BaseAuthContextProcessor`) exposes and which are used throughout `MenuController`, `ExecutionService`, `ScheduledExecutionService`, etc. — e.g. the job-list authorization check (`authorizeProjectResources`) evaluates every listed job against the current user's ACLs on every page load, and that benefits directly from this cache.

**Describe alternatives you've considered**

- Leaving the default as `false` and only documenting `rundeck.auth.evaluation.cache.enabled=true` as an opt-in setting. Rejected: this property isn't documented anywhere (docs site, config templates, or code comments), so almost no operator would discover it to opt in.
- Gating the fix on cluster-mode cache invalidation being fully implemented. Not necessary: this cache already invalidates locally on `acl.modified`, and other caches in `AuthorizationService`/`ProjectManagerService` already run unconditionally today with the same node-local, TTL-bounded staleness characteristics (no cluster-wide invalidation receiver either).

**Additional context**

Things I looked at while evaluating whether flipping this default back on is safe, noted here for reviewers rather than left implicit:

- *Cache key correctness*: `AuthContextEvaluatorCacheKey` compares/hashes on `username + roles + urn` for `UserAndRolesAuthContext` (the type actually used at runtime, `SubjectAuthContext`), not the object identity of the `AuthContext` instance — so cache hits work correctly across the per-request `AuthContext` objects created by `BaseAuthContextProvider`. There was a real bug of this kind early on (equality effectively fell back to self-comparison) but it was fixed in 2020 (`645947a61c`) and the invalidation-event wiring bug was fixed in 2021 (`9a2d230daa`); current code reflects both fixes.
- *Permission-change immediacy*: an ACL policy change invalidates the whole cache immediately. A user's *role assignment* change (e.g. LDAP group membership) is **not** picked up mid-session, but that's pre-existing behavior independent of this cache — `SetUserInterceptor` reuses the session's `Subject` (and therefore the same roles) until the next login, cache enabled or not.
- *Logout*: nothing currently invalidates cache entries on logout, but this isn't a correctness or leakage concern given the key includes username/roles/urn — a stale entry can only be matched by presenting the same identity again (i.e. logging back in with unchanged roles), which is the case where reusing the decision is actually correct.
- *Unbounded size*: the underlying Guava cache has no `maximumSize`, only `expireAfterWrite` (default 120m). For large job lists, `authorizeProjectResources` keys on the entire resource set passed in, so distinct pagination/filter/sort combinations produce distinct large-ish entries rather than one entry per job. This seems acceptable to ship as a default-on change (bounded by TTL, and this is the same growth/staleness trade-off other always-on caches in this codebase already make). Happy to add a `maximumSize` bound as a follow-up if there's a concrete number to target.
- *Observability gap found while checking the above*: `Util.addCacheMetrics` wires up `hitCount`/`missCount`/`evictionCount` gauges for this cache, but the underlying `CacheBuilder` never calls `.recordStats()`, so those gauges will read `0` regardless of real traffic once this cache is enabled (Guava only tracks stats when explicitly enabled). There's no way to tell from these metrics alone whether the cache is actually being hit after this change ships — `0` looks identical whether the cache is disabled or enabled-but-unmeasured. Not fixed in this PR to keep the diff to the one-line default restoration, but flagging it since anyone trying to verify this change's effect via those metrics will see `0` either way. Can follow up with a one-line `.recordStats()` addition if that's wanted before/alongside this rollout.

No behavior change beyond restoring the pre-2022 default. Operators who already set `rundeck.auth.evaluation.cache.enabled` explicitly (either value) are unaffected.

## Release Notes

Fixed: the ACL evaluation cache (`rundeck.auth.evaluation.cache.enabled`) now defaults to enabled again, restoring the behavior from before a Grails 7 migration config refactor unintentionally disabled it by default.
