### PR TITLE
[RUN-4952] Fix Nodes page 500 error when a node source fails to load

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdClient.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdClient.groovy
@@ -33,7 +33,7 @@ class RdClient {
     /**
      *  The current (latest) released version of the Rundeck API
      */
-    public static final int API_CURRENT_VERSION = 59
+    public static final int API_CURRENT_VERSION = 60
 
     final ObjectMapper mapper = new ObjectMapper()
     String baseUrl

--- a/plugins/object-store-plugin/src/test/groovy/testhelpers/MinioContainer.groovy
+++ b/plugins/object-store-plugin/src/test/groovy/testhelpers/MinioContainer.groovy
@@ -26,7 +26,7 @@ class MinioContainer extends GenericContainer<MinioContainer> {
     private String secretKey
 
     MinioContainer() {
-        this("minio/minio:RELEASE.2019-09-18T21-55-05Z")
+        this("quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z")
     }
 
     MinioContainer(String dockerImageName) {
@@ -37,7 +37,7 @@ class MinioContainer extends GenericContainer<MinioContainer> {
     }
 
     MinioContainer withAccess(String accessKey, String secretKey) {
-        withEnv MINIO_ACCESS_KEY: accessKey, MINIO_SECRET_KEY: secretKey
+        withEnv MINIO_ROOT_USER: accessKey, MINIO_ROOT_PASSWORD: secretKey
         this.accessKey = accessKey
         this.secretKey = secretKey
         return self()

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -693,6 +693,13 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         result.remove('query')
         result.remove('params')
         def nodes=result.remove('allnodes')
+        if (result.nodeserror) {
+            // Reduce to plain message strings: some ResourceModelSource plugins wrap third-party SDK
+            // exceptions whose internal object graph can't be safely reflected over by the JSON/XML
+            // converters (e.g. AWS SDK's non-public DefaultSdkHttpFullResponse), which would otherwise
+            // throw IllegalAccessException and turn a node-source error into an HTTP 500 for this request.
+            result.nodeserror = result.nodeserror.collect { Throwable t -> t.message ?: t.toString() }
+        }
         def controller = this
         withFormat {
             '*' {

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
@@ -47,6 +47,7 @@ class ApiVersions {
     public static final int V57 = 57
     public static final int V58 = 58
     public static final int V59 = 59
+    public static final int V60 = 60
 
     // ^^^ New version is to be added above this line. ^^^
     // Ensure the constant name follows the API_VERSION_VARIABLE_NAME_PATTERN pattern.
@@ -56,9 +57,9 @@ class ApiVersions {
      * Current API version Configuration
      */
     // References the current API version
-    public final static int API_CURRENT_VERSION = V59
+    public final static int API_CURRENT_VERSION = V60
     // Hardcoded inline string constant for the current version used in API doc generation
-    public final static String API_CURRENT_VERSION_STR = "59"
+    public final static String API_CURRENT_VERSION_STR = "60"
 
 
     /**

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -1015,6 +1015,108 @@ class FrameworkControllerSpec extends Specification implements ControllerUnitTes
         respObject.tags.isEmpty()
     }
 
+    /**
+     * Regression coverage for RUN-4952: a failing node source's exceptions were previously passed
+     * as raw Throwable objects into the JSON/XML model, which could throw IllegalAccessException when
+     * the converter reflected over an exception's internal object graph (e.g. a third-party SDK
+     * exception with non-public internals), turning a normal node-source error into an HTTP 500.
+     */
+    def "nodesQueryAjax reduces failing node source exceptions to plain message strings for json format"() {
+        setup:
+        def projectName = 'testproj'
+        def emptyNodes = new NodeSetImpl()
+        def authCtx = Mock(UserAndRolesAuthContext)
+        def messagedException = new ResourceModelSourceException("boom: could not load source")
+        def unmessagedException = new ResourceModelSourceException((String) null)
+        def projectNodes = Mock(IProjectNodes) {
+            getResourceModelSourceExceptions() >> [messagedException, unmessagedException]
+        }
+        def projectMock = Mock(IRundeckProject) {
+            getNodeSet() >> emptyNodes
+            getName() >> projectName
+            getProjectNodes() >> projectNodes
+        }
+        def mgr = Mock(ProjectManager) {
+            getFrameworkProject(projectName) >> projectMock
+            existsFrameworkProject(projectName) >> true
+        }
+        controller.frameworkService = Mock(FrameworkService) {
+            getRundeckFramework() >> Mock(Framework) {
+                getFrameworkProjectMgr() >> mgr
+                getFrameworkNodeName() >> 'localnode'
+            }
+            summarizeTags(_) >> [:]
+        }
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+            getAuthContextForSubjectAndProject(_, projectName) >> authCtx
+            authorizeProjectResource(authCtx, _, _, projectName) >> true
+            filterAuthorizedNodes(projectName, _, _, authCtx) >> emptyNodes
+        }
+        params.project = projectName
+        request.addHeader('x-rundeck-ajax', 'true')
+        def query = new ExtNodeFilters(project: projectName, filter: '.*')
+
+        when:
+        controller.nodesQueryAjax(query)
+
+        then:
+        response.status == 200
+        response.json.nodeserror instanceof List
+        response.json.nodeserror.size() == 2
+        response.json.nodeserror[0] instanceof String
+        response.json.nodeserror[0] == 'boom: could not load source'
+        response.json.nodeserror[1] instanceof String
+        response.json.nodeserror[1] == unmessagedException.toString()
+    }
+
+    def "nodesQueryAjax reduces failing node source exceptions to plain message strings for xml format"() {
+        setup:
+        def projectName = 'testproj'
+        def emptyNodes = new NodeSetImpl()
+        def authCtx = Mock(UserAndRolesAuthContext)
+        def sourceException = new ResourceModelSourceException("boom: could not load source")
+        def projectNodes = Mock(IProjectNodes) {
+            getResourceModelSourceExceptions() >> [sourceException]
+        }
+        def projectMock = Mock(IRundeckProject) {
+            getNodeSet() >> emptyNodes
+            getName() >> projectName
+            getProjectNodes() >> projectNodes
+        }
+        def mgr = Mock(ProjectManager) {
+            getFrameworkProject(projectName) >> projectMock
+            existsFrameworkProject(projectName) >> true
+        }
+        controller.frameworkService = Mock(FrameworkService) {
+            getRundeckFramework() >> Mock(Framework) {
+                getFrameworkProjectMgr() >> mgr
+                getFrameworkNodeName() >> 'localnode'
+            }
+            summarizeTags(_) >> [:]
+        }
+        controller.featureService = Mock(FeatureService) {
+            featurePresent(Features.LEGACY_XML) >> true
+        }
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+            getAuthContextForSubjectAndProject(_, projectName) >> authCtx
+            authorizeProjectResource(authCtx, _, _, projectName) >> true
+            filterAuthorizedNodes(projectName, _, _, authCtx) >> emptyNodes
+        }
+        params.project = projectName
+        request.addHeader('x-rundeck-ajax', 'true')
+        response.format = 'xml'
+        def query = new ExtNodeFilters(project: projectName, filter: '.*')
+
+        when:
+        controller.nodesQueryAjax(query)
+
+        then:
+        response.status == 200
+        // the raw exception's stack trace/cause chain must never reach the XML converter either
+        !response.text.contains('stackTrace')
+        response.text.contains('boom: could not load source')
+    }
+
     @Unroll
     def "get project resources default #mime for api_version #api_version"() {
         setup:


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. Jira ticket: [RUN-4953](https://pagerduty.atlassian.net/browse/RUN-4953)

When a project's node source (e.g. an AWS EC2 Resources source with invalid/expired credentials, or a denied STS AssumeRole) fails to load, `FrameworkController.nodesdata()` stores the raw `Throwable` list from `ProjectNodeSupport.getResourceModelSourceExceptions()` as `nodeserror` in the model returned to `nodesQueryAjax`. That action renders the model `as JSON` (or XML). Grails' JSON converter reflectively walks each exception's full object graph, and for an exception that wraps a third-party object with non-public internals (e.g. AWS SDK v2's package-private `DefaultSdkHttpFullResponse`, which only implements a *public* interface), that reflection throws `IllegalAccessException`. That's uncaught, so a normal, expected node-source error turns into an HTTP 500 for the whole Nodes page, every time the page is loaded/refreshed while any node source is failing.

**Describe the solution you've implemented**

In `nodesQueryAjax` (`FrameworkController.groovy`), reduce `result.nodeserror` to plain exception message strings immediately before it is serialized to JSON/XML, instead of passing the raw `Throwable` objects through. This is a framework-level fix: it protects the endpoint against *any* node source plugin whose exception type has an object graph that can't be safely reflected over, not just the AWS SDK case that surfaced it.

**Describe alternatives you've considered**

Fixing this only in the AWS EC2 node source plugin (e.g. never letting it produce an exception with SDK-internal objects in its chain) would be more narrowly scoped, but wouldn't protect against the same failure mode in other node source plugins, and the underlying bug is really that this endpoint should never serialize arbitrary third-party exception objects into a JSON API response.

**Additional context**

Root-caused from a customer log showing repeated AWS EC2 node source auth failures (invalid credentials on two node sources, and STS `AssumeRole` access-denied on five cross-account roles) correlating with 500 errors on `GET /resources/nodesQueryAjax`.

## Release Notes

Fixed: the Nodes page could return an HTTP 500 instead of a normal error indicator when a node source failed to load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RUN-4953]: https://pagerduty.atlassian.net/browse/RUN-4953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ