### PR TITLE
[RUN-4837] Distinguish error handler branch from main step in execution context

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContextImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContextImpl.java
@@ -665,6 +665,19 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
             ctx.componentList.addAll(components);
             return this;
         }
+
+        /**
+         * Remove any registered components assignable to the given type. Components otherwise
+         * propagate to every descendant context built from this one (e.g. via the copy
+         * constructor), so this is used to scope a component to a single execution boundary
+         * instead of letting it leak into unrelated descendant executions.
+         * @param type component type to remove
+         * @return this builder
+         */
+        public Builder removeComponentsOfType(Class<?> type) {
+            ctx.componentList.removeIf(component -> type.isAssignableFrom(component.getType()));
+            return this;
+        }
         
         public Builder execution(ExecutionReference execution) {
             ctx.execution = execution;

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/BaseWorkflowExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/BaseWorkflowExecutor.java
@@ -714,6 +714,14 @@ public abstract class BaseWorkflowExecutor implements WorkflowExecutor {
                     NodeRecorder handlerCaptureFailedNodesListener = new NodeRecorder();
 
                     ExecutionContextImpl.Builder wfHandlerContext = new ExecutionContextImpl.Builder(executionContext);
+                    //mark this context branch as an error handler execution, so components that
+                    //cannot otherwise distinguish a handler's context from its parent step's context
+                    //(e.g. runner/agent selection) can resolve their own, handler-specific configuration
+                    wfHandlerContext.addComponent(
+                            "WorkflowItemErrorHandlerContext",
+                            WorkflowItemErrorHandlerContext.INSTANCE,
+                            WorkflowItemErrorHandlerContext.class
+                    );
                     replaceFailedNodesListenerInContext(
                             wfHandlerContext,
                             handlerCaptureFailedNodesListener,

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/WorkflowItemErrorHandlerContext.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/WorkflowItemErrorHandlerContext.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.core.execution.workflow;
+
+/**
+ * Marker context component, registered via {@link com.dtolabs.rundeck.core.execution.ExecutionContext#componentForType(Class)},
+ * that indicates the current execution context originates from a workflow step's error handler
+ * branch rather than from the step's own main execution branch.
+ * <p>
+ * A plain {@code stepContext}/{@code stepNumber} path (see {@link com.dtolabs.rundeck.core.execution.ExecutionContext})
+ * cannot by itself distinguish a step's main execution from its error handler's execution, since
+ * both are built from the same numeric step path. Consumers that need to tell the two apart
+ * (e.g. to resolve per-branch configuration) can check for the presence of this component on the
+ * context instead.
+ */
+public final class WorkflowItemErrorHandlerContext {
+    public static final WorkflowItemErrorHandlerContext INSTANCE = new WorkflowItemErrorHandlerContext();
+
+    private WorkflowItemErrorHandlerContext() {
+    }
+}

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/ExecutionContextImplSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/ExecutionContextImplSpec.groovy
@@ -240,6 +240,28 @@ class ExecutionContextImplSpec extends Specification {
             String | ['Test1', 'Test2'] | false    | false
     }
 
+    def "removeComponentsOfType removes assignable components from a copied builder without affecting the original"() {
+        given:
+            def orig = ExecutionContextImpl.builder()
+                                           .addComponent('marker', 'MarkerValue', String)
+                                           .addComponent('flag', true, Boolean)
+                                           .build()
+
+        when:
+            def child = ExecutionContextImpl.builder(orig)
+                                            .removeComponentsOfType(String)
+                                            .build()
+
+        then:
+            !child.componentForType(String).present
+            child.componentForType(Boolean).present
+            child.componentForType(Boolean).get() == true
+
+        and: "the original context is unaffected"
+            orig.componentForType(String).present
+            orig.componentForType(String).get() == 'MarkerValue'
+    }
+
     def "merge builder merges settings"() {
         def selector1 = Mock(NodesSelector)
         def selector2 = Mock(NodesSelector)

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/BaseWorkflowExecutorSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/BaseWorkflowExecutorSpec.groovy
@@ -232,6 +232,9 @@ class BaseWorkflowExecutorSpec extends Specification {
                 getExecutionService()>>Mock(ExecutionService){
 
                     1 * executeStep(_, item)>> {
+                        StepExecutionContext ctx = (StepExecutionContext)it[0]
+                        // RUN-4837: the main step's own execution must not carry the error handler marker
+                        assert !ctx.componentForType(WorkflowItemErrorHandlerContext).present
                         return NodeDispatchStepExecutor.wrapDispatcherResult(
                             Mock(DispatcherResult) {
                                 isSuccess() >> false
@@ -243,6 +246,10 @@ class BaseWorkflowExecutorSpec extends Specification {
                         StepExecutionContext ctx = (StepExecutionContext)it[0]
                         assert !ctx.nodeSelector.acceptNode(testnode2)
                         assert ctx.nodeSelector.acceptNode(testnode1)
+                        // RUN-4837: the error handler's own execution must carry the marker, so
+                        // components that cannot otherwise distinguish it from the main step's
+                        // execution (e.g. Runner selection) can resolve handler-specific configuration
+                        assert ctx.componentForType(WorkflowItemErrorHandlerContext).present
                         return NodeDispatchStepExecutor.wrapDispatcherResult(
                             Mock(DispatcherResult) {
                                 isSuccess() >> true

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1958,6 +1958,11 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             //start a sub context
             builder.pushContextStep(1)
         }
+        //this context is about to become a referenced job's own top-level execution context.
+        //Any WorkflowItemErrorHandlerContext marker on origContext only describes how THIS job
+        //was invoked by its caller (e.g. as an error handler) - it must not leak into the
+        //referenced job's own internal steps, which are not error handlers of anything.
+        builder.removeComponentsOfType(WorkflowItemErrorHandlerContext)
         return builder.build()
     }
 


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Bugfix. In Manual Runner dispatch mode (rundeckpro / PagerDuty Runbook Automation), when a workflow step is a Job Reference and its Error Handler is also a Job Reference, the Error Handler silently inherits the failed step's Runner instead of resolving its own configured Runner. Root cause: the error handler's execution context is built from the same numeric step path as the step's own execution (`BaseWorkflowExecutor#executeWorkflowStep`), so any consumer that only has the plain step path cannot tell the two branches apart. See [RUN-4837](https://pagerduty.atlassian.net/browse/RUN-4837).

**Describe the solution you've implemented**
- Added a `WorkflowItemErrorHandlerContext` marker component, attached to the handler branch's execution context at the one point in `BaseWorkflowExecutor` that definitively knows it is about to run an error handler (rather than the step's own main execution).
- Added `ExecutionContextImpl.Builder#removeComponentsOfType` so the marker can be explicitly scoped to a single execution boundary — it is stripped again once a job reference's own execution begins, so it does not leak into that job's own internal steps (which are not error handlers of anything).
- Downstream consumers (in the closed-source `rundeckpro` repo) use `context.componentForType(WorkflowItemErrorHandlerContext)` to resolve handler-specific configuration (e.g. Runner selection) instead of always defaulting to the main step's configuration.

**Describe alternatives you've considered**
Encoding the handler/main distinction directly into the numeric step-context path itself was considered, but that path is built and consumed in multiple, executor-strategy-specific places; a side-channel marker component (using the existing generic `ExecutionContext` component mechanism) is a smaller, less invasive change that doesn't alter the step-context string format relied on elsewhere.

**Additional context**
This change is core-only and inert on its own — no existing behavior changes because nothing in this repo currently reads the new marker. It exists to unblock a corresponding fix in `rundeckpro`'s Manual Runner dispatch component. 

## Release Notes
Fixed: an execution context now distinguishes a workflow step's error handler branch from the step's own main execution branch, enabling Runner (agent) selection lifecycle components to resolve handler-specific configuration correctly.

[RUN-4837]: https://pagerduty.atlassian.net/browse/RUN-4837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ