### PR TITLE
[RUN-4971] Fix newline trimming in storage config template

### DIFF
--- a/docker/official/remco/templates/rundeck-config-storage.properties
+++ b/docker/official/remco/templates/rundeck-config-storage.properties
@@ -20,18 +20,18 @@ rundeck.storage.provider.{{index}}.config.baseDir={% set basedir = printf("%s/co
 rundeck.storage.converter.{{index}}.type={% set type = printf("%s/type", converter) %}{{ getv(type, "aes-gcm-encryption") }}
 rundeck.storage.converter.{{index}}.path={% set path = printf("%s/path", converter) %}{{ getv(path, "keys") }}
 rundeck.storage.converter.{{index}}.config.password={% set password = printf("%s/config/password", converter) %}{{ getv(password) }}
-{%- set encryptortype = printf("%s/config/encryptortype", converter) -%}
-{%- if exists(encryptortype) %}
+{% set encryptortype = printf("%s/config/encryptortype", converter) %}
+{% if exists(encryptortype) %}
 rundeck.storage.converter.{{index}}.config.encryptorType={{ getv(encryptortype) }}
-{%- endif %}
-{%- set algorithm = printf("%s/config/algorithm", converter) -%}
-{%- if exists(algorithm) %}
+{% endif %}
+{% set algorithm = printf("%s/config/algorithm", converter) %}
+{% if exists(algorithm) %}
 rundeck.storage.converter.{{index}}.config.algorithm={{ getv(algorithm) }}
-{%- endif %}
-{%- set provider = printf("%s/config/provider", converter) -%}
-{%- if exists(provider) %}
+{% endif %}
+{% set provider = printf("%s/config/provider", converter) %}
+{% if exists(provider) %}
 rundeck.storage.converter.{{index}}.config.provider={{ getv(provider) }}
-{%- endif %}
+{% endif %}
 {% endmacro %}
 
 {%- macro config_storage_converter(converter) %}
@@ -39,18 +39,18 @@ rundeck.storage.converter.{{index}}.config.provider={{ getv(provider) }}
 rundeck.config.storage.converter.{{index}}.type={% set type = printf("%s/type", converter) %}{{ getv(type, "aes-gcm-encryption") }}
 rundeck.config.storage.converter.{{index}}.path={% set path = printf("%s/path", converter) %}{{ getv(path, "projects") }}
 rundeck.config.storage.converter.{{index}}.config.password={% set password = printf("%s/config/password", converter) %}{{ getv(password) }}
-{%- set encryptortype = printf("%s/config/encryptortype", converter) -%}
-{%- if exists(encryptortype) %}
+{% set encryptortype = printf("%s/config/encryptortype", converter) %}
+{% if exists(encryptortype) %}
 rundeck.config.storage.converter.{{index}}.config.encryptorType={{ getv(encryptortype) }}
-{%- endif %}
-{%- set algorithm = printf("%s/config/algorithm", converter) -%}
-{%- if exists(algorithm) %}
+{% endif %}
+{% set algorithm = printf("%s/config/algorithm", converter) %}
+{% if exists(algorithm) %}
 rundeck.config.storage.converter.{{index}}.config.algorithm={{ getv(algorithm) }}
-{%- endif %}
-{%- set provider = printf("%s/config/provider", converter) -%}
-{%- if exists(provider) %}
+{% endif %}
+{% set provider = printf("%s/config/provider", converter) %}
+{% if exists(provider) %}
 rundeck.config.storage.converter.{{index}}.config.provider={{ getv(provider) }}
-{%- endif %}
+{% endif %}
 {% endmacro %}
 
 {%- if ls(printf("%s/1", providerBase)) | length == 0 %}


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. The Remco storage configuration template can produce malformed `.properties` output when optional storage converter properties are present. Whitespace trimming in the template can remove newlines between generated properties, causing properties to be concatenated.

Fixes #10580

**Describe the solution you've implemented**

Removed whitespace trimming from the template directives surrounding the optional `encryptorType`, `algorithm`, and `provider` properties in both storage converter macros. This preserves the newlines between generated properties while leaving the configuration logic unchanged.

**Describe alternatives you've considered**

Considered leaving the whitespace trimming in place, but it can cause valid properties to be concatenated in the generated configuration. Removing the trimming around these conditional blocks is a minimal change that preserves the intended `.properties` formatting.

**Additional context**

This is limited to the Remco template for storage configuration. The change does not alter the generated property values or configuration logic; it only ensures that each generated property remains on its own line.

## Release Notes

Fix malformed storage configuration properties caused by newline trimming in the Remco template.