### PR TITLE
[RUN-4552] Demote preauth filter identity/role logging from INFO to DEBUG

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/security/RundeckPreauthenticationRequestHeaderFilter.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/security/RundeckPreauthenticationRequestHeaderFilter.groovy
@@ -50,8 +50,8 @@ class RundeckPreauthenticationRequestHeaderFilter extends AbstractPreAuthenticat
         String forwardedUser = request.remoteUser  //in AJP this will be set by apache
         if(userNameHeader != null) {
             forwardedUser = request.getHeader(userNameHeader)
-            LOG.info("User header " + userNameHeader);
-            LOG.info("User / UUID recieved " + forwardedUser);
+            LOG.debug("User header " + userNameHeader);
+            LOG.debug("User / UUID received " + forwardedUser);
         }
         return forwardedUser
     }
@@ -68,8 +68,8 @@ class RundeckPreauthenticationRequestHeaderFilter extends AbstractPreAuthenticat
             // PreauthenticatedAttributeRoleSource
             forwardedRoles = request.getHeader(rolesHeader);
             request.setAttribute(rolesAttribute, forwardedRoles);
-            LOG.info("Roles header " + rolesHeader);
-            LOG.info("Roles received " + forwardedRoles);
+            LOG.debug("Roles header " + rolesHeader);
+            LOG.debug("Roles received " + forwardedRoles);
         }
         return forwardedRoles
     }


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Security finding (bugfix), [RUN-4552](https://pagerduty.atlassian.net/browse/RUN-4552), P3/Low, source [PS-1685](https://pagerduty.atlassian.net/browse/PS-1685). `RundeckPreauthenticationRequestHeaderFilter` logs the forwarded username and full role list at `INFO` on every request when header-based preauthentication is configured. That identity/authorization metadata then flows into any log aggregator or SIEM ingesting Rundeck's INFO logs — a minor compliance concern (personal data in logs) and a user/role inventory risk if logs are compromised. Gated on a non-default preauth topology, hence Low severity.

**Describe the solution you've implemented**

Demoted the four affected log statements in `RundeckPreauthenticationRequestHeaderFilter.groovy` from `LOG.info` to `LOG.debug` (lines logging the username header/value and the roles header/value). Also fixed the `recieved` → `received` typo flagged in the finding, while in the file.

**Describe alternatives you've considered**

Removing the log statements entirely — rejected, since DEBUG-level visibility into forwarded identity/roles is still useful for troubleshooting preauth header misconfiguration, without the always-on INFO exposure.

**Additional context**

No behavior change: existing unit tests in `RundeckPreauthenticationRequestHeaderFilterTest` (4 tests covering AJP and header-based principal/credential resolution) pass unchanged — verified locally, 0 failures/errors.

## Release Notes

Demoted preauthentication filter identity/role logging from INFO to DEBUG to reduce exposure of usernames and role assignments in log aggregators/SIEM.

[RUN-4552]: https://pagerduty.atlassian.net/browse/RUN-4552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ