### PR TITLE
[RUN-4949] Update MinIO test container image

### DIFF
--- a/plugins/object-store-plugin/src/test/groovy/testhelpers/MinioContainer.groovy
+++ b/plugins/object-store-plugin/src/test/groovy/testhelpers/MinioContainer.groovy
@@ -26,7 +26,7 @@ class MinioContainer extends GenericContainer<MinioContainer> {
     private String secretKey
 
     MinioContainer() {
-        this("minio/minio:RELEASE.2019-09-18T21-55-05Z")
+        this("quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z")
     }
 
     MinioContainer(String dockerImageName) {
@@ -37,7 +37,7 @@ class MinioContainer extends GenericContainer<MinioContainer> {
     }
 
     MinioContainer withAccess(String accessKey, String secretKey) {
-        withEnv MINIO_ACCESS_KEY: accessKey, MINIO_SECRET_KEY: secretKey
+        withEnv MINIO_ROOT_USER: accessKey, MINIO_ROOT_PASSWORD: secretKey
         this.accessKey = accessKey
         this.secretKey = secretKey
         return self()


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

This is test-infrastructure maintenance for [RUN-4949](https://pagerduty.atlassian.net/browse/RUN-4949). The object-store plugin tests could no longer start because Docker Hub returns 404 for the legacy `minio/minio:RELEASE.2019-09-18T21-55-05Z` image.

**Describe the solution you've implemented**

Updated the shared Testcontainers helper to use the available multi-platform image `quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z`. Updated the container credentials to the supported `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` environment variables.

**Describe alternatives you've considered**

- Rerunning CircleCI was rejected because the old image consistently returns 404.
- Using `latest` was rejected because it would make CI non-reproducible.
- Mirroring the removed 2019 image was rejected because the current release works with the existing S3 tests and supports Linux amd64 and arm64.

**Additional context**

This failure was observed in [rundeck/rundeck#10563](https://github.com/rundeck/rundeck/pull/10563), but it is unrelated to that PR's SCM changes.

Verification:

- `DOCKER_HOST=unix:///Users/jmanuelosunamoreno/.rd/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock ./gradlew :plugins:object-store-plugin:test --rerun-tasks`
- `./gradlew build -x check`
- `git diff --check`

## Release Notes

No release note required. This change only updates a container used by automated tests.


[RUN-4949]: https://pagerduty.atlassian.net/browse/RUN-4949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ