### PR TITLE
[RUN-4902] Add API version V60

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdClient.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdClient.groovy
@@ -33,7 +33,7 @@ class RdClient {
     /**
      *  The current (latest) released version of the Rundeck API
      */
-    public static final int API_CURRENT_VERSION = 59
+    public static final int API_CURRENT_VERSION = 60
 
     final ObjectMapper mapper = new ObjectMapper()
     String baseUrl

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
@@ -47,6 +47,7 @@ class ApiVersions {
     public static final int V57 = 57
     public static final int V58 = 58
     public static final int V59 = 59
+    public static final int V60 = 60
 
     // ^^^ New version is to be added above this line. ^^^
     // Ensure the constant name follows the API_VERSION_VARIABLE_NAME_PATTERN pattern.
@@ -56,9 +57,9 @@ class ApiVersions {
      * Current API version Configuration
      */
     // References the current API version
-    public final static int API_CURRENT_VERSION = V59
+    public final static int API_CURRENT_VERSION = V60
     // Hardcoded inline string constant for the current version used in API doc generation
-    public final static String API_CURRENT_VERSION_STR = "59"
+    public final static String API_CURRENT_VERSION_STR = "60"
 
 
     /**


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Enhancement (infrastructure). Adds a new API version constant, `V60`, and bumps the current API version to it.

**Describe the solution you've implemented**

Added `public static final int V60 = 60` to `ApiVersions.groovy` and updated `API_CURRENT_VERSION`/`API_CURRENT_VERSION_STR` to reference it, following the file's existing pattern for version bumps.

**Describe alternatives you've considered**

N/A — this is a mechanical version bump following the existing pattern in the file.

**Additional context**

This version bump is needed by a downstream rundeckpro change (promoting two incubating cluster API endpoints to official, versioned endpoints at v60). No behavior changes to rundeck itself in this PR.

## Release Notes

N/A — internal API version plumbing only.
