### PR TITLE
[RUN-4814] Fix Log Output ignoring disabled Follow on large execution logs

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
@@ -272,9 +272,23 @@ export default defineComponent({
       }
       // Re-enable follow when the user scrolls back to the bottom.
       // logViewer.vue only honors this in node view (onNodeFollowChange).
-      if (atBottom && !this.follow) {
+      //
+      // `el.scrollHeight` comes from DynamicScroller's virtualized layout,
+      // which estimates any not-yet-measured item as `min-item-size` (2px).
+      // On a large, actively-streaming log most of the trailing entries are
+      // still unmeasured, so scrollHeight is understated and `atBottom` can
+      // fire while the user is nowhere near the real end. Only trust it once
+      // the last entry has actually been measured.
+      if (atBottom && !this.follow && this._isLastEntryMeasured()) {
         this.$emit("follow-change", true);
       }
+    },
+    _isLastEntryMeasured(): boolean {
+      const entries = this.entryOutputs;
+      if (entries.length === 0) return true;
+      const scroller = this.$refs.scroller as any;
+      const lastEntry = entries[entries.length - 1];
+      return !!scroller?.getItemSize?.(lastEntry);
     },
     scrollToLine() {
       if (this.follow) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/test/LogNodeChunk.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/test/LogNodeChunk.spec.ts
@@ -256,5 +256,73 @@ describe("LogNodeChunk.vue", () => {
     expect(scrollToBottomMock).toHaveBeenCalledTimes(follow?1:0);
   });
 
+  describe("_isLastEntryMeasured", () => {
+    it("returns true when there are no entries", () => {
+      const wrapper = createWrapper({ entries: [] });
+      expect((wrapper.vm as any)._isLastEntryMeasured()).toBe(true);
+    });
 
+    it("returns false when the last entry has not been measured yet", () => {
+      const wrapper = createWrapper();
+      (wrapper.vm as any).$refs.scroller.getItemSize = jest
+        .fn()
+        .mockReturnValue(0);
+      expect((wrapper.vm as any)._isLastEntryMeasured()).toBe(false);
+    });
+
+    it("returns true once the last entry has been measured", () => {
+      const wrapper = createWrapper();
+      (wrapper.vm as any).$refs.scroller.getItemSize = jest
+        .fn()
+        .mockReturnValue(20);
+      expect((wrapper.vm as any)._isLastEntryMeasured()).toBe(true);
+    });
+  });
+
+  describe("onScrollerScroll", () => {
+    // RUN-4814: on a large, actively-streaming log, DynamicScroller's
+    // scrollHeight underestimates the real content height while trailing
+    // entries are still unmeasured, so the naive "am I at the bottom?"
+    // check can fire long before the user actually reaches the last line.
+    const scrollEvent = (
+      scrollTop: number,
+      clientHeight = 500,
+      scrollHeight = 1000,
+    ) =>
+      ({
+        target: { scrollTop, clientHeight, scrollHeight },
+      }) as unknown as Event;
+
+    it("disables follow when the user scrolls up", () => {
+      const wrapper = createWrapper({ follow: true });
+      const vm = wrapper.vm as any;
+
+      vm.onScrollerScroll(scrollEvent(500)); // primes _prevScrollTop
+      vm.onScrollerScroll(scrollEvent(400)); // scrolls up
+
+      expect(wrapper.emitted("follow-change")?.[0]).toEqual([false]);
+    });
+
+    it("does not re-enable follow at the bottom while the last entry is still unmeasured", () => {
+      const wrapper = createWrapper({ follow: false });
+      const vm = wrapper.vm as any;
+      vm.$refs.scroller.getItemSize = jest.fn().mockReturnValue(0);
+
+      vm.onScrollerScroll(scrollEvent(490)); // primes _prevScrollTop
+      vm.onScrollerScroll(scrollEvent(500)); // 500 + 500 >= 1000 - 10 -> at bottom
+
+      expect(wrapper.emitted("follow-change")).toBeFalsy();
+    });
+
+    it("re-enables follow at the bottom once the last entry has been measured", () => {
+      const wrapper = createWrapper({ follow: false });
+      const vm = wrapper.vm as any;
+      vm.$refs.scroller.getItemSize = jest.fn().mockReturnValue(20);
+
+      vm.onScrollerScroll(scrollEvent(490)); // primes _prevScrollTop
+      vm.onScrollerScroll(scrollEvent(500)); // 500 + 500 >= 1000 - 10 -> at bottom
+
+      expect(wrapper.emitted("follow-change")?.[0]).toEqual([true]);
+    });
+  });
 });


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Bugfix. [RUN-4814] Log Output auto-scrolls to bottom even when Follow is disabled, on large, actively-streaming execution logs.

This only reproduces in the per-node inline output view (expanding a node/step's output on the Workflow tab of a running execution) with a large log — not in the main Log Output view, which is unaffected.

**Describe the solution you've implemented**
`LogNodeChunk.vue` renders log lines through `vue-virtual-scroller`'s `DynamicScroller` with `min-item-size="2"`. Any line not yet measured/rendered is estimated at 2px in `el.scrollHeight`. On a large, actively-streaming log there are always unmeasured lines below the viewport, so `scrollHeight` understates the real content height.

`onScrollerScroll`'s "did the user scroll back to the bottom?" check (`atBottom`) trusted that estimate, so it could fire — and silently re-enable Follow — while the user was nowhere near the actual end of the log, undoing the fact that they had just scrolled up to disable it.

The fix guards that re-enable with `DynamicScroller`'s own `getItemSize()`, which only returns a non-zero size once an item has actually been measured. We now only trust `atBottom` once the last entry has genuinely been rendered.

**Describe alternatives you've considered**
- Removing the scroll-to-bottom auto re-enable entirely, requiring an explicit user action instead (simpler, but removes existing UX behavior on sm works correctly today).
- Bumping `min-item-size` to a more realistic line height — reduces but doesn't eliminate the issue on very large logs, so it's a mitigation rather than a fix.

Went with the measured-size guard since it fixes the root cause with a small, contained change and no user-facing behavior change on logs where the bug doesn't reproduce.

**Additional context**
Root cause and repro confirmed manually against a local instance: a job streaming several thousand lines slowly, expanding the node's inline outputing the view snap back to the bottom on its own.

## Release Notes

Fixed: Log Output could ignore a disabled "Follow" toggle and keep auto-scrolling to the bottom on large, actively-streaming execution logs.

[RUN-4814]: https://pagerduty.atlassian.net/browse/RUN-4814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ