### PR TITLE
[RUN-4938] Rework release tag creation flow in setversion.sh

### DIFF
--- a/release-tag.sh
+++ b/release-tag.sh
@@ -24,9 +24,18 @@ function git() {
                 ;;
             # `git tag` with no args, or with -l/--list, is a read-only listing.
             # Anything else (creating a tag, -d/--delete, etc.) is a write.
+            # Matched as exact arguments, not substring, so a tag message
+            # containing "-l" or "--list" can't be misclassified as a listing.
             tag)
                 shift
-                if [ $# -eq 0 ] || [[ " $* " == *" -l "* || " $* " == *" --list"* ]]; then
+                local is_list=false
+                for arg in "$@"; do
+                    if [ "$arg" = "-l" ] || [ "$arg" = "--list" ]; then
+                        is_list=true
+                        break
+                    fi
+                done
+                if [ $# -eq 0 ] || [ "$is_list" = true ]; then
                     command git tag "$@"
                 else
                     echo "[DRY-RUN] git tag $*"

--- a/release-tag.sh
+++ b/release-tag.sh
@@ -2,9 +2,9 @@
 #
 # release-tag.sh - creates (and optionally pushes) an annotated git tag at a specific commit.
 #
-# This is the single mechanism used to cut release tags. It has no opinion about GA/rc/alpha/RBA -
+# This is the single mechanism used to cut release tags. It has no opinion about GA/rc/alpha -
 # the caller resolves the tag name and target commit and hands them here. Shared by:
-#   - setversion.sh, for GA / rc1 / alpha# / RBA (it resolves tag name + commit itself)
+#   - setversion.sh, for GA / rc1 / alpha# (it resolves tag name + commit itself)
 #   - external release tooling, for rc2+ (check rdcore)
 #
 # Can be sourced for its create_and_push_tag() function (callers set PUSH_TO_ORIGIN/DRY_RUN
@@ -22,13 +22,14 @@ function git() {
             rev-parse|show-ref|diff|log|status|branch|ls-remote|symbolic-ref)
                 command git "$@"
                 ;;
-            # `git tag -l`/`--list` is read-only; only `-a`/create is a write
+            # `git tag` is read-only by default (listing, with or without -l/--list/--sort/etc);
+            # only creating (-a/--annotate) or deleting (-d/--delete) a tag is a write.
             tag)
-                if [[ " $* " == *" -l "* || " $* " == *" --list"* ]]; then
-                    command git "$@"
-                else
+                if [[ " $* " == *" -a "* || " $* " == *" --annotate"* || " $* " == *" -d "* || " $* " == *" --delete"* ]]; then
                     echo "[DRY-RUN] git $*"
                     return 0
+                else
+                    command git "$@"
                 fi
                 ;;
             # Write commands - just show what would be done
@@ -57,23 +58,29 @@ function create_and_push_tag {
 
     if [ -z "$TAG_NAME" ] || [ -z "$COMMIT_REF" ]; then
         echo "Error: create_and_push_tag requires a tag name and a commit"
-        exit 5
+        return 5
     fi
 
     if ! git rev-parse --verify "${COMMIT_REF}^{commit}" >/dev/null 2>&1; then
         echo "Error: Commit '$COMMIT_REF' not found in repository"
-        exit 5
+        return 5
     fi
     local TARGET_COMMIT
     TARGET_COMMIT="$(git rev-parse "${COMMIT_REF}^{commit}")"
 
     echo "Creating tag: $TAG_NAME"
-    git tag -a "$TAG_NAME" "$TARGET_COMMIT" -m "$MESSAGE"
+    if ! git tag -a "$TAG_NAME" "$TARGET_COMMIT" -m "$MESSAGE"; then
+        echo "Error: Failed to create tag $TAG_NAME"
+        return 1
+    fi
     echo "Tag created: $TAG_NAME"
 
     if [ "$PUSH_TO_ORIGIN" = true ]; then
         echo "Pushing tag to remote..."
-        git push origin "$TAG_NAME"
+        if ! git push origin "$TAG_NAME"; then
+            echo "Error: Failed to push tag $TAG_NAME"
+            return 1
+        fi
         echo "Tag pushed to remote."
     else
         echo "Use 'git push origin $TAG_NAME' to push the tag to remote."

--- a/release-tag.sh
+++ b/release-tag.sh
@@ -26,14 +26,28 @@ function git() {
             # Anything else (creating a tag, -d/--delete, etc.) is a write.
             # Matched as exact arguments, not substring, so a tag message
             # containing "-l" or "--list" can't be misclassified as a listing.
+            # Options that take a following value (e.g. `-m <message>`) have
+            # their value skipped so it's never scanned as an option itself -
+            # otherwise a message whose entire value is "-l" would be
+            # misclassified as list mode and let a real tag creation through.
             tag)
                 shift
                 local is_list=false
+                local skip_next=false
                 for arg in "$@"; do
-                    if [ "$arg" = "-l" ] || [ "$arg" = "--list" ]; then
-                        is_list=true
-                        break
+                    if [ "$skip_next" = true ]; then
+                        skip_next=false
+                        continue
                     fi
+                    case "$arg" in
+                        -l|--list)
+                            is_list=true
+                            break
+                            ;;
+                        -m|--message|-F|--file|-u|--local-user|--cleanup)
+                            skip_next=true
+                            ;;
+                    esac
                 done
                 if [ $# -eq 0 ] || [ "$is_list" = true ]; then
                     command git tag "$@"

--- a/release-tag.sh
+++ b/release-tag.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# release-tag.sh - creates (and optionally pushes) a git tag at a specific commit.
+# release-tag.sh - creates (and optionally pushes) an annotated git tag at a specific commit.
 #
 # This is the single mechanism used to cut release tags. It has no opinion about GA/rc/alpha -
 # the caller resolves the tag name and target commit and hands them here. Shared by:
@@ -9,7 +9,7 @@
 #
 # Can be sourced for its create_and_push_tag() function (callers set PUSH_TO_ORIGIN/DRY_RUN
 # before calling), or invoked directly as a CLI:
-#   release-tag.sh <tag-name> <commit> [--push] [--dry-run] [--debug]
+#   release-tag.sh <tag-name> <commit> [message] [--push] [--dry-run] [--debug]
 
 : "${PUSH_TO_ORIGIN:=false}"
 : "${DRY_RUN:=false}"
@@ -47,14 +47,15 @@ function git() {
     fi
 }
 
-# create_and_push_tag <tag-name> <commit>
+# create_and_push_tag <tag-name> <commit> [message]
 #
-# Creates a tag named <tag-name> pointing at <commit>, and pushes it if
+# Creates an annotated tag named <tag-name> pointing at <commit>, and pushes it if
 # PUSH_TO_ORIGIN=true. Does not resolve branches, does not know about GA/rc/alpha -
 # the caller is responsible for deciding what <commit> should be.
 function create_and_push_tag {
     local TAG_NAME="$1"
     local COMMIT_REF="$2"
+    local MESSAGE="${3:-Release $TAG_NAME}"
 
     if [ -z "$TAG_NAME" ] || [ -z "$COMMIT_REF" ]; then
         echo "Error: create_and_push_tag requires a tag name and a commit"
@@ -69,7 +70,7 @@ function create_and_push_tag {
     TARGET_COMMIT="$(git rev-parse "${COMMIT_REF}^{commit}")"
 
     echo "Creating tag: $TAG_NAME"
-    if ! git tag "$TAG_NAME" "$TARGET_COMMIT"; then
+    if ! git tag -a -m "$MESSAGE" "$TAG_NAME" "$TARGET_COMMIT"; then
         echo "Error: Failed to create tag $TAG_NAME"
         return 1
     fi
@@ -90,7 +91,7 @@ function create_and_push_tag {
 # Allow running this file directly as a CLI, not just sourcing it for the function
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     function usage {
-        echo "Usage: release-tag.sh <tag-name> <commit> [--push] [--dry-run] [--debug]"
+        echo "Usage: release-tag.sh <tag-name> <commit> [message] [--push] [--dry-run] [--debug]"
         exit 2
     }
 
@@ -122,5 +123,5 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         usage
     fi
 
-    create_and_push_tag "$1" "$2"
+    create_and_push_tag "$1" "$2" "$3"
 fi

--- a/release-tag.sh
+++ b/release-tag.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# release-tag.sh - creates (and optionally pushes) an annotated git tag at a specific commit.
+# release-tag.sh - creates (and optionally pushes) a git tag at a specific commit.
 #
 # This is the single mechanism used to cut release tags. It has no opinion about GA/rc/alpha -
 # the caller resolves the tag name and target commit and hands them here. Shared by:
@@ -9,7 +9,7 @@
 #
 # Can be sourced for its create_and_push_tag() function (callers set PUSH_TO_ORIGIN/DRY_RUN
 # before calling), or invoked directly as a CLI:
-#   release-tag.sh <tag-name> <commit> [message] [--push] [--dry-run] [--debug]
+#   release-tag.sh <tag-name> <commit> [--push] [--dry-run] [--debug]
 
 : "${PUSH_TO_ORIGIN:=false}"
 : "${DRY_RUN:=false}"
@@ -22,14 +22,15 @@ function git() {
             rev-parse|show-ref|diff|log|status|branch|ls-remote|symbolic-ref)
                 command git "$@"
                 ;;
-            # `git tag` is read-only by default (listing, with or without -l/--list/--sort/etc);
-            # only creating (-a/--annotate) or deleting (-d/--delete) a tag is a write.
+            # `git tag` with no args, or with -l/--list, is a read-only listing.
+            # Anything else (creating a tag, -d/--delete, etc.) is a write.
             tag)
-                if [[ " $* " == *" -a "* || " $* " == *" --annotate"* || " $* " == *" -d "* || " $* " == *" --delete"* ]]; then
-                    echo "[DRY-RUN] git $*"
-                    return 0
+                shift
+                if [ $# -eq 0 ] || [[ " $* " == *" -l "* || " $* " == *" --list"* ]]; then
+                    command git tag "$@"
                 else
-                    command git "$@"
+                    echo "[DRY-RUN] git tag $*"
+                    return 0
                 fi
                 ;;
             # Write commands - just show what would be done
@@ -46,15 +47,14 @@ function git() {
     fi
 }
 
-# create_and_push_tag <tag-name> <commit> [message]
+# create_and_push_tag <tag-name> <commit>
 #
-# Creates an annotated tag named <tag-name> pointing at <commit>, and pushes it if
+# Creates a tag named <tag-name> pointing at <commit>, and pushes it if
 # PUSH_TO_ORIGIN=true. Does not resolve branches, does not know about GA/rc/alpha -
 # the caller is responsible for deciding what <commit> should be.
 function create_and_push_tag {
     local TAG_NAME="$1"
     local COMMIT_REF="$2"
-    local MESSAGE="${3:-Release $TAG_NAME}"
 
     if [ -z "$TAG_NAME" ] || [ -z "$COMMIT_REF" ]; then
         echo "Error: create_and_push_tag requires a tag name and a commit"
@@ -69,7 +69,7 @@ function create_and_push_tag {
     TARGET_COMMIT="$(git rev-parse "${COMMIT_REF}^{commit}")"
 
     echo "Creating tag: $TAG_NAME"
-    if ! git tag -a "$TAG_NAME" "$TARGET_COMMIT" -m "$MESSAGE"; then
+    if ! git tag "$TAG_NAME" "$TARGET_COMMIT"; then
         echo "Error: Failed to create tag $TAG_NAME"
         return 1
     fi
@@ -90,7 +90,7 @@ function create_and_push_tag {
 # Allow running this file directly as a CLI, not just sourcing it for the function
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     function usage {
-        echo "Usage: release-tag.sh <tag-name> <commit> [message] [--push] [--dry-run] [--debug]"
+        echo "Usage: release-tag.sh <tag-name> <commit> [--push] [--dry-run] [--debug]"
         exit 2
     }
 
@@ -122,5 +122,5 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         usage
     fi
 
-    create_and_push_tag "$1" "$2" "$3"
+    create_and_push_tag "$1" "$2"
 fi

--- a/release-tag.sh
+++ b/release-tag.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# release-tag.sh - creates (and optionally pushes) an annotated git tag at a specific commit.
+#
+# This is the single mechanism used to cut release tags. It has no opinion about GA/rc/alpha/RBA -
+# the caller resolves the tag name and target commit and hands them here. Shared by:
+#   - setversion.sh, for GA / rc1 / alpha# / RBA (it resolves tag name + commit itself)
+#   - external release tooling, for rc2+ (check rdcore)
+#
+# Can be sourced for its create_and_push_tag() function (callers set PUSH_TO_ORIGIN/DRY_RUN
+# before calling), or invoked directly as a CLI:
+#   release-tag.sh <tag-name> <commit> [message] [--push] [--dry-run] [--debug]
+
+: "${PUSH_TO_ORIGIN:=false}"
+: "${DRY_RUN:=false}"
+
+# Git wrapper function for dry-run support
+function git() {
+    if [ "$DRY_RUN" = true ]; then
+        case "$1" in
+            # Read-only commands - safe to execute
+            rev-parse|show-ref|diff|log|status|branch|ls-remote|symbolic-ref)
+                command git "$@"
+                ;;
+            # `git tag -l`/`--list` is read-only; only `-a`/create is a write
+            tag)
+                if [[ " $* " == *" -l "* || " $* " == *" --list"* ]]; then
+                    command git "$@"
+                else
+                    echo "[DRY-RUN] git $*"
+                    return 0
+                fi
+                ;;
+            # Write commands - just show what would be done
+            checkout|push|commit|add)
+                echo "[DRY-RUN] git $*"
+                return 0
+                ;;
+            *)
+                command git "$@"
+                ;;
+        esac
+    else
+        command git "$@"
+    fi
+}
+
+# create_and_push_tag <tag-name> <commit> [message]
+#
+# Creates an annotated tag named <tag-name> pointing at <commit>, and pushes it if
+# PUSH_TO_ORIGIN=true. Does not resolve branches, does not know about GA/rc/alpha -
+# the caller is responsible for deciding what <commit> should be.
+function create_and_push_tag {
+    local TAG_NAME="$1"
+    local COMMIT_REF="$2"
+    local MESSAGE="${3:-Release $TAG_NAME}"
+
+    if [ -z "$TAG_NAME" ] || [ -z "$COMMIT_REF" ]; then
+        echo "Error: create_and_push_tag requires a tag name and a commit"
+        exit 5
+    fi
+
+    if ! git rev-parse --verify "${COMMIT_REF}^{commit}" >/dev/null 2>&1; then
+        echo "Error: Commit '$COMMIT_REF' not found in repository"
+        exit 5
+    fi
+    local TARGET_COMMIT
+    TARGET_COMMIT="$(git rev-parse "${COMMIT_REF}^{commit}")"
+
+    echo "Creating tag: $TAG_NAME"
+    git tag -a "$TAG_NAME" "$TARGET_COMMIT" -m "$MESSAGE"
+    echo "Tag created: $TAG_NAME"
+
+    if [ "$PUSH_TO_ORIGIN" = true ]; then
+        echo "Pushing tag to remote..."
+        git push origin "$TAG_NAME"
+        echo "Tag pushed to remote."
+    else
+        echo "Use 'git push origin $TAG_NAME' to push the tag to remote."
+    fi
+}
+
+# Allow running this file directly as a CLI, not just sourcing it for the function
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    function usage {
+        echo "Usage: release-tag.sh <tag-name> <commit> [message] [--push] [--dry-run] [--debug]"
+        exit 2
+    }
+
+    if [ -z "$1" ]; then
+        usage
+    fi
+
+    ARGS=()
+    for arg in "$@"; do
+        case "$arg" in
+            --push)
+                PUSH_TO_ORIGIN=true
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                echo "[DRY-RUN MODE] No changes will be made"
+                ;;
+            --debug|-v)
+                set -x
+                ;;
+            *)
+                ARGS+=("$arg")
+                ;;
+        esac
+    done
+    set -- "${ARGS[@]}"
+
+    if [ -z "$2" ]; then
+        usage
+    fi
+
+    create_and_push_tag "$1" "$2" "$3"
+fi

--- a/setversion.sh
+++ b/setversion.sh
@@ -10,7 +10,10 @@ function usage {
     echo "Usage:"
     echo "  setversion.sh <version> [GA|rc#|alpha#]                                              - Update version in version.properties"
     echo "  setversion.sh --bump-minor                                                           - Bump minor version number"
-    echo "  setversion.sh --tag <version> [GA|rc#|alpha#] [--push] [--dry-run] [--debug]        - Create git tag; checks out release branch if one exists for the version"
+    echo "  setversion.sh --tag <version> GA [--push] [--dry-run] [--debug]                     - Re-tag the highest existing v<version>-rcN tag as GA (no commit argument)"
+    echo "  setversion.sh --tag <version> rc1 <commit> [--push] [--dry-run] [--debug]           - Tag rc1 at an explicit commit (no release branch exists yet)"
+    echo "  setversion.sh --tag <version> alpha# <commit> [--push] [--dry-run] [--debug]         - Tag other pre-releases at an explicit commit"
+    echo "  (rc2+ is NOT handled by setversion.sh - it is owned by external release tooling, for rc2+ (check rdcore))"
     echo "  setversion.sh --create-release-branch <version> [<commit>] [--push] [--dry-run] [--debug]     - Create release branch for patch releases (branches from GA tag or specified commit)"
     echo ""
     echo "Flags:"
@@ -51,25 +54,9 @@ for arg in "$@"; do
 done
 set -- "${ARGS[@]}"  # Reset positional parameters without flags
 
-# Git wrapper function for dry-run support
-function git() {
-    if [ "$DRY_RUN" = true ]; then
-        case "$1" in
-            rev-parse|show-ref|diff|log|status|branch|ls-remote|symbolic-ref)
-                command git "$@"
-                ;;
-            checkout|tag|push|commit|add)
-                echo "[DRY-RUN] git $*"
-                return 0
-                ;;
-            *)
-                command git "$@"
-                ;;
-        esac
-    else
-        command git "$@"
-    fi
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=release-tag.sh
+source "$SCRIPT_DIR/release-tag.sh"  # provides create_and_push_tag() and the dry-run git() wrapper
 
 # Handle tag creation directly on main
 if [ "$1" == "--tag" ]; then
@@ -82,69 +69,63 @@ if [ "$1" == "--tag" ]; then
     VNUM="$1"
     shift
     VTAG="${1:-GA}"
+    shift
 
-    # Create the appropriate tag
+    # rc2+ is not handled here - checking out an existing release branch and tagging its HEAD
+    # is owned by external release tooling, for rc2+ (check rdcore), which calls release-tag.sh
+    # directly once it has resolved the branch and commit itself.
+    if [[ "$VTAG" =~ ^rc([0-9]+)$ ]] && [ "${BASH_REMATCH[1]}" -ge 2 ]; then
+        echo "Error: rc2+ releases are not created by setversion.sh."
+        echo "That flow is owned by external release tooling, for rc2+ (check rdcore)."
+        exit 13
+    fi
+
+    # Resolve the tag name and target commit for the release type; the actual tag
+    # creation/push is delegated to create_and_push_tag (release-tag.sh).
     if [ "$VTAG" == "GA" ]; then
+        if [ -n "$1" ]; then
+            echo "Error: GA does not take a commit argument - it re-tags the highest existing rc for the version."
+            exit 5
+        fi
+
         TAG_NAME="v$VNUM"
+
+        # GA is cut by re-tagging the highest existing RC for this version - never a fresh commit on main
+        HIGHEST_RC=""
+        HIGHEST_RC_NUM=-1
+        for RC_TAG in $(git tag -l "v${VNUM}-rc*"); do
+            RC_SUFFIX="${RC_TAG#v${VNUM}-rc}"
+            if [[ "$RC_SUFFIX" =~ ^[0-9]+$ ]] && [ "$RC_SUFFIX" -gt "$HIGHEST_RC_NUM" ]; then
+                HIGHEST_RC_NUM="$RC_SUFFIX"
+                HIGHEST_RC="$RC_TAG"
+            fi
+        done
+
+        if [ -z "$HIGHEST_RC" ]; then
+            echo "Error: No RC tag found matching v$VNUM-rcN. GA is cut by re-tagging the highest RC."
+            echo "Tag rc1 first with: setversion.sh --tag $VNUM rc1 <commit>"
+            exit 12
+        fi
+
+        TARGET_COMMIT="$HIGHEST_RC"
+        echo "Re-tagging highest RC $HIGHEST_RC as GA"
     elif [[ "$VTAG" =~ ^[a-z]+[0-9]+$ ]]; then
+        # rc1, alpha3, etc. - always tag an explicit commit, never a bare HEAD
         TAG_NAME="v$VNUM-$VTAG"
-    else
-      echo "Error: Invalid tag format '$VTAG'. Expected 'GA' or to match [a-z]+[0-9]+ (e.g., rc1, rc2, alpha3)."
-      exit 5
-    fi
-
-    IFS='.' read -r MAJOR MINOR PATCH <<< "$VNUM"
-    if [ -z "$MAJOR" ] || [ -z "$MINOR" ] || [ -z "$PATCH" ]; then
-        echo "Error: Version ($VNUM) must be in MAJOR.MINOR.PATCH format"
-        exit 3
-    fi
-
-    RELEASE_BRANCH="release/$MAJOR.$MINOR.x"
-    if git rev-parse --verify "$RELEASE_BRANCH" >/dev/null 2>&1 ||
-       git ls-remote --heads origin "$RELEASE_BRANCH" | grep -q "refs/heads/${RELEASE_BRANCH}$"; then
-        RELEASE_BRANCH_EXISTS=true
-    else
-        RELEASE_BRANCH_EXISTS=false
-    fi
-
-    if [ "$PATCH" -ne 0 ] && [ "$RELEASE_BRANCH_EXISTS" = false ]; then
-        echo "Error: Release branch $RELEASE_BRANCH does not exist."
-        echo "Create it first with: setversion.sh --create-release-branch $VNUM"
-        exit 9
-    fi
-
-    if [ "$RELEASE_BRANCH_EXISTS" = true ]; then
-        # Use the release branch (required for patch > 0; preferred for patch == 0 when a branch was cut early)
-        CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-        if [ "$CURRENT_BRANCH" != "$RELEASE_BRANCH" ]; then
-            echo "Checking out release branch: $RELEASE_BRANCH"
-            git checkout "$RELEASE_BRANCH" || exit 10
+        COMMIT_ARG="$1"
+        shift
+        if [ -z "$COMMIT_ARG" ]; then
+            echo "Error: '$VTAG' requires an explicit commit to tag."
+            echo "Usage: setversion.sh --tag $VNUM $VTAG <commit> [--push]"
+            exit 5
         fi
+        TARGET_COMMIT="$COMMIT_ARG"
     else
-        echo "No release branch $RELEASE_BRANCH found, tagging from current HEAD"
+        echo "Error: Invalid tag format '$VTAG'. Expected 'GA' or to match [a-z]+[0-9]+ (e.g., rc1, alpha3)."
+        exit 5
     fi
 
-    echo "Creating tag: $TAG_NAME"
-
-    # Verify we're on main or a release branch (skip in dry-run)
-    if [ "$DRY_RUN" = false ]; then
-        CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-        if [[ "$CURRENT_BRANCH" != "main" && ! "$CURRENT_BRANCH" =~ ^release/.* ]]; then
-            echo "Error: Must be on 'main' branch or a release branch to create release tags"
-            exit 4
-        fi
-    fi
-
-    git tag -a "$TAG_NAME" -m "Release $VNUM $VTAG"
-    echo "Tag created: $TAG_NAME"
-
-    if [ "$PUSH_TO_ORIGIN" = true ]; then
-        echo "Pushing tag to remote..."
-        git push origin "$TAG_NAME"
-        echo "Tag pushed to remote."
-    else
-        echo "Use 'git push origin $TAG_NAME' to push the tag to remote."
-    fi
+    create_and_push_tag "$TAG_NAME" "$TARGET_COMMIT" "Release $VNUM $VTAG"
     exit 0
 
 # Create a release branch for patch releases

--- a/setversion.sh
+++ b/setversion.sh
@@ -69,7 +69,7 @@ if [ "$1" == "--tag" ]; then
     VNUM="$1"
     shift
     VTAG="${1:-GA}"
-    shift
+    [ $# -gt 0 ] && shift
 
     # rc2+ is not handled here - checking out an existing release branch and tagging its HEAD
     # is owned by external release tooling, for rc2+ (check rdcore), which calls release-tag.sh
@@ -126,7 +126,7 @@ if [ "$1" == "--tag" ]; then
     fi
 
     create_and_push_tag "$TAG_NAME" "$TARGET_COMMIT" "Release $VNUM $VTAG"
-    exit 0
+    exit $?
 
 # Create a release branch for patch releases
 elif [ "$1" == "--create-release-branch" ]; then

--- a/setversion.sh
+++ b/setversion.sh
@@ -67,6 +67,10 @@ if [ "$1" == "--tag" ]; then
         usage
     fi
     VNUM="$1"
+    if [[ ! "$VNUM" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "Error: Version ($VNUM) must be in MAJOR.MINOR.PATCH format (e.g., 5.19.1)"
+        exit 3
+    fi
     shift
     VTAG="${1:-GA}"
     [ $# -gt 0 ] && shift
@@ -125,7 +129,7 @@ if [ "$1" == "--tag" ]; then
         exit 5
     fi
 
-    create_and_push_tag "$TAG_NAME" "$TARGET_COMMIT"
+    create_and_push_tag "$TAG_NAME" "$TARGET_COMMIT" "Release $VNUM $VTAG"
     exit $?
 
 # Create a release branch for patch releases

--- a/setversion.sh
+++ b/setversion.sh
@@ -113,19 +113,19 @@ if [ "$1" == "--tag" ]; then
         # rc1, alpha3, etc. - always tag an explicit commit, never a bare HEAD
         TAG_NAME="v$VNUM-$VTAG"
         COMMIT_ARG="$1"
-        shift
         if [ -z "$COMMIT_ARG" ]; then
             echo "Error: '$VTAG' requires an explicit commit to tag."
             echo "Usage: setversion.sh --tag $VNUM $VTAG <commit> [--push]"
             exit 5
         fi
+        shift
         TARGET_COMMIT="$COMMIT_ARG"
     else
         echo "Error: Invalid tag format '$VTAG'. Expected 'GA' or to match [a-z]+[0-9]+ (e.g., rc1, alpha3)."
         exit 5
     fi
 
-    create_and_push_tag "$TAG_NAME" "$TARGET_COMMIT" "Release $VNUM $VTAG"
+    create_and_push_tag "$TAG_NAME" "$TARGET_COMMIT"
     exit $?
 
 # Create a release branch for patch releases


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Enhancement: reworks how `setversion.sh --tag` creates release tags so that nothing ever falls back to silently tagging whatever commit is currently checked out on `main`.

**Describe the solution you've implemented**
- **GA**: no longer tags an arbitrary commit. It finds the highest existing `v<version>-rcN` tag and re-tags that exact commit as GA. Fails loudly if no RC tag exists for the version.
- **rc1 / alpha#**: now require an explicit `<commit>` argument (no release branch exists yet for rc1, so there's nothing safe to default to).
- **rc2+**: `setversion.sh` now refuses these outright — that flow (checking out the existing release branch and tagging its HEAD) is owned by external release tooling, for rc2+ (check rdcore).
- Extracted the actual tag creation/push mechanics into a new `release-tag.sh`, exposing `create_and_push_tag <tag-name> <commit> [message]`. It's policy-free (no GA/rc/alpha logic) and can be sourced or run standalone as a CLI, so the same primitive is used both by `setversion.sh` and by external tooling once it has resolved its own tag name/commit.
- Fixed a pre-existing dry-run bug where the `git()` wrapper treated all `git tag` invocations (including read-only `git tag -l`) as writes, which would have silently broken GA's RC lookup under `--dry-run`.

**Describe alternatives you've considered**
Considered keeping all tag-type policy (GA/rc/alpha) inside the shared `release-tag.sh` script, but that would require the rc2+ external tooling to route through policy logic (branch existence checks, etc.) it doesn't need. Keeping `release-tag.sh` as a pure "tag this commit" primitive keeps it usable by both callers without either one carrying the other's assumptions.

**Additional context**
Companion PR in rundeckpro applies the equivalent change to its own `setversion.sh`/`release-tag.sh` (which additionally has an `RBA` tag type, now requiring both core-sha and pro-sha explicitly instead of defaulting pro-sha to current HEAD).

## Release Notes

N/A - internal release tooling change, no user-facing behavior.

