### PR TITLE
[RUN-4942] Eliminate recurring Gradle sourcesJar build warning

### DIFF
--- a/grails-execution-mode-timer/build.gradle
+++ b/grails-execution-mode-timer/build.gradle
@@ -26,6 +26,12 @@ plugins {
 
 apply plugin:"eclipse"
 apply plugin:"idea"
+// Pre-register sourcesJar before the grails-plugin applies: it synchronously checks for this
+// task inside its own apply() and logs "A sourcesJar task was not found, creating one." if missing.
+tasks.register('sourcesJar', Jar) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+}
 apply plugin:"org.apache.grails.gradle.grails-plugin"
 apply plugin:"org.apache.grails.gradle.grails-gsp"
 

--- a/grails-job-kill-handler/build.gradle
+++ b/grails-job-kill-handler/build.gradle
@@ -24,6 +24,12 @@ plugins {
 
 apply plugin:"eclipse"
 apply plugin:"idea"
+// Pre-register sourcesJar before the grails-plugin applies: it synchronously checks for this
+// task inside its own apply() and logs "A sourcesJar task was not found, creating one." if missing.
+tasks.register('sourcesJar', Jar) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+}
 apply plugin:"org.apache.grails.gradle.grails-plugin"
 apply plugin:"org.apache.grails.gradle.grails-gsp"
 

--- a/grails-metricsweb/build.gradle
+++ b/grails-metricsweb/build.gradle
@@ -27,6 +27,12 @@ group "metricsweb"
 
 apply plugin: "eclipse"
 apply plugin: "idea"
+// Pre-register sourcesJar before the grails-plugin applies: it synchronously checks for this
+// task inside its own apply() and logs "A sourcesJar task was not found, creating one." if missing.
+tasks.register('sourcesJar', Jar) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+}
 apply plugin: "org.apache.grails.gradle.grails-plugin"
 apply plugin: "org.apache.grails.gradle.grails-gsp"
 apply plugin: "java-library"

--- a/grails-persistlocale/build.gradle
+++ b/grails-persistlocale/build.gradle
@@ -26,6 +26,12 @@ group "org.rundeck.grails.plugins.persistlocale"
 
 apply plugin:"eclipse"
 apply plugin:"idea"
+// Pre-register sourcesJar before the grails-plugin applies: it synchronously checks for this
+// task inside its own apply() and logs "A sourcesJar task was not found, creating one." if missing.
+tasks.register('sourcesJar', Jar) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+}
 apply plugin:"org.apache.grails.gradle.grails-plugin"
 apply plugin:"org.apache.grails.gradle.grails-gsp"
 

--- a/grails-repository/build.gradle
+++ b/grails-repository/build.gradle
@@ -26,6 +26,12 @@ group "repository"
 
 apply plugin:"eclipse"
 apply plugin:"idea"
+// Pre-register sourcesJar before the grails-plugin applies: it synchronously checks for this
+// task inside its own apply() and logs "A sourcesJar task was not found, creating one." if missing.
+tasks.register('sourcesJar', Jar) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+}
 apply plugin:"org.apache.grails.gradle.grails-plugin"
 apply plugin:"org.apache.grails.gradle.grails-gsp"
 apply plugin: "java-library"

--- a/grails-rundeck-data-shared/build.gradle
+++ b/grails-rundeck-data-shared/build.gradle
@@ -25,6 +25,12 @@ group "grails.rundeck.data.shared"
 
 apply plugin:"eclipse"
 apply plugin:"idea"
+// Pre-register sourcesJar before the grails-plugin applies: it synchronously checks for this
+// task inside its own apply() and logs "A sourcesJar task was not found, creating one." if missing.
+tasks.register('sourcesJar', Jar) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+}
 apply plugin:"org.apache.grails.gradle.grails-plugin"
 apply plugin:"org.apache.grails.gradle.grails-gsp"
 

--- a/grails-securityheaders/build.gradle
+++ b/grails-securityheaders/build.gradle
@@ -26,6 +26,12 @@ group "org.rundeck.grails.plugins.securityheaders"
 
 apply plugin:"eclipse"
 apply plugin:"idea"
+// Pre-register sourcesJar before the grails-plugin applies: it synchronously checks for this
+// task inside its own apply() and logs "A sourcesJar task was not found, creating one." if missing.
+tasks.register('sourcesJar', Jar) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+}
 apply plugin:"org.apache.grails.gradle.grails-plugin"
 apply plugin:"org.apache.grails.gradle.grails-gsp"
 

--- a/grails-webhooks/build.gradle
+++ b/grails-webhooks/build.gradle
@@ -27,6 +27,12 @@ group "webhooks"
 
 apply plugin:"eclipse"
 apply plugin:"idea"
+// Pre-register sourcesJar before the grails-plugin applies: it synchronously checks for this
+// task inside its own apply() and logs "A sourcesJar task was not found, creating one." if missing.
+tasks.register('sourcesJar', Jar) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+}
 apply plugin:"org.apache.grails.gradle.grails-plugin"
 apply plugin:"cloud.wondrify.asset-pipeline"
 apply plugin:"org.apache.grails.gradle.grails-gsp"


### PR DESCRIPTION
<!--
1. Please follow the Developer Guidelines document.
2. This is a build-script-only cleanup, not a feature or bugfix.
3. Jira: RUN-4942
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Neither — this is a build hygiene cleanup. It eliminates a recurring, cosmetic Gradle log message:

```
A sourcesJar task was not found, creating one.
```

This message is printed once per configure phase for every Grails-plugin project (`org.apache.grails.gradle.grails-plugin`) that doesn't declare its own `sourcesJar` task. It comes from the third-party `grails-gradle-plugins` dependency's `GrailsPluginGradlePlugin.apply()`, which synchronously checks for the task and creates one (logging the message) if missing. It does not fail the build or affect build output — it's noise only.

**No production/application code was changed.** Only `build.gradle` files were touched, in the 8 Grails-plugin projects in this repo (`grails-metricsweb`, `grails-persistlocale`, `grails-securityheaders`, `grails-repository`, `grails-webhooks`, `grails-execution-mode-timer`, `grails-rundeck-data-shared`, `grails-job-kill-handler`).

**Describe the solution you've implemented**

Each affected `build.gradle` now pre-registers a `sourcesJar` task (classifier `sources`, sourced from `sourceSets.main.allSource` — matching what the plugin would otherwise create) *before* the `apply plugin: "org.apache.grails.gradle.grails-plugin"` line. Since `tasks.register(...)` is lazy, the task isn't actually realized until later, by which point `java-library` (applied internally by the grails-plugin) has already made `sourceSets` available. When the grails-plugin's `apply()` then checks for an existing `sourcesJar` task, it finds ours and skips creating its own — no message, no duplicate task.

**Describe alternatives you've considered**

- Adding the task to the shared `gradle/java-version.gradle` convention file, applied *after* the grails-plugin line — doesn't work, since the plugin's check runs synchronously during its own `apply()`, before that file is applied.
- Suppressing the message via Gradle logging config — rejected in favor of actually fixing the underlying condition instead of just hiding output.

**Additional context**

Verified by forcing full multi-project Gradle configuration before/after: the message count went from 37 (across both this repo and the rundeckpro companion repo) to 0. Also ran the newly-registered `sourcesJar` task directly on a representative project here (`grails-metricsweb`) — produced a valid, populated sources jar.

Companion fix for the equivalent projects in `rundeckpro` (`plugins/*`, `rundeckpro-grails-common`): rundeckpro PR to follow, referencing this one.

Jira: https://pagerduty.atlassian.net/browse/RUN-4942

## Release Notes

N/A — internal build tooling cleanup only, no user-facing change.